### PR TITLE
Don't require doorkeeper from local path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ source 'https://rubygems.org'
 # Define Rails version
 gem 'rails', ENV['rails']
 
-gem 'doorkeeper', path: '/Users/sdengler/src/doorkeeper'
+#gem 'doorkeeper', path: '/Users/sdengler/src/doorkeeper'
+gem 'doorkeeper'
 
 gem 'pry'
 gem 'sqlite3'


### PR DESCRIPTION
Minor change to make it one bit easier for contributors to get started. Left the original line in there as a comment for quick access to using local Doorkeeper.
