### PR TITLE
Fix migration template to use Rails migrations DSL for association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [#114] Fix user_info endpoint when used in api mode
 - [#112] Add grant_types_supported to discovery response
 - [#111] Add configuration callback `select_account_for_resource_owner` to support the `prompt=select_account` param
+- [#117] Fix migration template to use Rails migrations DSL for association.
 
 ## v1.7.2 (2020-05-20)
 

--- a/lib/generators/doorkeeper/openid_connect/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/openid_connect/templates/migration.rb.erb
@@ -1,7 +1,7 @@
 class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :oauth_openid_requests do |t|
-      t.integer :access_grant_id, null: false
+      t.references :access_grant, null: false, index: true
       t.string :nonce, null: false
     end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2020_05_19_091115) do
   create_table "oauth_openid_requests", force: :cascade do |t|
     t.integer "access_grant_id", null: false
     t.string "nonce", null: false
+    t.index ["access_grant_id"], name: "index_oauth_openid_requests_on_access_grant_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Fix migration template to use `references` migrations DSL to properly create column type.
Also add an index for referenced column.

Fixes #115