### PR TITLE
Separate id-token-token URL generation from params

### DIFF
--- a/lib/doorkeeper/oauth/id_token_token_response.rb
+++ b/lib/doorkeeper/oauth/id_token_token_response.rb
@@ -2,14 +2,19 @@ module Doorkeeper
   module OAuth
     class IdTokenTokenResponse < IdTokenResponse
       def redirect_uri
-        Authorization::URIBuilder.uri_with_fragment(
-          pre_auth.redirect_uri,
+        Authorization::URIBuilder.uri_with_fragment(pre_auth.redirect_uri, redirect_uri_params)
+      end
+
+      private
+
+      def redirect_uri_params
+        {
           access_token: auth.token.token,
           token_type: auth.token.token_type,
           expires_in: auth.token.expires_in_seconds,
           state: pre_auth.state,
           id_token: id_token.as_jws_token
-        )
+        }
       end
     end
   end


### PR DESCRIPTION
For context, Doorkeeper recommends extending the token response with custom attributes by defining a module that overrides `body`, and prepending it to Doorkeeper::OAuth::Token response. In fact, this is the exact practice Doorkeeper OpenID Connect uses:

https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/master/lib/doorkeeper/openid_connect/oauth/authorization_code_request.rb#L23

In order to make extending Doorkeeper OIDC's own IdTokenTokenResponse easier, this pull request introduce a method that generates  the params hash, and makes `redirect_uri` consume that method. This means people wishing to extend the IdTokenToken  response with new parameters can prepend a module that defines `redirect_uri_params` and
invokes `super`, rather than having to reimplement all of `redirect_uri`.

This is useful for, for example, OIDC Session Management, which [requires that a `session_state` parameter be returned in the Authentication Response](https://openid.net/specs/openid-connect-session-1_0.html#CreatingUpdatingSessions).

Prior to this change, to achieve this goal, I would have two unappealing options:
-  either copy the complete implementation of `redirect_uri` into my own module, and replace that method entirely when I prepend my module to Doorkeeper's, or
- implement my own `redirect_uri` to call `super`, and retrieve the string URL from Doorkeeper, and then manipulate that string (either by parsing it back out to a hash of params and then reencoding the URL, *or* by string manipulation, ie appending `&session_state=...` to the URL)

After this change, I can simply define my own `redirect_uri_params`, invoke super, and merge my custom params into Doorkeeper's:

```
module IdTokenTokenResponseExtension
  def redirect_uri_params
    super.merge(session_state: 'foo')
   end
end

Doorkeeper::OAuth::IdTokenTokenResponse.send :prepend, IdTokenTokenResponseExtension
```