### PR TITLE
Update json-jwt version for OpenSSL 3

### DIFF
--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_runtime_dependency 'doorkeeper', '>= 5.5', '< 5.7'
-  spec.add_runtime_dependency 'json-jwt', '>= 1.11.0'
+  spec.add_runtime_dependency 'json-jwt', '>= 1.15.0'
 
   spec.add_development_dependency 'conventional-changelog', '~> 1.2'
   spec.add_development_dependency 'factory_bot'


### PR DESCRIPTION
The `json-jwt` version used by the current gem is [incompatible with OpenSSL 3.0](https://github.com/nov/json-jwt/pull/102). This is especially a problem with operating systems that are only shipped with OpenSSL 3.0 like Ubuntu 22.04 LTS.