### PR TITLE
Execute end_session_endpoint in the controllers context

### DIFF
--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -32,7 +32,7 @@ module Doorkeeper
           introspection_endpoint: oauth_introspect_url(protocol: protocol),
           userinfo_endpoint: oauth_userinfo_url(protocol: protocol),
           jwks_uri: oauth_discovery_keys_url(protocol: protocol),
-          end_session_endpoint: openid_connect.end_session_endpoint.call,
+          end_session_endpoint: openid_connect.end_session_endpoint.call(self),
 
           scopes_supported: doorkeeper.scopes,
 

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -32,7 +32,7 @@ module Doorkeeper
           introspection_endpoint: oauth_introspect_url(protocol: protocol),
           userinfo_endpoint: oauth_userinfo_url(protocol: protocol),
           jwks_uri: oauth_discovery_keys_url(protocol: protocol),
-          end_session_endpoint: openid_connect.end_session_endpoint.call(self),
+          end_session_endpoint: instance_exec(&openid_connect.end_session_endpoint),
 
           scopes_supported: doorkeeper.scopes,
 

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -86,7 +86,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
 
     it 'uses the configured end session endpoint with self as context' do
       Doorkeeper::OpenidConnect.configure do
-        end_session_endpoint ->(c) { c.logout_url }
+        end_session_endpoint -> { logout_url }
       end
 
       def controller.logout_url

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -84,9 +84,13 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       expect(data.key?('end_session_endpoint')).to be(false)
     end
 
-    it 'uses the configured end session endpoint' do
+    it 'uses the configured end session endpoint with self as context' do
       Doorkeeper::OpenidConnect.configure do
-        end_session_endpoint { 'http://test.host/logout' }
+        end_session_endpoint ->(c) { c.logout_url }
+      end
+
+      def controller.logout_url
+        'http://test.host/logout'
       end
 
       get :provider

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -195,5 +195,14 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
 
       expect(subject.end_session_endpoint.call).to eq('http://test.host/logout')
     end
+
+    it 'can be called with a context' do
+      described_class.configure do
+        end_session_endpoint ->(c) { c.url }
+      end
+
+      builder = double(url: 'http://test.host/logout')
+      expect(subject.end_session_endpoint.call(builder)).to eq('http://test.host/logout')
+    end
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -195,14 +195,5 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
 
       expect(subject.end_session_endpoint.call).to eq('http://test.host/logout')
     end
-
-    it 'can be called with a context' do
-      described_class.configure do
-        end_session_endpoint ->(c) { c.url }
-      end
-
-      builder = double(url: 'http://test.host/logout')
-      expect(subject.end_session_endpoint.call(builder)).to eq('http://test.host/logout')
-    end
   end
 end


### PR DESCRIPTION
Allows the application to use the configured host etc in url builders without having to set them again for the specific call.

Rationale is that it is cumbersome enough as it is to maintain this for mailers 