### PR TITLE
fix end_session_endpoint information in discovery

### DIFF
--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -132,7 +132,7 @@ module Doorkeeper
       }
 
       option :end_session_endpoint, default: lambda { |*_|
-        nil
+        logout_url
       }
 
       option :discovery_url_options, default: lambda { |*_|


### PR DESCRIPTION
fix missing information in http://localhost:3000//.well-known/openid-configuration.

This information is important to frameworks like SPRING SECURITY because it uses for autoconfiguration avoiding manual setup of the endpoint of logout.