### PR TITLE
Bump json-jwt because of CVE-2019-18848

### DIFF
--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.add_runtime_dependency 'doorkeeper', '~> 5.2.0'
-  spec.add_runtime_dependency 'json-jwt', '~> 1.6'
+  spec.add_runtime_dependency 'json-jwt', '>= 1.11.0'
 
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'factory_bot'

--- a/lib/doorkeeper/openid_connect/version.rb
+++ b/lib/doorkeeper/openid_connect/version.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
   module OpenidConnect
-    VERSION = '1.7.0'.freeze
+    VERSION = '1.7.1'.freeze
   end
 end


### PR DESCRIPTION
See - https://nvd.nist.gov/vuln/detail/CVE-2019-18848 