### PR TITLE
Exposing oauth-authorization-server, too

### DIFF
--- a/lib/doorkeeper/openid_connect/rails/routes.rb
+++ b/lib/doorkeeper/openid_connect/rails/routes.rb
@@ -62,6 +62,7 @@ module Doorkeeper
         def discovery_well_known_routes
           routes.scope path: '.well-known' do
             routes.get :provider, path: 'openid-configuration'
+            routes.get :provider, path: 'oauth-authorization-server'
             routes.get :webfinger
           end
         end


### PR DESCRIPTION
See [this GitLab issue](https://gitlab.com/gitlab-org/gitlab/-/issues/233956) for more background.

In short, both of those URIs and compatible to each other and contain a similar document with possibly slightly different fields, but both allow other fields to be present. So I propose we expose the same document on both locations.

Current document is already a mix of both specs, for example, `revocation_endpoint` is in fact defined for `oauth-authorization-server` and not `openid-configuration`, but it is exposed under `openid-configuration`. Which is fine.

So, in short, for maximum compatibility, let's expose this on both paths.