### PR TITLE
Add grant_types_supported to discovery response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [#114] Fix user_info endpoint when used in api mode
+- [#112] Add grant_types_supported to discovery response
 
 ## v1.7.2 (2020-05-20)
 

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -38,17 +38,13 @@ module Doorkeeper
 
           # TODO: support id_token response type
           response_types_supported: doorkeeper.authorization_response_types,
-          response_modes_supported: ['query', 'fragment'],
+          response_modes_supported: %w[query fragment],
           grant_types_supported: grant_types_supported(doorkeeper),
 
-          token_endpoint_auth_methods_supported: [
-            'client_secret_basic',
-            'client_secret_post',
-
-            # TODO: look into doorkeeper-jwt_assertion for these
-            # 'client_secret_jwt',
-            # 'private_key_jwt'
-          ],
+          # TODO: look into doorkeeper-jwt_assertion for these
+          #  'client_secret_jwt',
+          #  'private_key_jwt'
+          token_endpoint_auth_methods_supported: %w[client_secret_basic client_secret_post],
 
           subject_types_supported: openid_connect.subject_types_supported,
 

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -39,6 +39,7 @@ module Doorkeeper
           # TODO: support id_token response type
           response_types_supported: doorkeeper.authorization_response_types,
           response_modes_supported: ['query', 'fragment'],
+          grant_types_supported: grant_types_supported(doorkeeper),
 
           token_endpoint_auth_methods_supported: [
             'client_secret_basic',
@@ -71,6 +72,12 @@ module Doorkeeper
             iat
           ] | openid_connect.claims.to_h.keys,
         }.compact
+      end
+
+      def grant_types_supported(doorkeeper)
+        grant_types_supported = doorkeeper.grant_flows
+        grant_types_supported << 'refresh_token' if doorkeeper.refresh_token_enabled?
+        grant_types_supported
       end
 
       def webfinger_response

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -21,6 +21,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
 
         'response_types_supported' => ['code'],
         'response_modes_supported' => ['query', 'fragment'],
+        'grant_types_supported' => %w[authorization_code client_credentials],
 
         'token_endpoint_auth_methods_supported' => [
           'client_secret_basic',
@@ -55,6 +56,17 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
           user_info_response
         ],
       }.sort)
+    end
+
+    context 'when refresh_token grant type is enabled' do
+      before { Doorkeeper.configure { use_refresh_token } }
+
+      it 'add refresh_token to grant_types_supported' do
+        get :provider
+        data = JSON.parse(response.body)
+
+        expect(data['grant_types_supported']).to eq %w[authorization_code client_credentials refresh_token]
+      end
     end
 
     it 'uses the protocol option for generating URLs' do

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -20,13 +20,10 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
         'scopes_supported' => ['openid'],
 
         'response_types_supported' => ['code'],
-        'response_modes_supported' => ['query', 'fragment'],
+        'response_modes_supported' => %w[query fragment],
         'grant_types_supported' => %w[authorization_code client_credentials],
 
-        'token_endpoint_auth_methods_supported' => [
-          'client_secret_basic',
-          'client_secret_post',
-        ],
+        'token_endpoint_auth_methods_supported' => %w[client_secret_basic client_secret_post],
 
         'subject_types_supported' => [
           'public',


### PR DESCRIPTION
Resolves #106 

### What?
Commit#1: Add grant types supported to discovery
Commit#2: fix code style following rubocop rule

### How?

This is the list grant types defined in Doorkeeper: https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/oauth.rb

To get grant types supported by AS:
- User [grant_flows of doorkeeper configuration](https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/config.rb#L267) to get:
  - authorization_code
  - implicit
  - password
  - client_credentials

- Use [use_refresh_token of doorkeeper configuration](https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/config.rb#L122-L128) to add `refresh_token` grant types as [calculate_token_grant_types](https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/config.rb#L597)