### PR TITLE
Add discovery_url_options option for discovery endpoints URL generation.

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+doorkeeper-openid_connect

--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ The following settings are optional:
   - Used by implementations like https://github.com/IdentityModel/oidc-client-js.
   - The block is executed in the controller's scope, so you have access to your route helpers.
 
+- `discovery_url_options`
+  - The URL options for every available endpoint to use when generating the endpoint URL in the
+    discovery response. Available endpoints: `authorization`, `token`, `revocation`,
+    `introspection`, `userinfo`, `jwks`, `webfinger`.
+  - This option requires option keys with an available endpoint and
+    [URL options](https://api.rubyonrails.org/v6.0.3.3/classes/ActionDispatch/Routing/UrlFor.html#method-i-url_for)
+    as value.
+  - The default is to use the request host, just like all the other URLs in the discovery response.
+  - This is useful when you want endpoints to use a different URL than other requests.
+    For example, if your Doorkeeper server is behind a firewall with other servers, you might want
+    other servers to use an "internal" URL to communicate with Doorkeeper, but you want to present
+    an "external" URL to end-users for authentication requests. Note that this setting does not
+    actually change the URL that your Doorkeeper server responds on - that is outside the scope of
+    Doorkeeper.
+
 ### Scopes
 
 To perform authentication over OpenID Connect, an OAuth client needs to request the `openid` scope. This scope needs to be enabled using either `optional_scopes` in the global Doorkeeper configuration in `config/initializers/doorkeeper.rb`, or by adding it to any OAuth application's `scope` attribute.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,20 @@ The following settings are optional:
     actually change the URL that your Doorkeeper server responds on - that is outside the scope of
     Doorkeeper.
 
+    ```ruby
+    # config/initializers/doorkeeper_openid_connect.rb
+    Doorkeeper::OpenidConnect.configure do
+    # ...
+      discovery_url_options do |request|
+        {
+          authorization: { host: 'host.example.com' },
+          jwks:          { protocol: request.ssl? ? :https : :http }
+        }
+      end
+    # ...
+    end
+    ```
+
 ### Scopes
 
 To perform authentication over OpenID Connect, an OAuth client needs to request the `openid` scope. This scope needs to be enabled using either `optional_scopes` in the global Doorkeeper configuration in `config/initializers/doorkeeper.rb`, or by adding it to any OAuth application's `scope` attribute.

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -26,12 +26,12 @@ module Doorkeeper
         openid_connect = ::Doorkeeper::OpenidConnect.configuration
         {
           issuer: openid_connect.issuer,
-          authorization_endpoint: oauth_authorization_url(protocol: protocol),
-          token_endpoint: oauth_token_url(protocol: protocol),
-          revocation_endpoint: oauth_revoke_url(protocol: protocol),
-          introspection_endpoint: oauth_introspect_url(protocol: protocol),
-          userinfo_endpoint: oauth_userinfo_url(protocol: protocol),
-          jwks_uri: oauth_discovery_keys_url(protocol: protocol),
+          authorization_endpoint: oauth_authorization_url(authorization_url_options),
+          token_endpoint: oauth_token_url(token_url_options),
+          revocation_endpoint: oauth_revoke_url(revocation_url_options),
+          introspection_endpoint: oauth_introspect_url(introspection_url_options),
+          userinfo_endpoint: oauth_userinfo_url(userinfo_url_options),
+          jwks_uri: oauth_discovery_keys_url(jwks_url_options),
           end_session_endpoint: instance_exec(&openid_connect.end_session_endpoint),
 
           scopes_supported: doorkeeper.scopes,
@@ -82,7 +82,7 @@ module Doorkeeper
           links: [
             {
               rel: WEBFINGER_RELATION,
-              href: root_url(protocol: protocol),
+              href: root_url(webfinger_url_options),
             }
           ]
         }
@@ -103,6 +103,22 @@ module Doorkeeper
 
       def protocol
         Doorkeeper::OpenidConnect.configuration.protocol.call
+      end
+
+      def discovery_url_options
+        Doorkeeper::OpenidConnect.configuration.discovery_url_options
+      end
+
+      def discovery_url_default_options
+        {
+          protocol: protocol
+        }
+      end
+
+      %i[authorization token revocation introspection userinfo jwks webfinger].each do |endpoint|
+        define_method :"#{endpoint}_url_options" do
+          discovery_url_default_options.merge(discovery_url_options[endpoint.to_sym] || {})
+        end
       end
     end
   end

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -106,7 +106,7 @@ module Doorkeeper
       end
 
       def discovery_url_options
-        Doorkeeper::OpenidConnect.configuration.discovery_url_options
+        Doorkeeper::OpenidConnect.configuration.discovery_url_options.call(request)
       end
 
       def discovery_url_default_options

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -135,7 +135,9 @@ module Doorkeeper
         nil
       }
 
