### PR TITLE
Register token flows with the strategy instead of the token class

### DIFF
--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -67,14 +67,14 @@ module Doorkeeper
       :id_token,
       response_type_matches: 'id_token',
       response_mode_matches: %w[fragment form_post],
-      response_type_strategy: Doorkeeper::OpenidConnect::IdToken,
+      response_type_strategy: Doorkeeper::Request::IdToken,
     )
 
     Doorkeeper::GrantFlow.register(
       'id_token token',
       response_type_matches: 'id_token token',
       response_mode_matches: %w[fragment form_post],
-      response_type_strategy: Doorkeeper::OpenidConnect::IdTokenToken,
+      response_type_strategy: Doorkeeper::Request::IdTokenToken,
     )
 
     Doorkeeper::GrantFlow.register_alias(

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -53,4 +53,16 @@ describe Doorkeeper::OpenidConnect do
       end
     end
   end
+
+  describe 'registering grant flows' do
+    describe Doorkeeper::Request do
+      it 'uses the correct strategy for "id_token" response types' do
+        expect(described_class.authorization_strategy('id_token')).to eq(Doorkeeper::Request::IdToken)
+      end
+
+      it 'uses the correct strategy for "id_token token" response types' do
+        expect(described_class.authorization_strategy('id_token token')).to eq(Doorkeeper::Request::IdTokenToken)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This replaces https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/143 to resolve some merge conflicts.

Thanks to @paukul for the contribution! :heart: 