### PR TITLE
fix .well-known/openid-connect issuer {} #160

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The following settings are required in `config/initializers/doorkeeper_openid_co
 
 - `issuer`
   - Identifier for the issuer of the response (i.e. your application URL). The value is a case sensitive URL using the `https` scheme that contains scheme, host, and optionally, port number and path components and no query or fragment components.
-  - You can either pass a string value, or a block to generate the issuer dynamically based on the `resource_owner` and `application` passed to the block.
+  - You can either pass a string value, or a block to generate the issuer dynamically based on the `resource_owner` and `application` or [request](app/controllers/doorkeeper/openid_connect/discovery_controller.rb#L123) passed to the block.
 - `subject`
   - Identifier for the resource owner (i.e. the authenticated user). A locally unique and never reassigned identifier within the issuer for the end-user, which is intended to be consumed by the client. The value is a case-sensitive string and must not exceed 255 ASCII characters in length.
   - The database ID of the user is an acceptable choice if you don't mind leaking that information.

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -24,8 +24,9 @@ module Doorkeeper
       def provider_response
         doorkeeper = ::Doorkeeper.configuration
         openid_connect = ::Doorkeeper::OpenidConnect.configuration
+
         {
-          issuer: openid_connect.issuer,
+          issuer: issuer,
           authorization_endpoint: oauth_authorization_url(authorization_url_options),
           token_endpoint: oauth_token_url(token_url_options),
           revocation_endpoint: oauth_revoke_url(revocation_url_options),
@@ -117,6 +118,14 @@ module Doorkeeper
         {
           protocol: protocol
         }
+      end
+
+      def issuer
+        if Doorkeeper::OpenidConnect.configuration.issuer.respond_to?(:call)
+          Doorkeeper::OpenidConnect.configuration.issuer.call(request).to_s
+        else
+          Doorkeeper::OpenidConnect.configuration.issuer
+        end
       end
 
       %i[authorization token revocation introspection userinfo jwks webfinger].each do |endpoint|

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -65,6 +65,17 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       end
     end
 
+    context 'when issuer block' do
+      before { Doorkeeper::OpenidConnect.configure { issuer do |r, a| "test-issuer" end } }
+
+      it 'return blocks result' do
+        get :provider
+        data = JSON.parse(response.body)
+
+        expect(data['issuer']).to eq "test-issuer"
+      end
+    end
+
     context 'when grant_flows is configed with only client_credentials' do
       before { Doorkeeper.configure { grant_flows %w[client_credentials] } }
 


### PR DESCRIPTION
`issuer` block introduced in #144 breaks the `.well-known/openid-connect` response

when configuring issuer using a block
```
Doorkeeper::OpenidConnect.configure do
  issuer do |resource_owner, application|
  ...
  end
end
```

the `DiscoveryController.provider` return a `issuer: {}`

this gives the user back the control