### PR TITLE
Don't call active_record_options for Doorkeeper >= 5.6.3

### DIFF
--- a/lib/doorkeeper/openid_connect/orm/active_record.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record.rb
@@ -18,7 +18,7 @@ module Doorkeeper
             Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
           end
 
-          if Doorkeeper.configuration.active_record_options[:establish_connection]
+          if Doorkeeper.configuration.respond_to?(:active_record_options) && Doorkeeper.configuration.active_record_options[:establish_connection]
             [Doorkeeper::OpenidConnect::Request].each do |c|
               c.send :establish_connection, Doorkeeper.configuration.active_record_options[:establish_connection]
             end


### PR DESCRIPTION
Fixes #184