### PR TITLE
Pass Access Tokens to claim builders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Doorkeeper::OpenidConnect.configure do
       "#{resource_owner.first_name} #{resource_owner.last_name}"
     end
 
-    claim :preferred_username, scope: :openid do |resource_owner, application_scopes|
+    claim :preferred_username, scope: :openid do |resource_owner, application_scopes, access_token|
       # Pass the resource_owner's preferred_username if the application has
       # `profile` scope access. Otherwise, provide a more generic alternative.
       application_scopes.exists?(:profile) ? resource_owner.preferred_username : "summer-sun-9449"

--- a/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
@@ -5,9 +5,7 @@ module Doorkeeper
       before_action -> { doorkeeper_authorize! :openid }
 
       def show
-        resource_owner = Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(doorkeeper_token)
-        user_info = Doorkeeper::OpenidConnect::UserInfo.new(resource_owner, doorkeeper_token)
-        render json: user_info, status: :ok
+        render json: Doorkeeper::OpenidConnect::UserInfo.new(doorkeeper_token), status: :ok
       end
     end
   end

--- a/lib/doorkeeper/openid_connect/user_info.rb
+++ b/lib/doorkeeper/openid_connect/user_info.rb
@@ -3,10 +3,8 @@ module Doorkeeper
     class UserInfo
       include ActiveModel::Validations
 
-      def initialize(resource_owner, doorkeeper_token)
-        @resource_owner = resource_owner
-        @scopes = doorkeeper_token.scopes
-        @application = doorkeeper_token.application
+      def initialize(access_token)
+        @access_token = access_token
       end
 
       def claims
@@ -27,14 +25,26 @@ module Doorkeeper
 
       def resource_owner_claims
         Doorkeeper::OpenidConnect.configuration.claims.to_h.map do |name, claim|
-          if @scopes.exists? claim.scope
-            [name, claim.generator.call(@resource_owner, @scopes)]
+          if scopes.exists? claim.scope
+            [name, claim.generator.call(resource_owner, scopes, @access_token)]
           end
         end.compact.to_h
       end
 
       def subject
-        Doorkeeper::OpenidConnect.configuration.subject.call(@resource_owner, @application).to_s
+        Doorkeeper::OpenidConnect.configuration.subject.call(resource_owner, application).to_s
+      end
+
+      def resource_owner
+        @resource_owner ||= Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(@access_token)
+      end
+
+      def application
+        @application ||= @access_token.application
+      end
+
+      def scopes
+        @scopes ||= @access_token.scopes
       end
     end
   end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -45,6 +45,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
           'variable_name',
           'created_at',
           'updated_at',
+          'token_id',
         ],
       }.sort)
     end

--- a/spec/controllers/userinfo_controller_spec.rb
+++ b/spec/controllers/userinfo_controller_spec.rb
@@ -13,7 +13,7 @@ describe Doorkeeper::OpenidConnect::UserinfoController, type: :controller do
         get :show, access_token: token.token
 
         expect(response.status).to eq 200
-        expect(response.body).to eq %Q{{"sub":"#{user.id}","variable_name":"openid-name","created_at":#{user.created_at.to_i}}}
+        expect(response.body).to eq %Q{{"sub":"#{user.id}","variable_name":"openid-name","created_at":#{user.created_at.to_i},"token_id":#{token.id}}}
       end
     end
 
@@ -24,7 +24,7 @@ describe Doorkeeper::OpenidConnect::UserinfoController, type: :controller do
         get :show, access_token: token.token
 
         expect(response.status).to eq 200
-        expect(response.body).to eq %Q{{"sub":"#{user.id}","name":"Joe","variable_name":"profile-name","created_at":#{user.created_at.to_i},"updated_at":#{user.updated_at.to_i}}}
+        expect(response.body).to eq %Q{{"sub":"#{user.id}","name":"Joe","variable_name":"profile-name","created_at":#{user.created_at.to_i},"updated_at":#{user.updated_at.to_i},"token_id":#{token.id}}}
       end
     end
 

--- a/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
+++ b/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
@@ -65,5 +65,9 @@ tuQKYki41JvYqPobcq/rLE/AM7PKJftW35nqFuj0MrsUwPacaVwKBf5J
     normal_claim :updated_at do |user|
       user.updated_at.to_i
     end
+
+    normal_claim :token_id, scope: :openid do |user, scopes, token|
+      token.id
+    end
   end
 end

--- a/spec/lib/user_info_spec.rb
+++ b/spec/lib/user_info_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 describe Doorkeeper::OpenidConnect::UserInfo do
-  subject { described_class.new user, token }
+  subject { described_class.new token }
+
   let(:user) { create :user, name: 'Joe' }
   let(:token) { create :access_token, resource_owner_id: user.id, scopes: scopes }
   let(:scopes) { 'openid' }
@@ -12,6 +13,7 @@ describe Doorkeeper::OpenidConnect::UserInfo do
         sub: user.id.to_s,
         created_at: user.created_at.to_i,
         variable_name: 'openid-name',
+        token_id: token.id,
       })
     end
 
@@ -25,6 +27,7 @@ describe Doorkeeper::OpenidConnect::UserInfo do
           created_at: user.created_at.to_i,
           updated_at: user.updated_at.to_i,
           variable_name: 'profile-name',
+          token_id: token.id,
         })
       end
     end


### PR DESCRIPTION
There are specific cases where we need to customize the claims returned from our `UserInfo` endpoint based on the access token, which contains information about the user, application, grant, and more.

This PR passed the `access_token` as a third argument to the claims builder.

@toupeira