### PR TITLE
Allow silent authentication without user consent

### DIFF
--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -56,7 +56,7 @@ module Doorkeeper
             when 'none' then
               raise Errors::InvalidRequest if (prompt_values - [ 'none' ]).any?
               raise Errors::LoginRequired unless owner
-              raise Errors::ConsentRequired unless matching_tokens_for_oidc_resource_owner(owner).present?
+              raise Errors::ConsentRequired if oidc_consent_required?(owner)
             when 'login' then
               reauthenticate_oidc_resource_owner(owner) if owner
             when 'consent' then
@@ -99,6 +99,11 @@ module Doorkeeper
           Doorkeeper::AccessToken.authorized_tokens_for(pre_auth.client.id, owner.id).select do |token|
             Doorkeeper::AccessToken.scopes_match?(token.scopes, pre_auth.scopes, pre_auth.client.scopes)
           end
+        end
+
+        def oidc_consent_required?(owner)
+          return false if skip_authorization?
+          matching_tokens_for_oidc_resource_owner(owner).blank?
         end
       end
     end

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -138,6 +138,13 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
 
       context 'and no matching token' do
+        it 'redirects to the callback if skip_authorization is set to true' do
+          allow(controller).to receive(:skip_authorization?) { true }
+
+          authorize! prompt: 'none'
+          expect_successful_callback!
+        end
+
         it 'returns a consent_required error when logged in' do
           authorize! prompt: 'none'
 


### PR DESCRIPTION
This PR fixes an issue I've experienced when doing silent authentication together with
```
  skip_authorization do |resource_owner, client|
    true
  end
```
setting in `Doorkeeper.configure`. Silent authorization will pass `prompt=none` which will check if there are any existing tokens in `matching_tokens_for_oidc_resource_owner`. This check is not needed when `skip_authorization` is set to true.
