### PR TITLE
Prevent 500 when required parameters are not present

### DIFF
--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -8,6 +8,7 @@ module Doorkeeper
           super.tap do |owner|
             next unless controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] &&
               action_name == 'new'
+            raise Errors::OpenidConnectError unless pre_auth.valid?
             next unless pre_auth.scopes.include?('openid')
 
             handle_prompt_param!(owner)

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -262,4 +262,11 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
   end
+
+  describe 'when params are missing' do
+    it 'responds with 4xx' do
+      authorize!({ scope: nil, current_user: nil, client_id: nil })
+      expect(response.status).to be(401)
+    end
+  end
 end


### PR DESCRIPTION
Currently, the `pre_auth` object is getting inspected in `authenticate_resource_owner!`, before Doorkeeper validates it.  If the required OAuth params are not present, it will currently blow up with `undefined method application for nil`. Our pull request ensures a `401` error is returned rather than a `500` error for this bit.

Solves https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/78
This appears to be related to #71.