### PR TITLE
Add revocation_endpoint and introspection_endpoint to .well-known

### DIFF
--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -26,6 +26,8 @@ module Doorkeeper
           issuer: openid_connect.issuer,
           authorization_endpoint: oauth_authorization_url(protocol: protocol),
           token_endpoint: oauth_token_url(protocol: protocol),
+          revocation_endpoint: oauth_revoke_url(protocol: protocol),
+          introspection_endpoint: oauth_introspect_url(protocol: protocol),
           userinfo_endpoint: oauth_userinfo_url(protocol: protocol),
           jwks_uri: oauth_discovery_keys_url(protocol: protocol),
 

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -10,6 +10,8 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
         'issuer' => 'dummy',
         'authorization_endpoint' => 'http://test.host/oauth/authorize',
         'token_endpoint' => 'http://test.host/oauth/token',
+        'revocation_endpoint' => 'http://test.host/oauth/revoke',
+        'introspection_endpoint' => 'http://test.host/oauth/introspect',
         'userinfo_endpoint' => 'http://test.host/oauth/userinfo',
         'jwks_uri' => 'http://test.host/oauth/discovery/keys',
 


### PR DESCRIPTION
This PR adds `revocation_endpoint` and `introspection_endpoint` keys to `/.well-known/openid-configuration` response.

Although non-standard, there're multiple examples that provide those keys:

- https://accounts.google.com/.well-known/openid-configuration
- https://developer.okta.com/docs/api/resources/oidc/#response-properties-7
- https://connect2id.com/products/server/docs/api/discovery#openid-config
- https://developers.onelogin.com/openid-connect/api/provider-config

Taking into the consideration that doorkeeper already provides those endpoints, I think it makes sense to mention them in the discovery response as well.