### PR TITLE
Update changes for Doorkeeper 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-No changes yet.
+- [#97] Update to make doorkeeper-oidc compatible with Doorkeeper 5.2
 
 ## v1.7.0 (2019-11-04)
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_dependency "#{Doorkeeper::Engine.root}/app/controllers/doorkeeper/authorizations_controller.rb"
+
+module Doorkeeper
+  class AuthorizationsController
+    module AuthorizationsExtension
+      private
+
+      def pre_auth_param_fields
+        super.append(:nonce)
+      end
+    end
+
+    Doorkeeper::AuthorizationsController.send :prepend, AuthorizationsExtension
+  end
+end

--- a/lib/doorkeeper/oauth/id_token_request.rb
+++ b/lib/doorkeeper/oauth/id_token_request.rb
@@ -9,18 +9,14 @@ module Doorkeeper
       end
 
       def authorize
-        if pre_auth.authorizable?
-          @auth = Authorization::Token.new(pre_auth, resource_owner)
-          @auth.issue_token
-          @response = response
-        else
-          @response = error_response
-        end
+        @auth = Authorization::Token.new(pre_auth, resource_owner)
+        @auth.issue_token
+        response
       end
 
       def deny
         pre_auth.error = :access_denied
-        error_response
+        pre_auth.error_response
       end
 
       private
@@ -29,12 +25,6 @@ module Doorkeeper
         id_token = Doorkeeper::OpenidConnect::IdToken.new(auth.token, pre_auth.nonce)
 
         IdTokenResponse.new(pre_auth, auth, id_token)
-      end
-
-      def error_response
-        ErrorResponse.from_request pre_auth,
-                                   redirect_uri: pre_auth.redirect_uri,
-                                   response_on_fragment: true
       end
     end
   end

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -105,15 +105,17 @@ module Doorkeeper
         end
 
         def matching_tokens_for_oidc_resource_owner(owner)
-          Doorkeeper::AccessToken.authorized_tokens_for(pre_auth.client.id, owner.id).select do |token|
-            Doorkeeper::AccessToken.scopes_match?(token.scopes, pre_auth.scopes, pre_auth.client.scopes)
-          end
+          AccessToken.matching_token_for(
+            pre_auth.client,
+            owner.id,
+            pre_auth.scopes
+          )
         end
 
         def oidc_consent_required?(owner)
           return false if skip_authorization?
 
-          matching_tokens_for_oidc_resource_owner(owner).blank?
+          matching_tokens_for_oidc_resource_owner(owner).nil?
         end
       end
     end

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -60,7 +60,7 @@ module Doorkeeper
             when 'none'
               raise Errors::InvalidRequest if (prompt_values - [ 'none' ]).any?
               raise Errors::LoginRequired unless owner
-              raise Errors::ConsentRequired if oidc_consent_required?(owner)
+              raise Errors::ConsentRequired if oidc_consent_required?
             when 'login'
               reauthenticate_oidc_resource_owner(owner) if owner
             when 'consent'
@@ -104,18 +104,8 @@ module Doorkeeper
           raise Errors::LoginRequired unless performed?
         end
 
-        def matching_tokens_for_oidc_resource_owner(owner)
-          AccessToken.matching_token_for(
-            pre_auth.client,
-            owner.id,
-            pre_auth.scopes
-          )
-        end
-
-        def oidc_consent_required?(owner)
-          return false if skip_authorization?
-
-          matching_tokens_for_oidc_resource_owner(owner).nil?
+        def oidc_consent_required?
+          !skip_authorization? && !matching_token?
         end
       end
     end

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -19,7 +19,6 @@ module Doorkeeper
           controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] &&
             action_name == 'new' &&
             pre_auth.valid? &&
-            pre_auth.client &&
             pre_auth.scopes.include?('openid')
         end
 

--- a/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
@@ -8,6 +8,22 @@ module Doorkeeper
           super
           @nonce = attrs[:nonce]
         end
+
+        # This method will be updated when doorkeeper move to version > 5.2.2
+        # TODO: delete this method and refactor response_on_fragment? method (below) when doorkeeper gem version constrains is > 5.2.2
+        def error_response
+          if error == :invalid_request
+            Doorkeeper::OAuth::InvalidRequestResponse.from_request(self, response_on_fragment: response_on_fragment?)
+          else
+            Doorkeeper::OAuth::ErrorResponse.from_request(self, response_on_fragment: response_on_fragment?)
+          end
+        end
+
+        private
+
+        def response_on_fragment?
+          response_type == "token" || response_type == "id_token" || response_type == "id_token token"
+        end
       end
     end
   end

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -304,4 +304,11 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
   end
+
+  describe '#pre_auth' do
+    it 'permits nonce parameter' do
+      authorize! nonce: '123456'
+      expect(assigns(:pre_auth).nonce).to eq '123456'
+    end
+  end
 end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -1,12 +1,51 @@
 require 'rails_helper'
 
 describe Doorkeeper::OpenidConnect::OAuth::PreAuthorization do
-  subject { Doorkeeper::OAuth::PreAuthorization.new server, { nonce: '123456' } }
+  subject { Doorkeeper::OAuth::PreAuthorization.new server, attrs }
   let(:server) { double }
+  let(:attrs) {}
 
   describe '#initialize' do
-    it 'stores the nonce attribute' do
-      expect(subject.nonce).to eq '123456'
+    context 'with nonce parameter' do
+      let(:attrs) { { nonce: '123456' } }
+
+      it 'stores the nonce attribute' do
+        expect(subject.nonce).to eq '123456'
+      end
+    end
+  end
+
+  describe '#error_response' do
+    context 'with response_type = code' do
+      let(:attrs) { { response_type: 'code', redirect_uri: 'client.com/callback' } }
+
+      it 'should redirect to redirect_uri with query parameter' do
+        expect(subject.error_response.redirect_uri).to match(/#{attrs[:redirect_uri]}\?/)
+      end
+    end
+
+    context 'with response_type = token' do
+      let(:attrs) { { response_type: 'token', redirect_uri: 'client.com/callback' } }
+
+      it 'should redirect to redirect_uri with fragment' do
+        expect(subject.error_response.redirect_uri).to match(/#{attrs[:redirect_uri]}#/)
+      end
+    end
+
+    context 'with response_type = id_token' do
+      let(:attrs) { { response_type: 'id_token', redirect_uri: 'client.com/callback' } }
+
+      it 'should redirect to redirect_uri with fragment' do
+        expect(subject.error_response.redirect_uri).to match(/#{attrs[:redirect_uri]}#/)
+      end
+    end
+
+    context 'with response_type = id_token token' do
+      let(:attrs) { { response_type: 'id_token token', redirect_uri: 'client.com/callback' } }
+
+      it 'should redirect to redirect_uri with fragment' do
+        expect(subject.error_response.redirect_uri).to match(/#{attrs[:redirect_uri]}#/)
+      end
     end
   end
 end


### PR DESCRIPTION
#85 tried to make doorkeeper-openid_connect to be compatible with doorkeeper 5.2, but there are errors to be fixed and some place to refactor. So I create this PR to "completely" make this gem compatible with doorkeeper 5.2.

## What PR does
- Resolves #95 
- set response_on_fragment for pre_auth.error_response
- Refactor code.

The work is explained as PR's comment below 👇
