### PR TITLE
Defer to Doorkeeper when scopes are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,5 +291,3 @@ Doorkeeper::OpenidConnect is released under the [MIT License](http://www.opensou
 ## Sponsors
 
 Initial development of this project was sponsored by [PlayOn! Sports](https://github.com/playon).
-
-Can I do this?

--- a/README.md
+++ b/README.md
@@ -291,3 +291,5 @@ Doorkeeper::OpenidConnect is released under the [MIT License](http://www.opensou
 ## Sponsors
 
 Initial development of this project was sponsored by [PlayOn! Sports](https://github.com/playon).
+
+Can I do this?


### PR DESCRIPTION
As we explored our use case, we realized that we did not want to submit a 4xx error on missing parameters for openid connect within our Oauth flow. We refactored a bit and created a test case that proved that, if parameters were missing, doorkeeper-openid_connect would pass on its opportunity to interact with the flow and doorkeeper would take over.

The biggest change to pay attention to is the extraction of `pre_auth.scopes` out to a separate private method. This method captures a `NoMethodError` that gets thrown when pre_auth attempts to retrieve the scopes of an object that has no client, and therefore no application. This refactor is really a workaround--lacking the context concerning this flow, I decided that simply capturing the error and navigating around it would be the best way to go.

If any of you have any suggestions or desires to see this area move in a different direction, let me know and my team and I will adjust our PR to reflect that.

Solves #78
This appears to be related to #71.