### PR TITLE
Changes for Doorkeeper 5.0

### DIFF
--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -77,14 +77,8 @@ module Doorkeeper
         end
 
         def matching_tokens_for_resource_owner(owner)
-          # TODO: maybe use Doorkeeper::AccessToken.matching_token_for once
-          # https://github.com/doorkeeper-gem/doorkeeper/pull/907 is merged
-          Doorkeeper::AccessToken.where(
-            application_id: pre_auth.client.id,
-            resource_owner_id: owner.id,
-            revoked_at: nil,
-          ).select do |token|
-            Doorkeeper::AccessToken.scopes_match?(token.scopes, pre_auth.scopes, nil)
+          Doorkeeper::AccessToken.authorized_tokens_for(pre_auth.client.id, owner.id).select do |token|
+            Doorkeeper::AccessToken.scopes_match?(token.scopes, pre_auth.scopes, pre_auth.client.scopes)
           end
         end
       end

--- a/spec/dummy/db/migrate/20180904152859_add_confidential_to_applications.rb
+++ b/spec/dummy/db/migrate/20180904152859_add_confidential_to_applications.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddConfidentialToApplications < ActiveRecord::Migration[5.0]
+  def change
+    add_column(
+      :oauth_applications,
+      :confidential,
+      :boolean,
+      null: false,
+      default: true
+    )
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102204540) do
+ActiveRecord::Schema.define(version: 20180904152859) do
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false
@@ -40,15 +40,16 @@ ActiveRecord::Schema.define(version: 20161102204540) do
   end
 
   create_table "oauth_applications", force: :cascade do |t|
-    t.string   "name",                      null: false
-    t.string   "uid",                       null: false
-    t.string   "secret",                    null: false
-    t.text     "redirect_uri",              null: false
-    t.string   "scopes",       default: "", null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.string   "name",                        null: false
+    t.string   "uid",                         null: false
+    t.string   "secret",                      null: false
+    t.text     "redirect_uri",                null: false
+    t.string   "scopes",       default: "",   null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
     t.integer  "owner_id"
     t.string   "owner_type"
+    t.boolean  "confidential", default: true, null: false
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 describe Doorkeeper::OpenidConnect::OAuth::TokenResponse do
   subject { Doorkeeper::OAuth::TokenResponse.new token }
   let(:token) { create :access_token }
-  let(:pre_auth) { Doorkeeper::OAuth::PreAuthorization.new(nil, nil, nonce: '123456')}
+  let(:client) { Doorkeeper::OAuth::Client.new create(:application) }
+  let(:pre_auth) { Doorkeeper::OAuth::PreAuthorization.new(Doorkeeper.configuration, client, nonce: '123456')}
   let(:id_token) { Doorkeeper::OpenidConnect::IdToken.new token, pre_auth }
 
   describe '#body' do


### PR DESCRIPTION
Didn't realize that Travis was still pulling 4.x for https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/55, in the meantime Doorkeeper 5.0 came out of RC and broke our build :(

Had to change the DB schema (see https://github.com/doorkeeper-gem/doorkeeper/wiki/Migration-from-old-versions) and adjust the specs a little bit.