### PR TITLE
feature: Support pairwise subject identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ The following settings are required in `config/initializers/doorkeeper_openid_co
 - `subject`
   - Identifier for the resource owner (i.e. the authenticated user). A locally unique and never reassigned identifier within the issuer for the end-user, which is intended to be consumed by the client. The value is a case-sensitive string and must not exceed 255 ASCII characters in length.
   - The database ID of the user is an acceptable choice if you don't mind leaking that information.
+  - If you want to provide a different subject identifier to each client, use [pairwise subject identifier](http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes) with configurations like below.
+
+    ```ruby
+    # config/initializers/doorkeeper_openid_connect.rb 
+    Doorkeeper::OpenidConnect.configure do
+    # ...
+      subject_types_supported [:pairwise]
+
+      subject do |resource_owner, application|
+        Digest::SHA256.hexdigest("#{resource_owner.id}#{URI.parse(application.redirect_uri).host}#{'your_secret_salt'}")
+      end
+    # ...
+    end
+    ```
+
 - `jws_private_key`
   - Private RSA key for [JSON Web Signature](https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-31).
   - You can generate a private key with the `openssl` command, see e.g. [Generate a keypair using OpenSSL](https://en.wikibooks.org/wiki/Cryptography/Generate_a_keypair_using_OpenSSL).

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -44,10 +44,7 @@ module Doorkeeper
             #'private_key_jwt'
           ],
 
-          # TODO: make this configurable
-          subject_types_supported: [
-            'public',
-          ],
+          subject_types_supported: openid_connect.subject_types_supported,
 
           # TODO: make this configurable
           id_token_signing_alg_values_supported: [

--- a/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
@@ -6,7 +6,7 @@ module Doorkeeper
 
       def show
         resource_owner = Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(doorkeeper_token)
-        user_info = Doorkeeper::OpenidConnect::UserInfo.new(resource_owner, doorkeeper_token.scopes)
+        user_info = Doorkeeper::OpenidConnect::UserInfo.new(resource_owner, doorkeeper_token)
         render json: user_info, status: :ok
       end
     end

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -93,6 +93,7 @@ module Doorkeeper
 
       option :jws_private_key
       option :issuer
+      option :subject_types_supported, default: [:public]
 
       option :resource_owner_from_access_token, default: lambda { |*_|
         fail Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.resource_owner_from_access_token_not_configured')

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -39,7 +39,7 @@ module Doorkeeper
       end
 
       def subject
-        Doorkeeper::OpenidConnect.configuration.subject.call(@resource_owner).to_s
+        Doorkeeper::OpenidConnect.configuration.subject.call(@resource_owner, @access_token.application).to_s
       end
 
       def audience

--- a/lib/doorkeeper/openid_connect/user_info.rb
+++ b/lib/doorkeeper/openid_connect/user_info.rb
@@ -3,9 +3,10 @@ module Doorkeeper
     class UserInfo
       include ActiveModel::Validations
 
-      def initialize(resource_owner, scopes)
+      def initialize(resource_owner, doorkeeper_token)
         @resource_owner = resource_owner
-        @scopes = scopes
+        @scopes = doorkeeper_token.scopes
+        @application = doorkeeper_token.application
       end
 
       def claims
@@ -33,7 +34,7 @@ module Doorkeeper
       end
 
       def subject
-        Doorkeeper::OpenidConnect.configuration.subject.call(@resource_owner).to_s
+        Doorkeeper::OpenidConnect.configuration.subject.call(@resource_owner, @application).to_s
       end
     end
   end

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -7,6 +7,8 @@ Doorkeeper::OpenidConnect.configure do
 -----END RSA PRIVATE KEY-----
 EOL
 
+  subject_types_supported [:public]
+
   resource_owner_from_access_token do |access_token|
     # Example implementation:
     # User.find_by(id: access_token.resource_owner_id)
@@ -24,9 +26,12 @@ EOL
     # redirect_to new_user_session_url
   end
 
-  subject do |resource_owner|
+  subject do |resource_owner, application|
     # Example implementation:
-    # resource_owner.key
+    # resource_owner.id
+
+    # or if you need pairwise subject identifier, implement like below:
+    # Digest::SHA256.hexdigest("#{resource_owner.id}#{URI.parse(application.redirect_uri).host}#{'your_secret_salt'}")
   end
 
   # Protocol to use when generating URIs for the discovery endpoint,

--- a/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
+++ b/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
@@ -31,6 +31,8 @@ tuQKYki41JvYqPobcq/rLE/AM7PKJftW35nqFuj0MrsUwPacaVwKBf5J
 -----END RSA PRIVATE KEY-----
   EOL
 
+  subject_types_supported [:public]
+
   resource_owner_from_access_token do |access_token|
     User.find_by(id: access_token.resource_owner_id)
   end

--- a/spec/lib/user_info_spec.rb
+++ b/spec/lib/user_info_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Doorkeeper::OpenidConnect::UserInfo do
-  subject { described_class.new user, token.scopes }
+  subject { described_class.new user, token }
   let(:user) { create :user, name: 'Joe' }
   let(:token) { create :access_token, resource_owner_id: user.id, scopes: scopes }
   let(:scopes) { 'openid' }


### PR DESCRIPTION
According to [OpenID Connect specification](http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes), we can use `pairwise` subject identifier that provides a different subject identifier to each client.
This pull request adds abillity for generating pairwise subject identifier to this gem.

How about this?