### PR TITLE
Avoid to use the config alias while supporting Doorkeeper 5.2

### DIFF
--- a/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
@@ -3,7 +3,7 @@
 module Doorkeeper
   module OpenidConnect
     class UserinfoController < ::Doorkeeper::ApplicationController
-      unless Doorkeeper.config.api_only
+      unless Doorkeeper.configuration.api_only
         skip_before_action :verify_authenticity_token
       end
       before_action -> { doorkeeper_authorize! :openid }


### PR DESCRIPTION
The following error has occurred when accessing `GET /oauth/userinfo` with Doorkeeper 5.2.6 + doorkeeper-openid_connect 1.7.4:

```
ActionController::RoutingError (undefined method `config' for Doorkeeper:Module
Did you mean?  configure):
F, [2020-11-09T19:36:45.191126 #16] FATAL -- : [866e7cd8-dd2a-4868-b1d9-1dff5caae0bf]   
F, [2020-11-09T19:36:45.191227 #16] FATAL -- : [866e7cd8-dd2a-4868-b1d9-1dff5caae0bf] doorkeeper-openid_connect (1.7.4) app/controllers/doorkeeper/openid_connect/userinfo_controller.rb:6:in `<class:UserinfoController>'
doorkeeper-openid_connect (1.7.4) app/controllers/doorkeeper/openid_connect/userinfo_controller.rb:5:in `<module:OpenidConnect>'
doorkeeper-openid_connect (1.7.4) app/controllers/doorkeeper/openid_connect/userinfo_controller.rb:4:in `<module:Doorkeeper>'
doorkeeper-openid_connect (1.7.4) app/controllers/doorkeeper/openid_connect/userinfo_controller.rb:3:in `<top (required)>'
...
```

</details>

[`Doorkeeper.configuration` has been aliased as `Doorkeeper.config` from
Doorkeeper v5.3.0](https://github.com/doorkeeper-gem/doorkeeper/commit/fad9cec2699b7896f029f9963dfb9a4a4d5c8136). This alias has been used in `UserInfoController` from
doorkeeper-openid_connect v1.7.3.

https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/2dd6865d011ffacbb07a993e1317395fcb711d4f/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb#L6

However the latest doorkeeper-openid_connect is still supporting
Doorkeeper v5.2.* and `Doorkeeper.config` does not work in those
versions. To fix this, we should use the original method name while the
support of Doorkeeper v5.2.* continues.

https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/2dd6865d011ffacbb07a993e1317395fcb711d4f/doorkeeper-openid_connect.gemspec#L27