### PR TITLE
Use call rather than instance_eval for configuration blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * The configuration setting `jws_public_key` wasn't actually used, it's deprecated now and will be removed in the next major release
 * nil values and empty strings are now removed from the UserInfo and IdToken responses
 * Claims now receive an optional second `scopes` argument which allow you to dynamically adjust claim values based on the requesting applications' scopes
+* Configuration blocks no longer internally use `instance_eval` which previously gave undocumented and unexpected `self` access to the caller.
 
 <a name="v1.1.0"></a>
 ### v1.1.0 (2016-11-30)

--- a/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
@@ -5,7 +5,7 @@ module Doorkeeper
       before_action -> { doorkeeper_authorize! :openid }
 
       def show
-        resource_owner = doorkeeper_token.instance_eval(&Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token)
+        resource_owner = Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(doorkeeper_token)
         user_info = Doorkeeper::OpenidConnect::UserInfo.new(resource_owner, doorkeeper_token.scopes)
         render json: user_info, status: :ok
       end

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -8,7 +8,7 @@ module Doorkeeper
       def initialize(access_token, nonce = nil)
         @access_token = access_token
         @nonce = nonce
-        @resource_owner = access_token.instance_eval(&Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token)
+        @resource_owner = Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(access_token)
         @issued_at = Time.now
       end
 
@@ -39,7 +39,7 @@ module Doorkeeper
       end
 
       def subject
-        @resource_owner.instance_eval(&Doorkeeper::OpenidConnect.configuration.subject).to_s
+        Doorkeeper::OpenidConnect.configuration.subject.call(@resource_owner).to_s
       end
 
       def audience
@@ -55,7 +55,7 @@ module Doorkeeper
       end
 
       def auth_time
-        @resource_owner.instance_eval(&Doorkeeper::OpenidConnect.configuration.auth_time_from_resource_owner).try(:to_i)
+        Doorkeeper::OpenidConnect.configuration.auth_time_from_resource_owner.call(@resource_owner).try(:to_i)
       end
     end
   end

--- a/lib/doorkeeper/openid_connect/user_info.rb
+++ b/lib/doorkeeper/openid_connect/user_info.rb
@@ -33,7 +33,7 @@ module Doorkeeper
       end
 
       def subject
-        @resource_owner.instance_eval(&Doorkeeper::OpenidConnect.configuration.subject).to_s
+        Doorkeeper::OpenidConnect.configuration.subject.call(@resource_owner).to_s
       end
     end
   end


### PR DESCRIPTION
This removes some of the surprising context changes within the configuration blocks. Specifically, `self` is no longer the caller instance. This was an undocumented and surprising side effect of using `instance_eval` to execute blocks.