### PR TITLE
Feat/signing algorithm options

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ The following settings are required in `config/initializers/doorkeeper_openid_co
 - `jws_private_key`, `jws_public_key`
   - Private and public RSA key pair for [JSON Web Signature](https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-31).
   - You can generate these with the `openssl` command, see e.g. [Generate a keypair using OpenSSL](https://en.wikibooks.org/wiki/Cryptography/Generate_a_keypair_using_OpenSSL).
-  - You should not commit these keys to your repository, but use external files (in combination with `File.read`) or the [dotenv-rails](https://github.com/bkeepers/dotenv) gem (in combination with `ENV[...]`).
+  - You should not commit these keys to your repository, but use external files (in combination with `File.read`) or the [dotenv-rails](https://github.com/bkeepers/dotenv) gem (in combination with `ENV[...]`).  
+- `signing_algorithm`  
+  - Possible values include HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512  
+  - Read more at [JWT Algorithms](https://github.com/jwt/ruby-jwt#user-content-algorithms-and-usage)  
 - `resource_owner_from_access_token`
   - Defines how to translate the Doorkeeper access token to a resource owner model.
 

--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -25,8 +25,7 @@ require 'doorkeeper/openid_connect/rails/routes'
 
 module Doorkeeper
   module OpenidConnect
-    # TODO: make this configurable
-    SIGNING_ALGORITHM = 'RS256'.freeze
+    SIGNING_ALGORITHM = configuration.signing_algorithm.freeze
 
     def self.signing_key
       JSON::JWK.new(OpenSSL::PKey.read(configuration.jws_private_key))

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -12,6 +12,10 @@ EOL
 ....
 -----END RSA PUBLIC KEY-----
 EOL
+ 
+  signing_algorithm 'RS256'
+git@github.com:doorkeeper-gem/doorkeeper-openid_connect.git
+....
 
   resource_owner_from_access_token do |access_token|
     # Example implementation:

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 describe Doorkeeper::OpenidConnect do
   describe 'SIGNING_ALGORITHM' do
-    it 'is hard-coded to RS256' do
-      expect(subject::SIGNING_ALGORITHM).to eq 'RS256'
+    it 'is an allowable Signing Algorithm' do
+      let(:jwt_signing_algorithms) { %w[HS256 HS384 HS512 RS256 RS384 RS512 ES256 ES384 ES512] }
+      expect(jwt_signing_algorithms).to include(subject::SIGNING_ALGORITHM)
     end
   end
 


### PR DESCRIPTION
Adds configurable JWT Signing Algorithms 

- Configure in initializer  
- Allows any of [9 algorithms](https://github.com/jwt/ruby-jwt#user-content-algorithms-and-usage) currently in use by [ruby-jwt](https://github.com/jwt/ruby-jwt).