-      option :discovery_url_options, default: {}
+      option :discovery_url_options, default: lambda { |*_|
+        {}
+      }
     end
   end
 end

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -134,6 +134,8 @@ module Doorkeeper
       option :end_session_endpoint, default: lambda { |*_|
         nil
       }
+
+      option :discovery_url_options, default: {}
     end
   end
 end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -76,6 +76,54 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       expect(data['authorization_endpoint']).to eq 'testing://test.host/oauth/authorize'
     end
 
+    context 'when the discovery_url_options option is set for all endpoints' do
+      before do
+        Doorkeeper::OpenidConnect.configure do
+          discovery_url_options authorization: { host: 'alternate-authorization.host' },
+                                token: { host: 'alternate-token.host' },
+                                revocation: { host: 'alternate-revocation.host' },
+                                introspection: { host: 'alternate-introspection.host' },
+                                userinfo: { host: 'alternate-userinfo.host' },
+                                jwks: { host: 'alternate-jwks.host' }
+        end
+      end
+
+      it 'uses the discovery_url_options option when generating the endpoint urls' do
+        get :provider
+        data = JSON.parse(response.body)
+
+        expect(data['authorization_endpoint']).to eq 'http://alternate-authorization.host/oauth/authorize'
+        expect(data['token_endpoint']).to eq 'http://alternate-token.host/oauth/token'
+        expect(data['revocation_endpoint']).to eq 'http://alternate-revocation.host/oauth/revoke'
+        expect(data['introspection_endpoint']).to eq 'http://alternate-introspection.host/oauth/introspect'
+        expect(data['userinfo_endpoint']).to eq 'http://alternate-userinfo.host/oauth/userinfo'
+        expect(data['jwks_uri']).to eq 'http://alternate-jwks.host/oauth/discovery/keys'
+      end
+    end
+
+    context 'when the discovery_url_options option is only set for some endpoints' do
+      before do
+        Doorkeeper::OpenidConnect.configure do
+          discovery_url_options authorization: { host: 'alternate-authorization.host' }
+        end
+      end
+
+      it 'does not use the discovery_url_options option when generating other URLs' do
+        get :provider
+        data = JSON.parse(response.body)
+
+        {
+          'token_endpoint' => 'http://test.host/oauth/token',
+          'revocation_endpoint' => 'http://test.host/oauth/revoke',
+          'introspection_endpoint' => 'http://test.host/oauth/introspect',
+          'userinfo_endpoint' => 'http://test.host/oauth/userinfo',
+          'jwks_uri' => 'http://test.host/oauth/discovery/keys',
+        }.each do |endpoint, expected_url|
+          expect(data[endpoint]).to eq expected_url
+        end
+      end
+    end
+
     it 'does not return an end session endpoint if none is configured' do
       get :provider
       data = JSON.parse(response.body)
@@ -117,6 +165,21 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
           'href' => 'http://test.host/',
         ],
       }.sort)
