### PR TITLE
Add 'crv' param to normalized EC signing key

### DIFF
--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -56,7 +56,7 @@ module Doorkeeper
       when :RSA
         key.slice(:kty, :kid, :e, :n)
       when :EC
-        key.slice(:kty, :kid, :x, :y)
+        key.slice(:kty, :kid, :crv, :x, :y)
       when :oct
         key.slice(:kty, :kid)
       end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -108,7 +108,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
     context 'when using an EC key' do
       before { configure_ec }
 
-      it_behaves_like 'a key response', expected_parameters: [:kty, :kid, :x, :y, :use, :alg]
+      it_behaves_like 'a key response', expected_parameters: [:kty, :kid, :crv, :x, :y, :use, :alg]
     end
 
     context 'when using an HMAC key' do

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -33,6 +33,7 @@ describe Doorkeeper::OpenidConnect do
         expect(subject.signing_key_normalized).to eq(
           'kty' => :EC,
           'kid' => 'dOx_AhaepicN2r2M-sxZhgkYZMCX7dYhPsNOw1ZiFnI',
+          'crv' => :'P-521',
           'x' => 'AeYVvbl3zZcFCdE-0msqOowYODjzeXAhjsZKhdNjGlDREvko3UFOw6S43g-s8bvVBmBz3fCodEzFRYQqJVI4UFvF',
           'y' => 'AYJ7GYeBm_Fb6liN53xGASdbRSzF34h4BDSVYzjtQc7I-1LK17fwwS3VfQCJwaT6zX33HTrhR4VoUEUJHKwR3dNs'
         )


### PR DESCRIPTION
This change fixes the DiscoveryController#keys JSON response
not being compliant with RFC 7518 (JWA), when representing the
parameters for Elliptic Curve Keys.

See: https://tools.ietf.org/html/rfc7518#section-6.2.1

Closes #68 