### PR TITLE
Add support for Doorkeeper 5.4

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -12,6 +12,6 @@ module Doorkeeper
       end
     end
 
-    Doorkeeper::AuthorizationsController.send :prepend, AuthorizationsExtension
+    Doorkeeper::AuthorizationsController.prepend AuthorizationsExtension
   end
 end

--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = '>= 2.4'
 
-  spec.add_runtime_dependency 'doorkeeper', '>= 5.2', '< 5.4'
+  spec.add_runtime_dependency 'doorkeeper', '>= 5.2', '< 5.5'
   spec.add_runtime_dependency 'json-jwt', '>= 1.11.0'
 
   spec.add_development_dependency 'rspec-rails'

--- a/lib/doorkeeper/oauth/id_token_request.rb
+++ b/lib/doorkeeper/oauth/id_token_request.rb
@@ -10,7 +10,11 @@ module Doorkeeper
 
       def authorize
         @auth = Authorization::Token.new(pre_auth, resource_owner)
-        @auth.issue_token
+        if @auth.respond_to?(:issue_token!)
+          @auth.issue_token!
+        else
+          @auth.issue_token
+        end
         response
       end
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -4,6 +4,12 @@ module Doorkeeper
       module Controller
         private
 
+        # TODO: remove after Doorkeeper will merge it
+        def current_resource_owner
+          return @current_resource_owner if defined?(@current_resource_owner)
+          super
+        end
+
         def authenticate_resource_owner!
           super.tap do |owner|
             next unless oidc_authorization_request?
@@ -111,5 +117,5 @@ module Doorkeeper
     end
   end
 
-  Helpers::Controller.send :prepend, OpenidConnect::Helpers::Controller
+  Helpers::Controller.prepend OpenidConnect::Helpers::Controller
 end

--- a/lib/doorkeeper/openid_connect/oauth/authorization/code.rb
+++ b/lib/doorkeeper/openid_connect/oauth/authorization/code.rb
@@ -2,21 +2,38 @@ module Doorkeeper
   module OpenidConnect
     module OAuth
       module Authorization
-        module Code
-          def issue_token
-            super.tap do |access_grant|
-              if pre_auth.nonce.present?
-                ::Doorkeeper::OpenidConnect::Request.create!(
-                  access_grant: access_grant,
-                  nonce: pre_auth.nonce
-                )
+        Code = Module.new
+
+        Code.module_eval do
+          if Doorkeeper::OAuth::Authorization::Code.method_defined?(:issue_token!)
+            def issue_token!
+              super.tap do |access_grant|
+                create_openid_request(access_grant) if pre_auth.nonce.present?
               end
             end
+
+            alias issue_token issue_token!
+          else
+            # TOOO: drop after dropping support of Doorkeeper < 5.4
+            def issue_token
+              super.tap do |access_grant|
+                create_openid_request(access_grant) if pre_auth.nonce.present?
+              end
+            end
+          end
+
+          private
+
+          def create_openid_request(access_grant)
+            ::Doorkeeper::OpenidConnect::Request.create!(
+              access_grant: access_grant,
+              nonce: pre_auth.nonce
+            )
           end
         end
       end
     end
   end
 
-  OAuth::Authorization::Code.send :prepend, OpenidConnect::OAuth::Authorization::Code
+  OAuth::Authorization::Code.prepend OpenidConnect::OAuth::Authorization::Code
 end

--- a/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
@@ -4,8 +4,13 @@ module Doorkeeper
       module PreAuthorization
         attr_reader :nonce
 
-        def initialize(server, attrs = {})
-          super
+        def initialize(server, attrs = {}, resource_owner = nil)
+          if (Doorkeeper::VERSION::MAJOR >= 5 && Doorkeeper::VERSION::MINOR >= 4) ||
+            Doorkeeper::VERSION::MAJOR >= 6
+            super
+          else
+            super(server, attrs)
+          end
           @nonce = attrs[:nonce]
         end
 

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -4,7 +4,7 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
   subject {
     Doorkeeper::OAuth::AuthorizationCodeRequest.new(server, grant, client).tap do |request|
       request.instance_variable_set '@response', response
-      request.access_token = token
+      request.instance_variable_set("@access_token", token)
     end
   }
 

--- a/spec/lib/oauth/id_token_request_spec.rb
+++ b/spec/lib/oauth/id_token_request_spec.rb
@@ -25,7 +25,7 @@ describe Doorkeeper::OAuth::IdTokenRequest do
   end
 
   let(:owner) do
-    double :owner, id: 7866
+    double :owner, id: 7866, to_i: 7866
   end
 
   subject do

--- a/spec/lib/oauth/id_token_response_spec.rb
+++ b/spec/lib/oauth/id_token_response_spec.rb
@@ -21,9 +21,15 @@ describe Doorkeeper::OAuth::IdTokenResponse do
     )
   end
 
+  let(:owner) { double(id: 1, to_i: 1) }
+
   let(:auth) do
-    Doorkeeper::OAuth::Authorization::Token.new(pre_auth, double(id: 1)).tap do |c|
-      c.issue_token
+    Doorkeeper::OAuth::Authorization::Token.new(pre_auth, owner).tap do |c|
+      if c.respond_to?(:issue_token!)
+        c.issue_token!
+      else
+        c.issue_token
+      end
     end
   end
   let(:id_token) { Doorkeeper::OpenidConnect::IdToken.new(token, pre_auth) }

--- a/spec/lib/oauth/id_token_token_request_spec.rb
+++ b/spec/lib/oauth/id_token_token_request_spec.rb
@@ -25,7 +25,7 @@ describe Doorkeeper::OAuth::IdTokenTokenRequest do
   end
 
   let(:owner) do
-    double :owner, id: 7866
+    double :owner, id: 7866, to_i: 7866
   end
 
   subject do

--- a/spec/lib/oauth/id_token_token_response_spec.rb
+++ b/spec/lib/oauth/id_token_token_response_spec.rb
@@ -19,9 +19,14 @@ describe Doorkeeper::OAuth::IdTokenTokenResponse do
       nonce: '12345'
     )
   end
+  let(:owner) { double(id: 1, to_i: 1) }
   let(:auth) do
-    Doorkeeper::OAuth::Authorization::Token.new(pre_auth, double(id: 1)).tap do |c|
-      c.issue_token
+    Doorkeeper::OAuth::Authorization::Token.new(pre_auth, owner).tap do |c|
+      if c.respond_to?(:issue_token!)
+        c.issue_token!
+      else
+        c.issue_token
+      end
     end
   end
   let(:id_token) { Doorkeeper::OpenidConnect::IdToken.new(token, pre_auth) }

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -17,7 +17,7 @@ describe Doorkeeper::OpenidConnect::OAuth::PasswordAccessTokenRequest do
   describe '#after_successful_response' do
     it 'adds the ID token to the response' do
       subject.instance_variable_set '@response', response
-      subject.access_token = token
+      subject.instance_variable_set '@access_token', token
       subject.send :after_successful_response
 
       expect(response.id_token).to be_a Doorkeeper::OpenidConnect::IdToken


### PR DESCRIPTION
Doorkeeper 5.4 has some internals refactoring which breaks it to use with doorkeeper openid connect.

This PR solves the issue while staying backward compatible with Doorkeeper < 5.4