### PR TITLE
Fix audience method for null application

### DIFF
--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -46,7 +46,7 @@ module Doorkeeper
       end
 
       def audience
-        @access_token.application.uid
+        @access_token.application.try(:uid)
       end
 
       def expiration

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -32,6 +32,23 @@ describe Doorkeeper::OpenidConnect::IdToken do
     end
   end
 
+  describe '#claims when access_token application is null' do
+    let(:access_token) { create :access_token, resource_owner_id: user.id, application: nil, scopes: 'openid' }
+    it 'returns all default claims' do
+      expect(subject.claims).to eq({
+        iss: 'dummy',
+        sub: user.id.to_s,
+        aud: nil,
+        exp: 180,
+        iat: 60,
+        nonce: nonce,
+        auth_time: 23,
+        both_responses: 'both',
+        id_token_response: 'id_token',
+      })
+    end
+  end
+
   describe '#as_json' do
     it 'returns claims with nil values and empty strings removed' do
       allow(subject).to receive(:issuer).and_return(nil)


### PR DESCRIPTION
Audience method returns an error if called when the application on the access token is null. I have changed it to return null instead
`NoMethodError: undefined method `uid' for nil:NilClass`
```
"/code/masterlock/doorkeeper-openid_connect/lib/doorkeeper/openid_connect/id_token.rb:49:in `audience'",
"/code/masterlock/doorkeeper-openid_connect/lib/doorkeeper/openid_connect/id_token.rb:19:in `claims'",
"/code/masterlock/doorkeeper-openid_connect/lib/doorkeeper/openid_connect/id_token.rb:28:in `as_json'",
"/code/masterlock/doorkeeper-openid_connect/lib/doorkeeper/openid_connect/id_token.rb:32:in `as_jws_token'",
"/code/masterlock/doorkeeper-openid_connect/lib/doorkeeper/openid_connect/oauth/token_response.rb:12:in `body'",
"/code/masterlock/doorkeeper/app/controllers/doorkeeper/tokens_controller.rb:7:in `create'"
```