### PR TITLE
Add rails release version to the migration

### DIFF
--- a/lib/generators/doorkeeper/openid_connect/templates/migration.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration
+class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration[5.2]
   def change
     create_table :oauth_openid_requests do |t|
       t.integer :access_grant_id, null: false

--- a/lib/generators/doorkeeper/openid_connect/templates/migration.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration[5.2]
+class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration[4.2]
   def change
     create_table :oauth_openid_requests do |t|
       t.integer :access_grant_id, null: false


### PR DESCRIPTION
Sets the rails version for the migration file.

With a new rails 5.2.2 project, get the following when trying to build & migrate the migration:

```
~/clio/iam-rails: rake db:migrate
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration[4.2]
/Users/tysvongaza/clio/iam-rails/db/migrate/20190110185402_create_doorkeeper_openid_connect_tables.rb:1:in `<main>'

Caused by:
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration[4.2]
/Users/tysvongaza/clio/iam-rails/db/migrate/20190110185402_create_doorkeeper_openid_connect_tables.rb:1:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```