### PR TITLE
Use cascading deletes for deleting oauth_openid_requests upon deleting an access_grant

### DIFF
--- a/lib/generators/doorkeeper/openid_connect/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/openid_connect/templates/migration.rb.erb
@@ -8,7 +8,8 @@ class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration<%= migration
     add_foreign_key(
       :oauth_openid_requests,
       :oauth_access_grants,
-      column: :access_grant_id
+      column: :access_grant_id,
+      on_delete: :cascade
     )
   end
 end

--- a/spec/models/access_grant_spec.rb
+++ b/spec/models/access_grant_spec.rb
@@ -12,4 +12,15 @@ describe Doorkeeper::OpenidConnect::AccessGrant do
       dependent: :delete,
     })
   end
+
+  describe '#delete' do
+    it 'cascades to oauth_openid_requests' do
+      pending('Rails 6 changes - https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/91')
+
+      access_grant = create(:access_grant, application: create(:application))
+      create(:openid_request, access_grant: access_grant)
+
+      expect { access_grant.delete }.to change(Doorkeeper::OpenidConnect::Request, :count).by(-1)
+    end
+  end
 end


### PR DESCRIPTION
This fix closes #82

This change works only for new installations for this gem, since the fix is made in the migration template, which is only used during a fresh install.

For existing users who wish to avail the changes to fix the issue, please consider generating a new migration in your application which drops the existing `foreign_key` in the `oauth_openid_requests` table and then creating a new `foreign_key` in it's place with `on_delete: :cascade` included.

Example:

```ruby
class UpdateOauthOpenIdRequestsForeignKeys < ActiveRecord::Migration[5.2]
  def up
    remove_foreign_key(:oauth_openid_requests, column: :access_grant_id)
    add_foreign_key(:oauth_openid_requests, :oauth_access_grants, column: :access_grant_id, on_delete: :cascade)
  end

  def down
    remove_foreign_key(:oauth_openid_requests, column: :access_grant_id)
    add_foreign_key(:oauth_openid_requests, :oauth_access_grants, column: :access_grant_id)
  end
end

```