### PR TITLE
Support configurable protocol.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Changes
 
 * The configuration setting `jws_public_key` wasn't actually used, it's deprecated now and will be removed in the next major release
+* The configuration setting `protocol` was added.
 
 
 <a name="v1.1.0"></a>

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ The following settings are optional:
   - Expiration time after which the ID Token must not be accepted for processing by clients.
   - The default is 120 seconds
 
+- `protocol`
+  - The protocol to use when generating URIs for the discovery endpoints.
+  - The default is `https` for production, and `http` for all other environments
+
 ### Scopes
 
 To perform authentication over OpenID Connect, an OAuth client needs to request the `openid` scope. This scope needs to be enabled using either `optional_scopes` in the global Doorkeeper configuration in `config/initializers/doorkeeper.rb`, or by adding it to any OAuth application's `scope` attribute.

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -98,11 +98,7 @@ module Doorkeeper
       end
 
       def protocol
-        if ::Rails.env.production?
-          :https
-        else
-          :http
-        end
+        Doorkeeper::OpenidConnect.configuration.protocol
       end
     end
   end

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -125,7 +125,6 @@ module Doorkeeper
 
       def protocol
         @protocol ||= ::Rails.env.production? ? :https : :http
-        @protocol
       end
     end
   end

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -121,7 +121,11 @@ module Doorkeeper
 
       option :claims, builder_class: ClaimsBuilder
 
-      option :protocol, default: ::Rails.env.production? ? :https : :http
+      option :protocol
+
+      def protocol
+        @protocol ||= ::Rails.env.production? ? :https : :http
+      end
     end
   end
 end

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -117,6 +117,8 @@ module Doorkeeper
       option :expiration, default: 120
 
       option :claims, builder_class: ClaimsBuilder
+
+      option :protocol, default: ::Rails.env.production? ? :https : :http
     end
   end
 end

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -125,6 +125,7 @@ module Doorkeeper
 
       def protocol
         @protocol ||= ::Rails.env.production? ? :https : :http
+        @protocol
       end
     end
   end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -48,8 +48,8 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       }.sort)
     end
 
-    it 'uses HTTPS URLs in production' do
-      allow(Rails.env).to receive(:production?).and_return(true)
+    it 'uses the protocol option for generating URLs' do
+      allow(Doorkeeper::OpenidConnect.configuration).to receive(:protocol).and_return('https')
 
       get :provider
       data = JSON.parse(response.body)

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -103,4 +103,24 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       expect(subject.claims).to_not be_nil
     end
   end
+
+  describe 'protocol' do
+    it 'defaults to https in production' do
+      expect(::Rails.env).to receive(:production?).and_return(true)
+      expect(subject.protocol).to eq(:https)
+    end
+
+    it 'defaults to http in other environments' do
+      expect(::Rails.env).to receive(:production?).and_return(false)
+      expect(subject.protocol).to eq(:http)
+    end
+
+    it 'can be set to other protocols' do
+      Doorkeeper::OpenidConnect.configure do
+        protocol :ftp
+      end
+
+      expect(subject.protocol).to eq(:ftp)
+    end
+  end
 end


### PR DESCRIPTION
Heya! Was going to make an issue for this to discuss the implementation, but the change was so small I figured I might as well associate it with a PR.

In a nutshell, this makes the `protocol` used in the discovery endpoints configurable. We use `https` even in `development` and without this configuration option we have to monkey patch `Doorkeeper::OpenidConnect::DiscoveryController#protocol`. 