### PR TITLE
`introspection_endpoint` cannot be defined when token introspection is turned off

### DIFF
--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -30,7 +30,7 @@ module Doorkeeper
           authorization_endpoint: oauth_authorization_url(authorization_url_options),
           token_endpoint: oauth_token_url(token_url_options),
           revocation_endpoint: oauth_revoke_url(revocation_url_options),
-          introspection_endpoint: oauth_introspect_url(introspection_url_options),
+          introspection_endpoint: respond_to?(:oauth_introspect_url) ? oauth_introspect_url(introspection_url_options) : nil,
           userinfo_endpoint: oauth_userinfo_url(userinfo_url_options),
           jwks_uri: oauth_discovery_keys_url(jwks_url_options),
           end_session_endpoint: instance_exec(&openid_connect.end_session_endpoint),

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -195,6 +195,28 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
 
       expect(data['end_session_endpoint']).to eq 'http://test.host/logout'
     end
+
+    context 'when token inspection is disallowed' do
+      let(:doorkeeper_config) { Doorkeeper.config }
+      let!(:allow_token_introspection) { doorkeeper_config.allow_token_introspection }
+
+      before do
+        allow(doorkeeper_config).to receive(:allow_token_introspection).and_return(false)
+        Rails.application.reload_routes!
+      end
+
+      after do
+        allow(doorkeeper_config).to receive(:allow_token_introspection).and_return(allow_token_introspection)
+        Rails.application.reload_routes!
+      end
+
+      it 'does not return introspection_endpoint' do
+        get :provider
+        data = JSON.parse(response.body)
+
+        expect(data.key?('introspection_endpoint')).to be(false)
+      end
+    end
   end
 
   describe '#webfinger' do


### PR DESCRIPTION
This fixes #166.

Since `oauth_introspect_url` is not available, let's workaround by checking if it can be responded to before actually calling it. Another possible solution is to replicate the same condition as doorkeeper repo, namely `Doorkeeper.config.allow_token_introspection.is_a?(FalseClass)`, which I've not chosen because I thought it'd make it more complex to depend on the configuration of a different gem.

Getting rid of `introspection_endpoint` field can be justified because it is a non-standard (as described in #72, the original PR which introduced it) and not required nor defined by [the specification of OIDC Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html).

About the test case added, the entire routes must be reloaded because the configuration here is loaded once and routes drawn once, refusing to be overriden just like this:

```ruby
before { Doorkeeper.configure { allow_token_introspection false } }
```

So I've chosen to mock it and reload routes before and after the example case, knowing this is perhaps a little clumsy type. What do you think?