### PR TITLE
Update issuer configuration to allow dynamic values

### DIFF
--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -40,7 +40,11 @@ module Doorkeeper
       private
 
       def issuer
-        Doorkeeper::OpenidConnect.configuration.issuer
+        if Doorkeeper::OpenidConnect.configuration.issuer.respond_to?(:call)
+          Doorkeeper::OpenidConnect.configuration.issuer.call(@resource_owner, @access_token.application).to_s
+        else
+          Doorkeeper::OpenidConnect.configuration.issuer
+        end
       end
 
       def subject

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 Doorkeeper::OpenidConnect.configure do
-  issuer 'issuer string'
+  issuer do |resource_owner, application|
+    'issuer string'
+  end
 
   signing_key <<~KEY
     -----BEGIN RSA PRIVATE KEY-----

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -49,6 +49,14 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       end
       expect(subject.issuer).to eq(value)
     end
+
+    it 'sets the block that is accessible via issuer' do
+      block = proc {}
+      described_class.configure do
+        issuer(&block)
+      end
+      expect(subject.issuer).to eq(block)
+    end
   end
 
   describe 'resource_owner_from_access_token' do


### PR DESCRIPTION
Proposing a small change here so that `issuer` accepts a string or a block. This is useful in cases where Doorkeeper API mode is enabled and requests are proxied from multiple hosts, so that the value may be set dynamically from the resource owner and/or application. Please let me know if you have any concerns. Thanks!