### PR TITLE
Fix Password after_successful_response so the id_token is not nil in Doorkeeper hook after_successful_strategy_response

### DIFF
--- a/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
@@ -12,9 +12,9 @@ module Doorkeeper
         private
 
         def after_successful_response
-          super
           id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
           @response.id_token = id_token
+          super
         end
       end
     end


### PR DESCRIPTION
When using Doorkeeper strategy hook the `response.id_token` was nil:
```
  after_successful_strategy_response do |request, response|
    puts "#{response.id_token.inspect}" # nil
  end
```

The fix is to return `super` in Doorkeeper hook `after_successful_strategy_response`  
It returns a `Doorkeeper::OAuth::TokenResponse` with two attributes:  
`@token` of class `Doorkeeper::AccessToken`  
`@id_token` of class `Doorkeeper::OpenidConnect::IdToken`


Before:
```
[2] pry(#<Doorkeeper::Config::Builder>)> response
=> #<Doorkeeper::OAuth::TokenResponse:0x00007ffe8324dcc0
 @token=
  #<Doorkeeper::AccessToken:0x00007ffe8310e760
   id: 175,
   resource_owner_id: 1,
   application_id: 1,
   token: "YkKr-j3ize0*************WIUGb42rS1QIGzfQkiZM",
   refresh_token: nil,
   expires_in: 7200,
   revoked_at: nil,
   created_at: Wed, 22 May 2019 00:57:43 PDT -07:00,
   scopes: "",
   previous_refresh_token: "">>
```

After:
```
[1] pry(#<Doorkeeper::Config::Builder>)> response
=> #<Doorkeeper::OAuth::TokenResponse:0x00007feff16e1868
 @id_token=
  #<Doorkeeper::OpenidConnect::IdToken:0x00007feff16e17f0
   @access_token=
    #<Doorkeeper::AccessToken:0x00007feff1592368
     id: 176,
     resource_owner_id: 1,
     application_id: 1,
     token: "fqAtBk0rR0B****************h-DOK3UNKw4yWQ",
     refresh_token: nil,
     expires_in: 7200,
     revoked_at: nil,
     created_at: Wed, 22 May 2019 01:00:49 PDT -07:00,
     scopes: "",
     previous_refresh_token: "">,
   @issued_at=2019-05-22 01:00:49 -0700,
   @nonce=nil,
   @resource_owner=
    #<User id: 1, ..................>>,
 @token=
  #<Doorkeeper::AccessToken:0x00007feff1592368
   id: 176,
   resource_owner_id: 1,
   application_id: 1,
   token: "fqAtBk0rR0BT****************h-DOK3UNKw4yWQ",
   refresh_token: nil,
   expires_in: 7200,
   revoked_at: nil,
   created_at: Wed, 22 May 2019 01:00:49 PDT -07:00,
   scopes: "",
   previous_refresh_token: "">>
```

Then we can access the `id_token` in Doorkeeper:
```
  after_successful_strategy_response do |request, response|
    puts "#{response.id_token.as_jws_token.inspect}"
  end
```


