### PR TITLE
Release version 1.8.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 ## Unreleased
 
-- [#138] Support form_post response mode (This gem now requires Doorkeeper v5.5)
-- [#146] Require at least Ruby 2.5
+## v1.8.0-rc1 (2021-04-20)
+
+### Upgrading
+
+This gem now requires Doorkeeper 5.5 and Ruby 2.5.
+
+### Changes
+
+- [#138] Support form_post response mode (thanks to @linhdangduy)
+- [#144] Support block syntax for `issuer` configuration (thanks to @maxxsnake)
+- [#145] Register token flows with the strategy instead of the token class (thanks to @paukul)
 
 ## v1.7.5 (2020-12-15)
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following settings are required in `config/initializers/doorkeeper_openid_co
 
 - `issuer`
   - Identifier for the issuer of the response (i.e. your application URL). The value is a case sensitive URL using the `https` scheme that contains scheme, host, and optionally, port number and path components and no query or fragment components.
+  - You can either pass a string value, or a block to generate the issuer dynamically based on the `resource_owner` and `application` passed to the block.
 - `subject`
   - Identifier for the resource owner (i.e. the authenticated user). A locally unique and never reassigned identifier within the issuer for the end-user, which is intended to be consumed by the client. The value is a case-sensitive string and must not exceed 255 ASCII characters in length.
   - The database ID of the user is an acceptable choice if you don't mind leaking that information.

--- a/lib/doorkeeper/openid_connect/version.rb
+++ b/lib/doorkeeper/openid_connect/version.rb
@@ -2,6 +2,6 @@
 
 module Doorkeeper
   module OpenidConnect
-    VERSION = '1.7.5'
+    VERSION = '1.8.0-rc1'
   end
 end


### PR DESCRIPTION
### Upgrading

This gem now requires Doorkeeper 5.5 and Ruby 2.5.

### Changes

- [#138] Support form_post response mode (thanks to @linhdangduy)
- [#144] Support block syntax for `issuer` configuration (thanks to @maxxsnake)
- [#145] Register token flows with the strategy instead of the token class (thanks to @paukul)