### PR TITLE
feature: hook for extra data in id_token

### DIFF
--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -21,7 +21,7 @@ module Doorkeeper
           iat: issued_at,
           nonce: nonce,
           auth_time: auth_time,
-        }
+        }.merge(@resource_owner.try(:to_token_payload) || {})
       end
 
       def as_json(*_)

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -30,6 +30,31 @@ describe Doorkeeper::OpenidConnect::IdToken do
     end
   end
 
+  describe '#claims with extra payload' do
+
+    it 'returns all default claims' do
+
+      def user.to_token_payload 
+        {
+          username: 'test_name'
+        }
+      end
+
+      subject.instance_variable_set '@resource_owner', user
+
+      expect(subject.claims).to eq({
+        iss: 'dummy',
+        sub: user.id.to_s,
+        aud: access_token.application.uid,
+        exp: 180,
+        iat: 60,
+        nonce: nonce,
+        auth_time: 23,
+        username: 'test_name'
+      })
+    end
+  end
+
   describe '#as_json' do
     it 'returns claims with nil values and empty strings removed' do
       allow(subject).to receive(:issuer).and_return(nil)


### PR DESCRIPTION
Learn from [knock](https://github.com/nsarno/knock) to add extra payload to `id_token`.

This may have some conflicts with claims but the claims are used in `/userinfo` access. And the payload for `id_token` make it more useful to communicate through multi sub systems. So I can get enough info about the user without access to `/userinfo` url.