### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 cache: bundler
 sudo: false
+arch:
+  - amd64
+  - ppc64le
 
 before_install:
   - gem install bundler
@@ -30,6 +33,16 @@ matrix:
       rvm: 2.4
     - gemfile: gemfiles/rails_master.gemfile
       rvm: 2.4
+    - gemfile: gemfiles/rails_6.0.gemfile
+      rvm: 2.4
+      arch: ppc64le
+    - gemfile: gemfiles/rails_master.gemfile
+      rvm: 2.4
+      arch: ppc64le
   allow_failures:
     - gemfile: gemfiles/rails_master.gemfile
     - gemfile: gemfiles/doorkeeper_master.gemfile
+    - gemfile: gemfiles/rails_master.gemfile
+      arch: ppc64le
+    - gemfile: gemfiles/doorkeeper_master.gemfile
+      arch: ppc64le


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/doorkeeper-openid_connect/builds/208548628