### PR TITLE
Bug fix: Fragment urls for implicit flow error redirects

### DIFF
--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -22,6 +22,7 @@ require 'doorkeeper/openid_connect/errors'
 require 'doorkeeper/openid_connect/id_token'
 require 'doorkeeper/openid_connect/id_token_token'
 require 'doorkeeper/openid_connect/user_info'
+require 'doorkeeper/openid_connect/response_mode'
 require 'doorkeeper/openid_connect/version'
 
 require 'doorkeeper/openid_connect/helpers/controller'

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -49,7 +49,7 @@ module Doorkeeper
                                name: exception.type,
                                state: params[:state],
                                redirect_uri: params[:redirect_uri],
-                               response_on_fragment: pre_auth.response_on_fragment?,
+                               response_on_fragment: Doorkeeper::OpenidConnect::ResponseMode.new(pre_auth.response_type).fragment?,
                              )
           end
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -38,18 +38,20 @@ module Doorkeeper
           # FIXME: workaround for Rails 5, see https://github.com/rails/rails/issues/25106
           @_response_body = nil
 
+          should_respond_on_fragment = Doorkeeper::OpenidConnect::ResponseMode.new(pre_auth.response_type).fragment?
           error_response = if exception.type == :invalid_request
                              ::Doorkeeper::OAuth::InvalidRequestResponse.new(
                                name: exception.type,
                                state: params[:state],
                                redirect_uri: params[:redirect_uri],
+                               response_on_fragment: should_respond_on_fragment,
                              )
                            else
                              ::Doorkeeper::OAuth::ErrorResponse.new(
                                name: exception.type,
                                state: params[:state],
                                redirect_uri: params[:redirect_uri],
-                               response_on_fragment: Doorkeeper::OpenidConnect::ResponseMode.new(pre_auth.response_type).fragment?,
+                               response_on_fragment: should_respond_on_fragment,
                              )
           end
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -49,6 +49,7 @@ module Doorkeeper
                                name: exception.type,
                                state: params[:state],
                                redirect_uri: params[:redirect_uri],
+                               response_on_fragment: pre_auth.response_on_fragment?,
                              )
           end
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -38,20 +38,19 @@ module Doorkeeper
           # FIXME: workaround for Rails 5, see https://github.com/rails/rails/issues/25106
           @_response_body = nil
 
-          should_respond_on_fragment = Doorkeeper::OpenidConnect::ResponseMode.new(pre_auth.response_type).fragment?
           error_response = if exception.type == :invalid_request
                              ::Doorkeeper::OAuth::InvalidRequestResponse.new(
                                name: exception.type,
                                state: params[:state],
                                redirect_uri: params[:redirect_uri],
-                               response_on_fragment: should_respond_on_fragment,
+                               response_on_fragment: pre_auth.response_on_fragment?,
                              )
                            else
                              ::Doorkeeper::OAuth::ErrorResponse.new(
                                name: exception.type,
                                state: params[:state],
                                redirect_uri: params[:redirect_uri],
-                               response_on_fragment: should_respond_on_fragment,
+                               response_on_fragment: pre_auth.response_on_fragment?,
                              )
           end
 

--- a/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
@@ -26,8 +26,6 @@ module Doorkeeper
           end
         end
 
-        private
-
         def response_on_fragment?
           Doorkeeper::OpenidConnect::ResponseMode.new(response_type).fragment?
         end

--- a/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
@@ -26,8 +26,10 @@ module Doorkeeper
           end
         end
 
+        private
+
         def response_on_fragment?
-          response_type == 'token' || response_type == 'id_token' || response_type == 'id_token token'
+          Doorkeeper::OpenidConnect::ResponseMode.new(response_type).fragment?
         end
       end
     end

--- a/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
@@ -26,8 +26,6 @@ module Doorkeeper
           end
         end
 
-        private
-
         def response_on_fragment?
           response_type == 'token' || response_type == 'id_token' || response_type == 'id_token token'
         end

