### PR TITLE
Remove reference to ApplicationRecord

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,8 @@ Rails/RakeEnvironment:
     - Rakefile
 Rails/SkipsModelValidations:
   Enabled: false
+Rails/ApplicationRecord:
+  Enabled: false
 
 RSpec/DescribeClass:
   Enabled: false

--- a/lib/doorkeeper/openid_connect/orm/active_record/request.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/request.rb
@@ -2,7 +2,7 @@
 
 module Doorkeeper
   module OpenidConnect
-    class Request < ApplicationRecord
+    class Request < ::ActiveRecord::Base
       self.table_name = "#{table_name_prefix}oauth_openid_requests#{table_name_suffix}".to_sym
 
       validates :access_grant_id, :nonce, presence: true


### PR DESCRIPTION
This reference to `ApplicationRecord` is causing an error when initializing in Rails 6:

    DEPRECATION WARNING: Initialization autoloaded the constant ApplicationRecord. (ActiveSupport::DeprecationException)

This is a change in the way Rails 6 does autoloading; it looks like this was done to appease rubocop's style rules, which shouldn't apply to this situation.