### PR TITLE
Webfinger now returns issuer location

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The following settings are optional:
 - `discovery_url_options`
   - The URL options for every available endpoint to use when generating the endpoint URL in the
     discovery response. Available endpoints: `authorization`, `token`, `revocation`,
-    `introspection`, `userinfo`, `jwks`, `webfinger`.
+    `introspection`, `userinfo`, `jwks`.
   - This option requires option keys with an available endpoint and
     [URL options](https://api.rubyonrails.org/v6.0.3.3/classes/ActionDispatch/Routing/UrlFor.html#method-i-url_for)
     as value.

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -87,7 +87,7 @@ module Doorkeeper
           links: [
             {
               rel: WEBFINGER_RELATION,
-              href: root_url(webfinger_url_options),
+              href: issuer,
             }
           ]
         }
@@ -128,7 +128,7 @@ module Doorkeeper
         end
       end
 
-      %i[authorization token revocation introspection userinfo jwks webfinger].each do |endpoint|
+      %i[authorization token revocation introspection userinfo jwks].each do |endpoint|
         define_method :"#{endpoint}_url_options" do
           discovery_url_default_options.merge(discovery_url_options[endpoint.to_sym] || {})
         end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -212,26 +212,9 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
         'subject' => 'user@example.com',
         'links' => [
           'rel' => 'http://openid.net/specs/connect/1.0/issuer',
-          'href' => 'http://test.host/',
+          'href' => 'dummy',
         ],
       }.sort)
-    end
-
-    context 'when the discovery_url_options option is set for webfinger endpoint' do
-      before do
-        Doorkeeper::OpenidConnect.configure do
-          discovery_url_options do |request|
-            { webfinger: { host: 'alternate-webfinger.host' } }
-          end
-        end
-      end
-
-      it 'uses the discovery_url_options option when generating the webfinger endpoint url' do
-        get :webfinger, params: { resource: 'user@example.com' }
-        data = JSON.parse(response.body)
-
-        expect(data['links'].first['href']).to eq 'http://alternate-webfinger.host/'
-      end
     end
 
     context 'when the discovery_url_options option uses the request for an endpoint' do


### PR DESCRIPTION
Also removes the definition of `webfinger_url_options`, as it now becomes irrelevant.

This closes #171. Detailed background is provided in the issue.

Removing configurability of `webfinger_url_options` can be non-trivial. However if we are going to let it stick around, some might feel that another option like `provider_url_options` is missing. I wouldn't prefer adding it, because these `/.well-known` stuff are supposed to be self-sufficient, unlike endpoints that `#provider` might return. How does that sound?