### PR TITLE
Set id_token when nil (RefreshToken)

### DIFF
--- a/lib/doorkeeper/openid_connect/oauth/token_response.rb
+++ b/lib/doorkeeper/openid_connect/oauth/token_response.rb
@@ -7,7 +7,7 @@ module Doorkeeper
         def body
           if token.includes_scope? 'openid'
             super
-              .merge(id_token: id_token.try(:as_jws_token))
+              .merge(id_token:  id_token ? id_token.as_jws_token : Doorkeeper::OpenidConnect::IdToken.new(token).as_jws_token)
               .reject { |_, value| value.blank? }
           else
             super

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -21,6 +21,17 @@ describe Doorkeeper::OpenidConnect::OAuth::TokenResponse do
       end
     end
 
+    context 'with the openid scope present but no id_token' do
+      before do
+        token.scopes = 'openid email'
+        subject.id_token = nil
+      end
+
+      it 'adds the ID token to the response' do
+        expect(subject.body[:id_token]).to be_truthy
+      end
+    end
+
     context 'with the openid scope not present' do
       before do
         token.scopes = 'email'


### PR DESCRIPTION
This adds the id_token as part of the refresh token response as permitted by the OIDC spec:
> the response body is the Token Response of Section 3.1.3.3 except that it might not contain an id_token

Many OIDC providers, like Google, have that behavior so it's used in things like Kubernetes:
> Providers that don’t return an id_token as part of their refresh token response (e.g. Okta) aren’t supported by this plugin and should use “Option 2” below.
[source](https://kubernetes.io/docs/admin/authentication/#option-1---oidc-authenticator)

See also https://gitlab.com/gitlab-org/gitlab-ce/issues/44485