### PR TITLE
Clone doorkeeper.grant_flows array before appending 'refresh_token'

### DIFF
--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -71,7 +71,7 @@ module Doorkeeper
       end
 
       def grant_types_supported(doorkeeper)
-        grant_types_supported = doorkeeper.grant_flows
+        grant_types_supported = doorkeeper.grant_flows.dup
         grant_types_supported << 'refresh_token' if doorkeeper.refresh_token_enabled?
         grant_types_supported
       end


### PR DESCRIPTION
Without cloning the array, the original doorkeeper configuration's `grant_flows` would be mutated, so that multiple calls would lead to multiple 'refresh_token's filling up the array.
This would look as follows when visiting the discovery endpoint (3 times):

```
grant_types_supported: [
  "authorization_code",
  "refresh_token",
  "refresh_token",
  "refresh_token
],
```

With the change in this MR it should look like this, even after multiple calls:
```
grant_types_supported: [
  "authorization_code",
  "refresh_token"
],
```
