### PR TITLE
Controllers inherit `Doorkeeper::AppliactionMetalController`

### DIFF
--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -2,7 +2,7 @@
 
 module Doorkeeper
   module OpenidConnect
-    class DiscoveryController < ::Doorkeeper::ApplicationController
+    class DiscoveryController < ::Doorkeeper::ApplicationMetalController
       include Doorkeeper::Helpers::Controller
 
       WEBFINGER_RELATION = 'http://openid.net/specs/connect/1.0/issuer'

--- a/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
@@ -2,10 +2,7 @@
 
 module Doorkeeper
   module OpenidConnect
-    class UserinfoController < ::Doorkeeper::ApplicationController
-      unless Doorkeeper.configuration.api_only
-        skip_before_action :verify_authenticity_token
-      end
+    class UserinfoController < ::Doorkeeper::ApplicationMetalController
       before_action -> { doorkeeper_authorize! :openid }
 
       def show


### PR DESCRIPTION
This closes #169. Background is reasoned in the issue.

Initially I only wanted to raise discussion, but since I have already had a patch that can work for me I'm proceeding with opening a PR. What do you think? I appreciate any feedbacks 🙂 