### PR TITLE
Add authorization_url_host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ The following settings are optional:
   - Note that the OIDC specification mandates HTTPS, so you shouldn't change this
     for production environments unless you have a really good reason!
 
+- `authorization_url_host`
+  - The hostname to use when generating the `authorization_url` in the discovery response.
+  - The default is to use the request host, just like all the other URLs in the discovery response.
+  - This is useful when you want authorization requests to use a different URL than other requests.
+    For example, if your Doorkeeper server is behind a firewall with other servers, you might want
+    other servers to use an "internal" URL to communicate with Doorkeeper, but you want to present
+    an "external" URL to end-users for authentication requests. Note that this setting does not
+    actually change the URL that your Doorkeeper server responds on - that is outside the scope of
+    Doorkeeper.
+
 ### Scopes
 
 To perform authentication over OpenID Connect, an OAuth client needs to request the `openid` scope. This scope needs to be enabled using either `optional_scopes` in the global Doorkeeper configuration in `config/initializers/doorkeeper.rb`, or by adding it to any OAuth application's `scope` attribute.

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -24,7 +24,7 @@ module Doorkeeper
         openid_connect = ::Doorkeeper::OpenidConnect.configuration
         {
           issuer: openid_connect.issuer,
-          authorization_endpoint: oauth_authorization_url(protocol: protocol),
+          authorization_endpoint: oauth_authorization_url(authorization_url_options),
           token_endpoint: oauth_token_url(protocol: protocol),
           revocation_endpoint: oauth_revoke_url(protocol: protocol),
           introspection_endpoint: oauth_introspect_url(protocol: protocol),
@@ -97,6 +97,18 @@ module Doorkeeper
 
       def protocol
         Doorkeeper::OpenidConnect.configuration.protocol.call
+      end
+
+      def authorization_url_host
+        Doorkeeper::OpenidConnect.configuration.authorization_url_host
+      end
+
+      def authorization_url_options
+        {
+          protocol: protocol
+        }.tap do |opt|
+          opt[:host] = authorization_url_host if authorization_url_host
+        end
       end
     end
   end

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -124,6 +124,8 @@ module Doorkeeper
       option :protocol, default: lambda { |*_|
         ::Rails.env.production? ? :https : :http
       }
+
+      option :authorization_url_host
     end
   end
 end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -65,6 +65,36 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
 
       expect(data['authorization_endpoint']).to eq 'testing://test.host/oauth/authorize'
     end
+
+    context "when the authorization_url_host option is set" do
+      before do
+        Doorkeeper::OpenidConnect.configure do
+          authorization_url_host "alternate-authorization-host"
+        end
+      end
+
+      it 'uses the authorization_url_host option when generating the authorization_url' do
+        get :provider
+        data = JSON.parse(response.body)
+
+        expect(data['authorization_endpoint']).to eq 'http://alternate-authorization-host/oauth/authorize'
+      end
+
+      it 'does not use the authorization_url_host option when generating other URLs' do
+        get :provider
+        data = JSON.parse(response.body)
+
+        {
+          'token_endpoint' => 'http://test.host/oauth/token',
+          'revocation_endpoint' => 'http://test.host/oauth/revoke',
+          'introspection_endpoint' => 'http://test.host/oauth/introspect',
+          'userinfo_endpoint' => 'http://test.host/oauth/userinfo',
+          'jwks_uri' => 'http://test.host/oauth/discovery/keys',
+        }.each do |endpoint, expected_url|
+          expect(data[endpoint]).to eq expected_url
+        end
+      end
+    end
   end
 
   describe '#webfinger' do

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -162,4 +162,18 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       expect(subject.protocol.call).to eq(:ftp)
     end
   end
+
+  describe 'authorization_url_host' do
+    it 'defaults to nil' do
+      expect(subject.authorization_url_host).to be_nil
+    end
+
+    it 'can be set to other hosts' do
+      Doorkeeper::OpenidConnect.configure do
+        authorization_url_host "alternate-authorization-host"
+      end
+
+      expect(subject.authorization_url_host).to eq("alternate-authorization-host")
+    end
+  end
 end


### PR DESCRIPTION
This change adds a new configuration option, `authorization_url_host`.  If set, this causes the discovery endpoint to generate the `authorization_url` using this setting as the `host`.  The rationale is explained in my change to the README:

> This is useful when you want authorization requests to use a different URL than other requests. For example, if your Doorkeeper server is behind a firewall with other servers, you might want other servers to use an "internal" URL to communicate with Doorkeeper, but you want to present an "external" URL to end-users for authentication requests.

This change scratches my particular itch for configuration, but I'm not sure if it makes sense to make other generated URLs configurable as well, or make this configurable in a different way.  I'm happy to raise an issue for discussion instead, but I figured I might as well raise a PR since I already wrote the code :).