--- a/lib/doorkeeper/openid_connect/response_mode.rb
+++ b/lib/doorkeeper/openid_connect/response_mode.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OpenidConnect
+    class ResponseMode
+      attr_reader :type
+
+      def initialize(response_type)
+        @type = response_type
+      end
+
+      def fragment?
+        mode == 'fragment'
+      end
+
+      def query?
+        mode == 'query'
+      end
+
+      def mode
+        case type
+        when 'token', 'id_token', 'id_token token'
+          'fragment'
+        else
+          'query'
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -132,6 +132,20 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
           expect(JSON.parse(response.body)).to eq(error_params)
         end
 
+        it 'uses the fragment style uris when redirecting an invalid request error for implicit flow request' do
+          allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(['implicit_oidc'])
+
+          authorize! response_type: 'id_token token', prompt: 'none login'
+
+          error_params = {
+            'error' => 'invalid_request',
+            'error_description' => 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.',
+          }
+
+          expect(response.status).to redirect_to build_redirect_uri(error_params, type: 'fragment')
+          expect(JSON.parse(response.body)).to eq(error_params)
+        end
+
         context 'when not logged in' do
           let(:error_params) do
             {
@@ -145,6 +159,15 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
             authorize! prompt: 'none', current_user: nil, state: 'somestate'
 
             expect(response).to redirect_to build_redirect_uri(error_params)
+            expect(JSON.parse(response.body)).to eq(error_params)
+          end
+
+          it 'uses the fragment style uris when redirecting an error for implicit flow request' do
+            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(['implicit_oidc'])
+
+            authorize! response_type: 'id_token token', prompt: 'none', current_user: nil, state: 'somestate'
+
+            expect(response).to redirect_to build_redirect_uri(error_params, type: 'fragment')
             expect(JSON.parse(response.body)).to eq(error_params)
           end
         end

--- a/spec/lib/response_mode_spec.rb
+++ b/spec/lib/response_mode_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Doorkeeper::OpenidConnect::ResponseMode do
+  describe '#mode' do
+    it 'recognizes fragment response types' do
+      expect(Doorkeeper::OpenidConnect::ResponseMode.new('token').mode).to eq('fragment')
+      expect(Doorkeeper::OpenidConnect::ResponseMode.new('id_token').mode).to eq('fragment')
+      expect(Doorkeeper::OpenidConnect::ResponseMode.new('id_token token').mode).to eq('fragment')
+    end
+
+    it 'defaults to query' do
+      expect(Doorkeeper::OpenidConnect::ResponseMode.new('other').mode).to eq('query')
+    end
+  end
+
+  describe '#fragment?' do
+    it 'is truthy for the fragment mode' do
+      expect(Doorkeeper::OpenidConnect::ResponseMode.new('id_token')).to be_fragment
+    end
+
+    it 'is falsey for other modes' do
+      expect(Doorkeeper::OpenidConnect::ResponseMode.new('other')).not_to be_fragment
+    end
+  end
+
+  describe '#query?' do
+    it 'is truthy for the query mode' do
+      expect(Doorkeeper::OpenidConnect::ResponseMode.new('other')).to be_query
+    end
+
+    it 'is falsey for other modes' do
+      expect(Doorkeeper::OpenidConnect::ResponseMode.new('id_token')).not_to be_query
+    end
+  end
+end


### PR DESCRIPTION
We noticed that when using the `promt=none` option our client did not parse the returned login error.

This was due to that the computed redirect url for errors used query strings instead of fragments even if the response_type was of the id_token type. 

This PR aims to ensure that the same response mode is used regardless on success or error as per https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthError 

> If the End-User denies the request or the End-User authentication fails, the Authorization Server MUST return the error Authorization Response in the fragment component of the Redirection URI …  unless a different Response Mode was specified.

and https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#Combinations

> When supplied as the value for the response_type parameter, a successful response MUST include an Access Token, an Access Token Type, and an id_token. The default Response Mode for this Response Type is the fragment encoding and the query encoding MUST NOT be used. Both successful and error responses SHOULD be returned using the supplied Response Mode, or if none is supplied, using the default Response Mode.

It _does not_ try to fix responding to the response mode parameter as this seems to be unsupported by doorkeeper at the moment (unless I'm misstaken, it has been known to happen before).

Further refactoring could be made to ensure the error responses is not as tied to the pre_auth as it is currently but I tried to keep the change small.

Do note that this is the first time I've touched openid / oauth stuff so sorry if I misunderstood how this is supposed to work! =)