### PR TITLE
Add configuration for prompt=select_account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [#114] Fix user_info endpoint when used in api mode
 - [#112] Add grant_types_supported to discovery response
+- [#111] Add configuration callbacks `select_account_for_resource_owner` to support param prompt=select_account
 
 ## v1.7.2 (2020-05-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - [#114] Fix user_info endpoint when used in api mode
 - [#112] Add grant_types_supported to discovery response
-- [#111] Add configuration callbacks `select_account_for_resource_owner` to support param prompt=select_account
+- [#111] Add configuration callback `select_account_for_resource_owner` to support the `prompt=select_account` param
 
 ## v1.7.2 (2020-05-20)
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The following settings are optional, but recommended for better client compatibi
   - Required to support the `max_age` and `prompt=login` parameters.
   - The block is executed in the controller's scope, so you have access to methods like `params`, `redirect_to` etc.
 - `select_account_for_resource_owner`
-  - Defines how to trigger account selecting to choose the current login user
+  - Defines how to trigger account selection to choose the current login user.
   - Required to support the `prompt=select_account` parameter.
   - The block is executed in the controller's scope, so you have access to methods like `params`, `redirect_to` etc.
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ The following settings are optional, but recommended for better client compatibi
   - Defines how to trigger reauthentication for the current user (e.g. display a password prompt, or sign-out the user and redirect to the login form).
   - Required to support the `max_age` and `prompt=login` parameters.
   - The block is executed in the controller's scope, so you have access to methods like `params`, `redirect_to` etc.
+- `select_account_for_resource_owner`
+  - Defines how to trigger account selecting to choose the current login user
+  - Required to support the `prompt=select_account` parameter.
+  - The block is executed in the controller's scope, so you have access to methods like `params`, `redirect_to` etc.
 
 The following settings are optional:
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,4 +19,5 @@ en:
           resource_owner_from_access_token_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.resource_owner_from_access_token missing configuration.'
           auth_time_from_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.auth_time_from_resource_owner missing configuration.'
           reauthenticate_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.reauthenticate_resource_owner missing configuration.'
+          select_account_for_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.select_account_for_resource_owner missing configuration.'
           subject_not_configured: 'ID Token generation failed due to Doorkeeper::OpenidConnect.configure.subject missing configuration.'

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -115,6 +115,10 @@ module Doorkeeper
         raise Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.reauthenticate_resource_owner_not_configured')
       }
 
+      option :select_account_for_resource_owner, default: lambda { |*_|
+        raise Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.select_account_for_resource_owner_not_configured')
+      }
+
       option :subject, default: lambda { |*_|
         raise Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.subject_not_configured')
       }

--- a/lib/doorkeeper/openid_connect/errors.rb
+++ b/lib/doorkeeper/openid_connect/errors.rb
@@ -26,7 +26,6 @@ module Doorkeeper
       class LoginRequired < OpenidConnectError; end
       class ConsentRequired < OpenidConnectError; end
       class InteractionRequired < OpenidConnectError; end
-      class AccountSelectionRequired < OpenidConnectError; end
     end
   end
 end

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -96,7 +96,7 @@ module Doorkeeper
           end
         end
 
-        def return_without_prompt_param(prompt_value)
+        def return_without_oidc_prompt_param(prompt_value)
           return_to = URI.parse(request.path)
           return_to.query = request.query_parameters.tap do |params|
             params['prompt'] = params['prompt'].to_s.sub(/\b#{prompt_value}\s*\b/, '').strip
@@ -106,7 +106,7 @@ module Doorkeeper
         end
 
         def reauthenticate_oidc_resource_owner(owner)
-          return_to = return_without_prompt_param('login')
+          return_to = return_without_oidc_prompt_param('login')
 
           instance_exec(
             owner,
@@ -122,7 +122,7 @@ module Doorkeeper
         end
 
         def select_account_for_oidc_resource_owner(owner)
-          return_to = return_without_prompt_param('select_account')
+          return_to = return_without_oidc_prompt_param('select_account')
 
           instance_exec(
             owner,

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -28,6 +28,18 @@ Doorkeeper::OpenidConnect.configure do
     # redirect_to new_user_session_url
   end
 
+  # Depend on the configuration, the DoubleRenderError could be occurred
+  #  because of render/redirect is called at some configuration before this configure is called.
+  # To avoid DoubleRenderError, you could adding these two lines at the beginning
+  #  of this configuration: (Reference: https://github.com/rails/rails/issues/25106)
+  #   self.response_body = nil
+  #   @_response_body = nil
+  select_account_for_resource_owner do |resource_owner, return_to|
+    # Example implementation:
+    # store_location_for resource_owner, return_to
+    # redirect_to account_select_url
+  end
+
   subject do |resource_owner, application|
     # Example implementation:
     # resource_owner.id

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -28,10 +28,10 @@ Doorkeeper::OpenidConnect.configure do
     # redirect_to new_user_session_url
   end
 
-  # Depend on the configuration, the DoubleRenderError could be occurred
-  #  because of render/redirect is called at some configuration before this configure is called.
-  # To avoid DoubleRenderError, you could adding these two lines at the beginning
-  #  of this configuration: (Reference: https://github.com/rails/rails/issues/25106)
+  # Depending on your configuration, a DoubleRenderError could be raised
+  # if render/redirect_to is called at some point before this callback is executed.
+  # To avoid the DoubleRenderError, you could add these two lines at the beginning
+  #  of this callback: (Reference: https://github.com/rails/rails/issues/25106)
   #   self.response_body = nil
   #   @_response_body = nil
   select_account_for_resource_owner do |resource_owner, return_to|

--- a/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
+++ b/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
@@ -47,6 +47,10 @@ Doorkeeper::OpenidConnect.configure do
     redirect_to '/reauthenticate'
   end
 
+  select_account_for_resource_owner do |_resource_owner, _return_to|
+    redirect_to '/select_account'
+  end
+
   subject do |resource_owner|
     resource_owner.id
   end

--- a/spec/dummy/config/locales/doorkeeper_openid_connect.en.yml
+++ b/spec/dummy/config/locales/doorkeeper_openid_connect.en.yml
@@ -19,4 +19,5 @@ en:
           resource_owner_from_access_token_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.resource_owner_from_access_token missing configuration.'
           auth_time_from_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.auth_time_from_resource_owner missing configuration.'
           reauthenticate_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.reauthenticate_resource_owner missing configuration.'
+          select_account_for_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.select_account_for_resource_owner missing configuration.'
           subject_not_configured: 'ID Token generation failed due to Doorkeeper::OpenidConnect.configure.subject missing configuration.'

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -105,6 +105,24 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
+  describe 'select_account_for_resource_owner' do
+    it 'sets the block that is accessible via select_account_for_resource_owner' do
+      block = proc {}
+      described_class.configure do
+        select_account_for_resource_owner(&block)
+      end
+      expect(subject.select_account_for_resource_owner).to eq(block)
+    end
+
+    it 'fails if unset' do
+      described_class.configure {}
+
+      expect do
+        subject.select_account_for_resource_owner.call
+      end.to raise_error Doorkeeper::OpenidConnect::Errors::InvalidConfiguration
+    end
+  end
+
   describe 'subject' do
     it 'sets the block that is accessible via subject' do
       block = proc {}


### PR DESCRIPTION
## Summary
Add `select_account_for_resource_owner` configuration to allow defining behavior when receiving param `prompt=select_account` at authorization request.

Resolves #107 