### PR TITLE
Redirect errors per Section 3.1.2.6 of OpenID Connect 1.0

### DIFF
--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -19,9 +19,14 @@ module Doorkeeper
           # FIXME: workaround for Rails 5, see https://github.com/rails/rails/issues/25106
           @_response_body = nil
 
-          error = ::Doorkeeper::OAuth::ErrorResponse.new(name: exception.error_name)
+          error = ::Doorkeeper::OAuth::ErrorResponse.new(name: exception.error_name, state: params[:state], redirect_uri: params[:redirect_uri])
           response.headers.merge!(error.headers)
-          render json: error.body, status: error.status
+
+          if error.redirectable?
+            render json: error.body, status: :found, location: error.redirect_uri
+          else
+            render json: error.body, status: error.status
+          end
         end
 
         def handle_prompt_param!(owner)


### PR DESCRIPTION
Error handling currently returns a json object whose body contains the error code and description along with an HTTP status 401.  This pull-request changes the behavior of error handling in the gem to conform with [OpenID Connect 1.0 Section 3.1.2.6](http://openid.net/specs/openid-connect-core-1_0.html#AuthError):

> Unless the Redirection URI is invalid, the Authorization Server returns the
> Client to the Redirection URI specified in the Authorization Request with the
> appropriate error and state parameters. Other parameters SHOULD NOT be
> returned.