### PR TITLE
Fix Doorkeeper 5.2 compatibility

### DIFF
--- a/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
@@ -4,8 +4,19 @@ module Doorkeeper
       module PreAuthorization
         attr_reader :nonce
 
-        def initialize(server, client, attrs = {})
-          super
+        def initialize(server, client_or_attrs, attrs = {})
+          if client_or_attrs.is_a?(ActionController::Parameters)
+            attrs = client_or_attrs
+            client = nil
+          else
+            client = client_or_attrs
+          end
+
+          if OAuth::PreAuthorization.method(:initialize).parameters.include?([:req, :client])
+            super(server, client, attrs)
+          else
+            super(server, attrs)
+          end
           @nonce = attrs[:nonce]
         end
       end


### PR DESCRIPTION
Doorkeeper 5.2.0 seems to have changed the method signature for `OAuth::PreAuthorization#initialize`.  It previously took a `client` as a parameter, but now expects a `:client_id` key in `attrs` instead.  (This probably should have been considered a breaking change but doesn't seem to have been.)

Because of that, trying to log in when the server is using this gem with doorkeeper 5.2.0 gives a traceback ending in:

```
doorkeeper-openid_connect (1.6.2) lib/doorkeeper/openid_connect/oauth/pre_authorization.rb:8:in `initialize'
doorkeeper (5.2.0) lib/doorkeeper/oauth/pre_authorization.rb:20:in `initialize'
ArgumentError processing GraphQL query: wrong number of arguments (given 3, expected 1..2)
```

This patch attempts to fix it while still maintaining compatibility with older Doorkeeper releases.  To do that, it checks both the type of the `client` parameter and whether or not the super initializer has a parameter called `client`.  It's a little complicated but it seems to work.