### PR TITLE
allow to use custom doorkeeper access grant model

### DIFF
--- a/lib/doorkeeper/openid_connect/orm/active_record.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record.rb
@@ -6,12 +6,18 @@ module Doorkeeper
   module OpenidConnect
     autoload :AccessGrant, "doorkeeper/openid_connect/orm/active_record/access_grant"
     autoload :Request, "doorkeeper/openid_connect/orm/active_record/request"
-    
+
     module Orm
       module ActiveRecord
         def run_hooks
           super
-          Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
+
+          if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.0')
+            Doorkeeper.config.access_grant_model.prepend Doorkeeper::OpenidConnect::AccessGrant
+          else
+            Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
+          end
+
           if Doorkeeper.configuration.active_record_options[:establish_connection]
             [Doorkeeper::OpenidConnect::Request].each do |c|
               c.send :establish_connection, Doorkeeper.configuration.active_record_options[:establish_connection]
@@ -25,7 +31,11 @@ module Doorkeeper
             require 'doorkeeper/openid_connect/orm/active_record/access_grant'
             require 'doorkeeper/openid_connect/orm/active_record/request'
 
-            Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
+            if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.0')
+              Doorkeeper.config.access_grant_model.prepend Doorkeeper::OpenidConnect::AccessGrant
+            else
+              Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
+            end
 
             if Doorkeeper.configuration.active_record_options[:establish_connection]
               [Doorkeeper::OpenidConnect::Request].each do |c|

--- a/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb
@@ -7,6 +7,7 @@ module Doorkeeper
         base.class_eval do
           has_one :openid_request,
             class_name: 'Doorkeeper::OpenidConnect::Request',
+            foreign_key: 'access_grant_id',
             inverse_of: :access_grant,
             dependent: :delete
         end

--- a/lib/doorkeeper/openid_connect/orm/active_record/request.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/request.rb
@@ -6,9 +6,16 @@ module Doorkeeper
       self.table_name = "#{table_name_prefix}oauth_openid_requests#{table_name_suffix}".to_sym
 
       validates :access_grant_id, :nonce, presence: true
-      belongs_to :access_grant,
-                 class_name: 'Doorkeeper::AccessGrant',
-                 inverse_of: :openid_request
+
+      if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.0')
+        belongs_to :access_grant,
+                   class_name: Doorkeeper.config.access_grant_class.to_s,
+                   inverse_of: :openid_request
+      else
+        belongs_to :access_grant,
+                   class_name: 'Doorkeeper::AccessGrant',
+                   inverse_of: :openid_request
+      end
     end
   end
 end


### PR DESCRIPTION
Since this gem is hard-coding `Doorkeeper::AccessGrant` in some places, it prevents using custom doorkeeper model.
So this pull request replaces it with `Doorkeeper.config.access_grant_model` with doorkeeper gem version check.