### PR TITLE
Fixes incorrect strategy registration for "id_token" and "id_token token" flows

### DIFF
--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -69,13 +69,13 @@ module Doorkeeper
       Doorkeeper::GrantFlow.register(
         :id_token,
         response_type_matches: 'id_token',
-        response_type_strategy: Doorkeeper::OpenidConnect::IdToken,
+        response_type_strategy: Doorkeeper::Request::IdToken,
       )
 
       Doorkeeper::GrantFlow.register(
         'id_token token',
         response_type_matches: 'id_token token',
-        response_type_strategy: Doorkeeper::OpenidConnect::IdTokenToken,
+        response_type_strategy: Doorkeeper::Request::IdTokenToken,
       )
 
       Doorkeeper::GrantFlow.register_alias(

--- a/spec/lib/doorkeeper_spec.rb
+++ b/spec/lib/doorkeeper_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'doorkeeper modifications' do
+  describe Doorkeeper::Request do
+    it 'uses the correct strategy for "id_token" response types' do
+      expect(described_class.authorization_strategy('id_token')).to eq(Doorkeeper::Request::IdToken)
+    end
+
+    it 'uses the correct strategy for "id_token token" response types' do
+      expect(described_class.authorization_strategy('id_token token')).to eq(Doorkeeper::Request::IdTokenToken)
+    end
+  end
+end


### PR DESCRIPTION
Issue:
the `response_type_strategy` was incorrectly set to `Doorkeeper::OpenidConnect::IdToken` instead of ` Doorkeeper::Request::IdToken`. This only worked by accident because Doorkeeper < 5.5 builds the strategy by constantizing the request type so `"token"` becomes `"Doorkeeper::Request::Token"` even though `Doorkeeper::OpenidConnect::IdToken` has been (incorrectly) registered.

However, besides from the registration only working incidentally, this will break with Doorkeeper versions from 5.5 upwards.

Compare the 5.4 implementation with 5.5:
5.4: https://github.com/doorkeeper-gem/doorkeeper/blob/v5.4.0/lib/doorkeeper/request.rb#L30
5.5: https://github.com/doorkeeper-gem/doorkeeper/blob/v5.5.0/lib/doorkeeper/request.rb#L7

As soon as https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/138 is merged the current implementation will cause issues.

An example for issues that will appear is that `resource_owner_from_access_token` will get passed the `server` (or `Doorkeeper.configuration`) object instead of an access token object for "id_token" and "id_token token" response types