### PR TITLE
Add support for end_session_endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ The following settings are optional:
   - Note that the OIDC specification mandates HTTPS, so you shouldn't change this
     for production environments unless you have a really good reason!
 
+- `end_session_endpoint`
+  - The URL that the user is redirected to after ending the session on the client.
+  - Used by implementations like https://github.com/IdentityModel/oidc-client-js.
+
 ### Scopes
 
 To perform authentication over OpenID Connect, an OAuth client needs to request the `openid` scope. This scope needs to be enabled using either `optional_scopes` in the global Doorkeeper configuration in `config/initializers/doorkeeper.rb`, or by adding it to any OAuth application's `scope` attribute.

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -30,6 +30,7 @@ module Doorkeeper
           introspection_endpoint: oauth_introspect_url(protocol: protocol),
           userinfo_endpoint: oauth_userinfo_url(protocol: protocol),
           jwks_uri: oauth_discovery_keys_url(protocol: protocol),
+          end_session_endpoint: Doorkeeper::OpenidConnect.configuration.end_session_endpoint.call(),
 
           scopes_supported: doorkeeper.scopes,
 
@@ -67,7 +68,7 @@ module Doorkeeper
             'exp',
             'iat',
           ] | openid_connect.claims.to_h.keys,
-        }
+        }.compact
       end
 
       def webfinger_response

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -124,6 +124,10 @@ module Doorkeeper
       option :protocol, default: lambda { |*_|
         ::Rails.env.production? ? :https : :http
       }
+
+      option :end_session_endpoint, default: lambda { |*_|
+        nil
+      }
     end
   end
 end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -65,6 +65,17 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
 
       expect(data['authorization_endpoint']).to eq 'testing://test.host/oauth/authorize'
     end
+
+    it 'uses the configured end session endpoint' do
+      Doorkeeper::OpenidConnect.configure do
+        end_session_endpoint { 'http://test.host/logout' }
+      end
+
+      get :provider
+      data = JSON.parse(response.body)
+
+      expect(data['end_session_endpoint']).to eq 'http://test.host/logout'
+    end
   end
 
   describe '#webfinger' do

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -66,6 +66,13 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       expect(data['authorization_endpoint']).to eq 'testing://test.host/oauth/authorize'
     end
 
+    it 'does not return an end session endpoint if none is configured' do
+      get :provider
+      data = JSON.parse(response.body)
+
+      expect(data.key?('end_session_endpoint')).to be(false)
+    end
+
     it 'uses the configured end session endpoint' do
       Doorkeeper::OpenidConnect.configure do
         end_session_endpoint { 'http://test.host/logout' }

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -162,4 +162,18 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       expect(subject.protocol.call).to eq(:ftp)
     end
   end
+
+  describe 'end_session_endpoint' do
+    it 'defaults to nil' do
+      expect(subject.end_session_endpoint.call).to be_nil
+    end
+
+    it 'can be set to a custom url' do
+      Doorkeeper::OpenidConnect.configure do
+        end_session_endpoint { 'http://test.host/logout' }
+      end
+
+      expect(subject.end_session_endpoint.call).to eq('http://test.host/logout')
+    end
+  end
 end


### PR DESCRIPTION
This is in the spec for discovery:
https://openid.net/specs/openid-connect-discovery-1_0.html

And in the spec for RP-Initiated Logout:
https://openid.net/specs/openid-connect-session-1_0.html#RPLogout

And used by popular libraries like:
https://github.com/IdentityModel/oidc-client-js

When you trigger the `userUnloaded` event with `oidc-client-js`, it will print the following error in the browser console when used with `doorkeeper-openid_connect`:

<img width="695" alt="Bildschirmfoto 2020-02-07 um 16 01 45" src="https://user-images.githubusercontent.com/2190/74040149-6d55a080-49c3-11ea-94bb-d8182083140f.png">

With the end_session_endpoint configured like in this PR, `oidc-client-js` will work as expected when emitting the `userUnloaded` event (running the client side hook and then redirecting to the specified url).

If you want to use named routes inside the initializer, you can do it like so:

```
  end_session_endpoint do
    Rails.application.routes.url_for({ host: ENV.fetch('HOSTNAME') }, :destroy_user_session)
  end
```