### PR TITLE
Fix dookeeper-jwt compatibility

### DIFF
--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -48,7 +48,7 @@ module Doorkeeper
         else
           OpenSSL::PKey.read(configuration.signing_key)
         end
-      JWT::JWK.new(key)
+      ::JWT::JWK.new(key)
     end
 
     def self.signing_key_normalized

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -31,7 +31,7 @@ module Doorkeeper
       end
 
       def as_jws_token
-        JWT.encode(as_json,
+        ::JWT.encode(as_json,
           Doorkeeper::OpenidConnect.signing_key.keypair,
           Doorkeeper::OpenidConnect.signing_algorithm.to_s,
           { kid: Doorkeeper::OpenidConnect.signing_key.kid }

--- a/spec/dummy/config/initializers/jwt.rb
+++ b/spec/dummy/config/initializers/jwt.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-JWT.configuration.jwk.kid_generator_type = :rfc7638_thumbprint
+::JWT.configuration.jwk.kid_generator_type = :rfc7638_thumbprint

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -74,7 +74,7 @@ describe Doorkeeper::OpenidConnect::IdToken do
       it 'returns claims encoded as JWT' do
         algorithms = [Doorkeeper::OpenidConnect.signing_algorithm.to_s]
 
-        data, headers = JWT.decode subject.as_jws_token, Doorkeeper::OpenidConnect.signing_key.keypair, true, { algorithms: algorithms }
+        data, headers = ::JWT.decode subject.as_jws_token, Doorkeeper::OpenidConnect.signing_key.keypair, true, { algorithms: algorithms }
 
         expect(data.to_hash).to eq subject.as_json.stringify_keys
         expect(headers["kid"]).to eq Doorkeeper::OpenidConnect.signing_key.kid

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -11,7 +11,7 @@ describe Doorkeeper::OpenidConnect do
 
   describe '.signing_key' do
     it 'returns the private key as JWK instance' do
-      expect(subject.signing_key).to be_a JWT::JWK::KeyBase
+      expect(subject.signing_key).to be_a ::JWT::JWK::KeyBase
       expect(subject.signing_key.kid).to eq 'IqYwZo2cE6hsyhs48cU8QHH4GanKIx0S4Dc99kgTIMA'
     end
   end


### PR DESCRIPTION
Using this gem along with the `doorkeeper-jwt` gem caused problems because that gem defines a `Doorkeeper::JWT` constant, so the autoloader thinks it should load `JWT::JWK` and other constants under the `JWT` namespace from there since this gem is also under the `Doorkeeper` namespace. The solution is to prefix the `JWT` uses with `::`.

Fixes #187.