### PR TITLE
Send scopes to claim generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * The configuration setting `jws_public_key` wasn't actually used, it's deprecated now and will be removed in the next major release
 * nil values and empty strings are now removed from the UserInfo and IdToken responses
-
+* Claims now receive an optional second `scopes` argument which allow you to dynamically adjust claim values based on the requesting applications' scopes
 
 <a name="v1.1.0"></a>
 ### v1.1.0 (2016-11-30)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ Doorkeeper::OpenidConnect.configure do
     claim :full_name do |resource_owner|
       "#{resource_owner.first_name} #{resource_owner.last_name}"
     end
+
+    claim :preferred_username, scope: :openid do |resource_owner, application_scopes|
+      # Pass the resource_owner's preferred_username if the application has
+      # `profile` scope access. Otherwise, provide a more generic alternative.
+      application_scopes.exists?(:profile) ? resource_owner.preferred_username : "summer-sun-9449"
+    end
   end
 end
 ```

--- a/lib/doorkeeper/openid_connect/user_info.rb
+++ b/lib/doorkeeper/openid_connect/user_info.rb
@@ -27,7 +27,7 @@ module Doorkeeper
       def resource_owner_claims
         Doorkeeper::OpenidConnect.configuration.claims.to_h.map do |name, claim|
           if @scopes.exists? claim.scope
-            [name, @resource_owner.instance_eval(&claim.generator)]
+            [name, claim.generator.call(@resource_owner, @scopes)]
           end
         end.compact.to_h
       end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -42,6 +42,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
           'exp',
           'iat',
           'name',
+          'variable_name',
           'created_at',
           'updated_at',
         ],

--- a/spec/controllers/userinfo_controller_spec.rb
+++ b/spec/controllers/userinfo_controller_spec.rb
@@ -13,7 +13,7 @@ describe Doorkeeper::OpenidConnect::UserinfoController, type: :controller do
         get :show, access_token: token.token
 
         expect(response.status).to eq 200
-        expect(response.body).to eq %Q{{"sub":"#{user.id}","created_at":#{user.created_at.to_i}}}
+        expect(response.body).to eq %Q{{"sub":"#{user.id}","variable_name":"openid-name","created_at":#{user.created_at.to_i}}}
       end
     end
 
@@ -24,7 +24,7 @@ describe Doorkeeper::OpenidConnect::UserinfoController, type: :controller do
         get :show, access_token: token.token
 
         expect(response.status).to eq 200
-        expect(response.body).to eq %Q{{"sub":"#{user.id}","name":"Joe","created_at":#{user.created_at.to_i},"updated_at":#{user.updated_at.to_i}}}
+        expect(response.body).to eq %Q{{"sub":"#{user.id}","name":"Joe","variable_name":"profile-name","created_at":#{user.created_at.to_i},"updated_at":#{user.updated_at.to_i}}}
       end
     end
 

--- a/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
+++ b/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
@@ -48,7 +48,13 @@ tuQKYki41JvYqPobcq/rLE/AM7PKJftW35nqFuj0MrsUwPacaVwKBf5J
   end
 
   claims do
-    normal_claim :name, &:name
+    normal_claim :name do |user|
+      user.name
+    end
+
+    normal_claim :variable_name, scope: :openid do |user, scopes|
+      scopes.exists?(:profile) ? "profile-name" : "openid-name"
+    end
 
     normal_claim :created_at, scope: :openid do |user|
       user.created_at.to_i

--- a/spec/lib/user_info_spec.rb
+++ b/spec/lib/user_info_spec.rb
@@ -11,6 +11,7 @@ describe Doorkeeper::OpenidConnect::UserInfo do
       expect(subject.claims).to eq({
         sub: user.id.to_s,
         created_at: user.created_at.to_i,
+        variable_name: 'openid-name',
       })
     end
 
@@ -23,6 +24,7 @@ describe Doorkeeper::OpenidConnect::UserInfo do
           name: 'Joe',
           created_at: user.created_at.to_i,
           updated_at: user.updated_at.to_i,
+          variable_name: 'profile-name',
         })
       end
     end


### PR DESCRIPTION
It is occasionally useful to know _which_ scopes a calling application is using when generating claim values.

In the current implementation, `instance_eval` is used which causes unexpected context changes (`self` is the resource owner instance within the claim block which is undocumented and unexpected). Ruby's `instance_eval` also disallows additional arguments to be passed to the block.

Rather than using `instance_eval` this just `call`s the block with the resource owner and new scopes argument. Thereby sending the caller's scopes and leaving the block context unchanged.

💥  Undocumented breaking change: The context within the `normal_claim` is no longer the resource owner instance.