### PR TITLE
stop render consent screen when user is not logged-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [#PR ID] Add your changelog entry here.
+- [#183] stop render consent screen when user is not logged-in
 
 ## v1.8.3 (2022-12-02)
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -76,7 +76,7 @@ module Doorkeeper
             when 'login'
               reauthenticate_oidc_resource_owner(owner) if owner
             when 'consent'
-              render :new
+              render :new if owner
             when 'select_account'
               select_account_for_oidc_resource_owner(owner)
             else

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -262,6 +262,12 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
     end
 
     context 'with a prompt=consent parameter' do
+      it 'redirects to the sign in form if not logged in' do
+        authorize! prompt: 'consent', current_user: nil
+
+        expect(response).to redirect_to('/login')
+      end
+
       it 'renders the authorization form even if a matching token is present' do
         create :access_token, token_attributes
         authorize! prompt: 'consent'


### PR DESCRIPTION
current `doorkeeper-openid_connect` implementation always renders consent screen when `prompt=consent` is requested.
however, user can be **_non-authenticated_** status when requesting.
in that case, application tend to redirect to login page, and it conflicts with rendering consent screen, and results in `AbstractController::DoubleRenderError` error.

this pull request stop rendering consent screen when user is not authenticated, and will render consent screen after the user is authenticated.