### PR TITLE
fix runtime dependency

### DIFF
--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3"
 
-  spec.add_runtime_dependency 'doorkeeper', '>= 4.3'
+  spec.add_runtime_dependency 'doorkeeper', '>= 5.0'
   spec.add_runtime_dependency 'json-jwt', '~> 1.6'
 
   spec.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
since #67, doorkeeper-open-id_connect has called an API (`#mapping`) that was introduced in doorkeeper 5.0. (https://github.com/doorkeeper-gem/doorkeeper/pull/1082/files#diff-30d1c02eb523d3fdbe0ea87cd811bc3fR7)

See more here: https://github.com/doorkeeper-gem/doorkeeper-openid_connect/commit/3893ea1318e302a078272ff408aff1c50bef85d1#r32599682