### PR TITLE
Loosen json-jwt dependency restriction to ~> 1.6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * The configuration setting `jws_public_key` wasn't actually used, it's deprecated now and will be removed in the next major release
 * nil values and empty strings are now removed from the UserInfo and IdToken responses
 * Claims now receive an optional second `scopes` argument which allow you to dynamically adjust claim values based on the requesting applications' scopes
+* Allow json-jwt dependency at ~> 1.6.
 
 <a name="v1.1.0"></a>
 ### v1.1.0 (2016-11-30)

--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.1"
 
   spec.add_runtime_dependency 'doorkeeper', '~> 4.0'
-  spec.add_runtime_dependency 'json-jwt', '~> 1.6.5'
+  spec.add_runtime_dependency 'json-jwt', '~> 1.6'
 
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'factory_girl'


### PR DESCRIPTION
This allows developers to use the current [v1.7.0 json-jwt](https://github.com/nov/json-jwt/tree/v1.7.0) release which appears to pass all current tests.