### PR TITLE
Bump the range of supported Ruby and Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,23 +21,16 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         ruby:
-          - 2.6
           - 2.7
           - '3.0'
           - '3.1'
+          - '3.2'
           - head
         gemfile:
-          - gemfiles/rails_5.0.gemfile
-          - gemfiles/rails_5.2.gemfile
           - gemfiles/rails_6.0.gemfile
           - gemfiles/rails_6.1.gemfile
           - gemfiles/rails_7.0.gemfile
           - gemfiles/doorkeeper_master.gemfile
-        exclude:
-          - ruby: 3.0
-            gemfile: gemfiles/rails_5_2.gemfile
-          - ruby: 2.6
-            gemfile: gemfiles/rails_7_0.gemfile
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [#PR ID] Add your changelog entry here.
 - [#186] Simplify gem configuration reusing Doorkeeper configuration option DSL (thanks to @nbulaj).
+- [#182] Drop support for Ruby 2.6 and Rails 5.
 
 ## v1.8.4 (2023-02-01)
 

--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_runtime_dependency 'doorkeeper', '>= 5.5', '< 5.7'
   spec.add_runtime_dependency 'jwt', '>= 2.5'

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 5.0.0'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.3', '< 1.4', platform: %i[ruby mswin mingw x64_mingw]
-
-gemspec path: '../'

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 5.2.0'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.3', '< 1.4', platform: %i[ruby mswin mingw x64_mingw]
-
-gemspec path: '../'


### PR DESCRIPTION
Ruby 3.2 is out and 2.6 has reached the EOL:
https://www.ruby-lang.org/en/downloads/branches/

Also since Rails 5 has been dropped support for and
corresponding gemfiles are now dispensable to ci.

This is a follow-up to what I have committed to doorkeeper gem in https://github.com/doorkeeper-gem/doorkeeper/pull/1618.  I guess it would be great if the CI setup mirrors what doorkeeper has just like #175 has achieved it.

As 2.6 is dropped from CI I'm including the change that bumps the required ruby version. What do you think?