### PR TITLE
Update password_access_token_request.rb to match method parameters in doorkeeper 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- [#153] Fix ArgumentError caused by client credential validation introduced in Doorkeeper 5.5.1
+
 ## v1.8.0 (2021-05-11)
 
 No changes from v1.8.0-rc1.

--- a/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       module PasswordAccessTokenRequest
         attr_reader :nonce
 
-        def initialize(server, client, resource_owner, parameters = {})
+        def initialize(server, client, credentials, resource_owner, parameters = {})
           super
           @nonce = parameters[:nonce]
         end

--- a/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
@@ -6,9 +6,16 @@ module Doorkeeper
       module PasswordAccessTokenRequest
         attr_reader :nonce
 
-        def initialize(server, client, credentials, resource_owner, parameters = {})
-          super
-          @nonce = parameters[:nonce]
+        if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.1')
+          def initialize(server, client, credentials, resource_owner, parameters = {})
+            super
+            @nonce = parameters[:nonce]
+          end
+        else
+          def initialize(server, client, resource_owner, parameters = {})
+            super
+            @nonce = parameters[:nonce]
+          end
         end
 
         private

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -3,10 +3,15 @@
 require 'rails_helper'
 
 describe Doorkeeper::OpenidConnect::OAuth::PasswordAccessTokenRequest do
-  subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, resource_owner, { nonce: '123456' } }
+  if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.1')
+    subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, credentials, resource_owner, { nonce: '123456' } }
+  else
+    subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, resource_owner, { nonce: '123456' } }
+  end
 
   let(:server) { double }
   let(:client) { double }
+  let(:credentials) { }
   let(:resource_owner) { create :user }
   let(:token) { create :access_token }
   let(:response) { Doorkeeper::OAuth::TokenResponse.new token }


### PR DESCRIPTION
doorkeeper 5.5 added a new parameter `credentials` to `Doorkeeper::Oauth::PasswordAccessTokenRequest.initialize` resulting in ArgumentError thrown. See [this issue](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/151).

Once we match the parameters in the methods, we can set `skip_client_authentication_for_password_grant` to `true` and it works just fine.