### PR TITLE
Loose doorkeeper version.

### DIFF
--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3"
 
-  spec.add_runtime_dependency 'doorkeeper', '~> 4.3'
+  spec.add_runtime_dependency 'doorkeeper', '>= 4.3'
   spec.add_runtime_dependency 'json-jwt', '~> 1.6'
 
   spec.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
closes #54 

@toupeira hey, I tested my production app with latest Doorkeeper release candidate and all my tests are green so I think we can let people use it with Doorkeeper OpenidConnect.