### PR TITLE
Add support for additional encryption methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ The following settings are required in `config/initializers/doorkeeper_openid_co
   - Identifier for the resource owner (i.e. the authenticated user). A locally unique and never reassigned identifier within the issuer for the end-user, which is intended to be consumed by the client. The value is a case-sensitive string and must not exceed 255 ASCII characters in length.
   - The database ID of the user is an acceptable choice if you don't mind leaking that information.
 - `jws_private_key`
-  - Private RSA key for [JSON Web Signature](https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-31).
-  - You can generate a private key with the `openssl` command, see e.g. [Generate a keypair using OpenSSL](https://en.wikibooks.org/wiki/Cryptography/Generate_a_keypair_using_OpenSSL).
+  - Private key for [JSON Web Signature](https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-31).
+  - You can generate a private key with the `openssl` command, see e.g. [Generate an RSA keypair using OpenSSL](https://en.wikibooks.org/wiki/Cryptography/Generate_a_keypair_using_OpenSSL).
   - You should not commit the key to your repository, but use an external file (in combination with `File.read`) and/or the [dotenv-rails](https://github.com/bkeepers/dotenv) gem (in combination with `ENV[...]`).
+- `signing_algorithm`
+  - The encryption type of the private key which defaults to `:rs256`. The list of supported algorithms can be found [here](https://github.com/nov/json-jwt/wiki/JWE#supported-algorithms)
 - `resource_owner_from_access_token`
   - Defines how to translate the Doorkeeper access token to a resource owner model.
 

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -49,9 +49,8 @@ module Doorkeeper
             'public',
           ],
 
-          # TODO: make this configurable
           id_token_signing_alg_values_supported: [
-            'RS256',
+            ::Doorkeeper::OpenidConnect.signing_algorithm
           ],
 
           claim_types_supported: [
@@ -85,13 +84,13 @@ module Doorkeeper
       end
 
       def keys_response
-        signing_key = Doorkeeper::OpenidConnect.signing_key
+        signing_key = Doorkeeper::OpenidConnect.signing_key_normalized
 
         {
           keys: [
-            signing_key.slice(:kty, :kid, :e, :n).merge(
+            signing_key.merge(
               use: 'sig',
-              alg: Doorkeeper::OpenidConnect::SIGNING_ALGORITHM
+              alg: Doorkeeper::OpenidConnect.signing_algorithm
             )
           ]
         }

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -26,6 +26,11 @@ module Doorkeeper
         def jws_public_key(*args)
           puts "DEPRECATION WARNING: `jws_public_key` is not needed anymore and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb"
         end
+
+        def jws_private_key(*args)
+          puts "DEPRECATION WARNING: `jws_private_key` has been replaced by signing_key and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb"
+          signing_key(*args)
+        end
       end
 
       module Option
@@ -91,8 +96,9 @@ module Doorkeeper
 
       extend Option
 
-      option :jws_private_key
       option :issuer
+      option :signing_key
+      option :signing_algorithm, default: :rs256
 
       option :resource_owner_from_access_token, default: lambda { |*_|
         fail Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.resource_owner_from_access_token_not_configured')

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -29,7 +29,10 @@ module Doorkeeper
       end
 
       def as_jws_token
-        JSON::JWT.new(as_json).sign(Doorkeeper::OpenidConnect.signing_key).to_s
+        JSON::JWT.new(as_json).sign(
+          Doorkeeper::OpenidConnect.signing_key,
+          Doorkeeper::OpenidConnect.signing_algorithm
+        ).to_s
       end
 
       private

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -1,7 +1,7 @@
 Doorkeeper::OpenidConnect.configure do
   issuer 'issuer string'
 
-  jws_private_key <<-EOL
+  signing_key <<-EOL
 -----BEGIN RSA PRIVATE KEY-----
 ....
 -----END RSA PRIVATE KEY-----

--- a/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
+++ b/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
@@ -1,7 +1,7 @@
 Doorkeeper::OpenidConnect.configure do
   issuer 'dummy'
 
-  jws_private_key <<-EOL
+  signing_key <<-EOL
 -----BEGIN RSA PRIVATE KEY-----
 MIIEpgIBAAKCAQEAsjdnSA6UWUQQHf6BLIkIEUhMRNBJC1NN/pFt1EJmEiI88GS0
 ceROO5B5Ooo9Y3QOWJ/n+u1uwTHBz0HCTN4wgArWd1TcqB5GQzQRP4eYnWyPfi4C

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -20,12 +20,22 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
   end
 
   describe 'jws_private_key' do
-    it 'sets the value that is accessible via jws_private_key' do
+    it 'delegates to signing_key' do
       value = 'private_key'
       Doorkeeper::OpenidConnect.configure do
         jws_private_key value
       end
-      expect(subject.jws_private_key).to eq(value)
+      expect(subject.signing_key).to eq(value)
+    end
+  end
+
+  describe 'signing_key' do
+    it 'sets the value that is accessible via signing_key' do
+      value = 'private_key'
+      Doorkeeper::OpenidConnect.configure do
+        signing_key value
+      end
+      expect(subject.signing_key).to eq(value)
     end
   end
 

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -45,9 +45,25 @@ describe Doorkeeper::OpenidConnect::IdToken do
   end
 
   describe '#as_jws_token' do
-    it 'returns claims encoded as JWT' do
-      jwt = JSON::JWT.decode_compact_serialized subject.as_jws_token, Doorkeeper::OpenidConnect.signing_key
-      expect(jwt.to_hash).to eq subject.as_json.stringify_keys
+    shared_examples 'a jws token' do
+      it 'returns claims encoded as JWT' do
+        jwt = JSON::JWT.decode_compact_serialized subject.as_jws_token, Doorkeeper::OpenidConnect.signing_key
+        expect(jwt.to_hash).to eq subject.as_json.stringify_keys
+      end
+    end
+
+    it_behaves_like 'a jws token'
+
+    context 'when signing_algorithm is EC' do
+      before { configure_ec }
+
+      it_behaves_like 'a jws token'
+    end
+
+    context 'when signing_algorithm is HMAC' do
+      before { configure_hmac }
+
+      it_behaves_like 'a jws token'
     end
   end
 end

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe Doorkeeper::OpenidConnect do
-  describe 'SIGNING_ALGORITHM' do
-    it 'is hard-coded to RS256' do
-      expect(subject::SIGNING_ALGORITHM).to eq 'RS256'
+  describe '.signing_algorithm' do
+    it 'returns the signing_algorithm as an uppercase symbol' do
+      expect(subject.signing_algorithm).to eq :RS256
     end
   end
 
@@ -11,6 +11,43 @@ describe Doorkeeper::OpenidConnect do
     it 'returns the private key as JWK instance' do
       expect(subject.signing_key).to be_instance_of JSON::JWK
       expect(subject.signing_key[:kid]).to eq 'IqYwZo2cE6hsyhs48cU8QHH4GanKIx0S4Dc99kgTIMA'
+    end
+  end
+
+  describe '.signing_key_normalized' do
+    context 'when signing key is RSA' do
+      it 'returns the RSA public key parameters' do
+        expect(subject.signing_key_normalized).to eq(
+          'kty' => :RSA,
+          'kid' => 'IqYwZo2cE6hsyhs48cU8QHH4GanKIx0S4Dc99kgTIMA',
+          'e' => 'AQAB',
+          'n' => 'sjdnSA6UWUQQHf6BLIkIEUhMRNBJC1NN_pFt1EJmEiI88GS0ceROO5B5Ooo9Y3QOWJ_n-u1uwTHBz0HCTN4wgArWd1TcqB5GQzQRP4eYnWyPfi4CfeqAHzQp-v4VwbcK0LW4FqtW5D0dtrFtI281FDxLhARzkhU2y7fuYhL8fVw5rUhE8uwvHRZ5CEZyxf7BSHxIvOZAAymhuzNLATt2DGkDInU1BmF75tEtBJAVLzWG_j4LPZh1EpSdfezqaXQlcy9PJi916UzTl0P7Yy-ulOdUsMlB6yo8qKTY1-AbZ5jzneHbGDU_O8QjYvii1WDmJ60t0jXicmOkGrOhruOptw'
+        )
+      end
+    end
+
+    context 'when signing key is EC' do
+      before { configure_ec }
+
+      it 'returns the EC public key parameters' do
+        expect(subject.signing_key_normalized).to eq(
+          'kty' => :EC,
+          'kid' => 'dOx_AhaepicN2r2M-sxZhgkYZMCX7dYhPsNOw1ZiFnI',
+          'x' => 'AeYVvbl3zZcFCdE-0msqOowYODjzeXAhjsZKhdNjGlDREvko3UFOw6S43g-s8bvVBmBz3fCodEzFRYQqJVI4UFvF',
+          'y' => 'AYJ7GYeBm_Fb6liN53xGASdbRSzF34h4BDSVYzjtQc7I-1LK17fwwS3VfQCJwaT6zX33HTrhR4VoUEUJHKwR3dNs'
+        )
+      end
+    end
+
+    context 'when signing key is HMAC' do
+      before { configure_hmac }
+
+      it 'returns the HMAC public key parameters' do
+        expect(subject.signing_key_normalized).to eq(
+          'kty' => :oct,
+          'kid' => 'lyAW7LdxryFWQtLdgxZpOrI87APHrzJKgWLT0BkWVog'
+        )
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,8 @@ ActiveRecord::Migration.maintain_test_schema!
 # Remove after dropping support of Rails 4.2
 require_relative 'support/http_method_shim.rb'
 
+require_relative 'support/doorkeeper_configuration.rb'
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/support/doorkeeper_configuration.rb
+++ b/spec/support/doorkeeper_configuration.rb
@@ -1,0 +1,40 @@
+module DoorkeeperConfiguration
+  def configure_doorkeeper(signing_key, signing_algorithm)
+    Doorkeeper::OpenidConnect.configure do
+      signing_key signing_key
+
+      signing_algorithm signing_algorithm
+
+      resource_owner_from_access_token do |access_token|
+        User.find_by(id: access_token.resource_owner_id)
+      end
+
+      auth_time_from_resource_owner do |resource_owner|
+        resource_owner.current_sign_in_at
+      end
+
+      subject do |resource_owner|
+        resource_owner.id
+      end
+    end
+  end
+
+  def configure_ec
+    signing_key = <<-EOL
+-----BEGIN EC PRIVATE KEY-----
+MIHbAgEBBEF9VcxGjPKczrJlE1N3oEpZsauQfDXIjLeini7h4/3+DOKw2VWE4lCU
+rNJJL65EHT+2TriRg2xSb0l0rK/MAFAFraAHBgUrgQQAI6GBiQOBhgAEAeYVvbl3
+zZcFCdE+0msqOowYODjzeXAhjsZKhdNjGlDREvko3UFOw6S43g+s8bvVBmBz3fCo
+dEzFRYQqJVI4UFvFAYJ7GYeBm/Fb6liN53xGASdbRSzF34h4BDSVYzjtQc7I+1LK
+17fwwS3VfQCJwaT6zX33HTrhR4VoUEUJHKwR3dNs
+-----END EC PRIVATE KEY-----
+        EOL
+    configure_doorkeeper(signing_key, :ES512)
+  end
+
+  def configure_hmac
+    configure_doorkeeper('the_greatest_secret_key', :HS512)
+  end
+end
+
+RSpec.configure { |config| config.include DoorkeeperConfiguration }


### PR DESCRIPTION
This PR allows applications using the gem to configure the encryption type of the private key. This should allow all methods (RSA, EC, etc) supported by [json/jwt](https://github.com/nov/json-jwt/wiki/JWS) This is in response to issue: https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/25