+    end
+
+    context 'when the discovery_url_options option is set for webfinger endpoint' do
+      before do
+        Doorkeeper::OpenidConnect.configure do
+          discovery_url_options webfinger: { host: 'alternate-webfinger.host' }
+        end
+      end
+
+      it 'uses the discovery_url_options option when generating the webfinger endpoint url' do
+        get :webfinger, params: { resource: 'user@example.com' }
+        data = JSON.parse(response.body)
+
+        expect(data['links'].first['href']).to eq 'http://alternate-webfinger.host/'
+      end
     end
   end
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -199,21 +199,25 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
 
   describe 'discovery_url_options' do
     it 'defaults to empty hash' do
-      expect(subject.discovery_url_options).to be_kind_of(Hash)
-      expect(subject.discovery_url_options).to be_empty
+      expect(subject.discovery_url_options.call).to be_kind_of(Hash)
+      expect(subject.discovery_url_options.call).to be_empty
     end
 
     it 'can be set to other hosts' do
       Doorkeeper::OpenidConnect.configure do
-        discovery_url_options authorization: { host: 'alternate-authorization-host' },
-                              token: { host: 'alternate-token-host' },
-                              revocation: { host: 'alternate-revocation-host' },
-                              introspection: { host: 'alternate-introspection-host' },
-                              userinfo: { host: 'alternate-userinfo-host' },
-                              jwks: { host: 'alternate-jwks-host' }
+        discovery_url_options do |request|
+          {
+            authorization: { host: 'alternate-authorization-host' },
+            token: { host: 'alternate-token-host' },
+            revocation: { host: 'alternate-revocation-host' },
+            introspection: { host: 'alternate-introspection-host' },
+            userinfo: { host: 'alternate-userinfo-host' },
+            jwks: { host: 'alternate-jwks-host' }
+          }
+        end
       end
 
-      expect(subject.discovery_url_options[:authorization]).to eq(host: 'alternate-authorization-host')
+      expect(subject.discovery_url_options.call[:authorization]).to eq(host: 'alternate-authorization-host')
     end
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -196,4 +196,24 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       expect(subject.end_session_endpoint.call).to eq('http://test.host/logout')
     end
   end
+
+  describe 'discovery_url_options' do
+    it 'defaults to empty hash' do
+      expect(subject.discovery_url_options).to be_kind_of(Hash)
+      expect(subject.discovery_url_options).to be_empty
+    end
+
+    it 'can be set to other hosts' do
+      Doorkeeper::OpenidConnect.configure do
+        discovery_url_options authorization: { host: 'alternate-authorization-host' },
+                              token: { host: 'alternate-token-host' },
+                              revocation: { host: 'alternate-revocation-host' },
+                              introspection: { host: 'alternate-introspection-host' },
+                              userinfo: { host: 'alternate-userinfo-host' },
+                              jwks: { host: 'alternate-jwks-host' }
+      end
+
+      expect(subject.discovery_url_options[:authorization]).to eq(host: 'alternate-authorization-host')
+    end
+  end
 end


### PR DESCRIPTION
Like described from @steti in PR #90, this is a re-work to be able to configure all discovery endpoint URL generations.

Example:

```ruby
Doorkeeper::OpenidConnect.configure do
  # ...

  discovery_url_options do |request| 
    {
      authorization: { host: 'alternate-authorization.host' },
      token: { host: 'alternate-token.host' },
      revocation: { host: 'alternate-revocation.host' },
      introspection: { host: 'alternate-introspection.host' },
      userinfo: { host: 'alternate-userinfo.host' },
      jwks: { host: 'alternate-jwks.host', protocol: request.ssl? ? :https : :http }
    }
  end

  # ...
end
```

or for only one endpoint:

```ruby
Doorkeeper::OpenidConnect.configure do
  # ...

  discovery_url_options do
    {  authorization: { host: 'alternate-authorization.host' } }
  end

  # ...
end
```