### PR TITLE
API mode will not define the verify_authenticity_token action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- [#114] Fix user_info endpoint when used in api mode
+
 ## v1.7.2 (2020-05-20)
 
 ### Changes

--- a/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
@@ -3,7 +3,9 @@
 module Doorkeeper
   module OpenidConnect
     class UserinfoController < ::Doorkeeper::ApplicationController
-      skip_before_action :verify_authenticity_token
+      unless Doorkeeper.config.api_only
+        skip_before_action :verify_authenticity_token
+      end
       before_action -> { doorkeeper_authorize! :openid }
 
       def show


### PR DESCRIPTION
### WHY

If you run this in a Rails 5 API application you will get an <ArgumentError: Before process_action callback :verify_authenticity_token has not been defined> error

Resolves #114 
