### PR TITLE
Default to RFC 7638 kid fingerprint generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [#PR ID] Add your changelog entry here.
+- [#194] Default to RFC 7638 kid fingerprint generation (thanks to @stanhu).
 
 ## v1.8.5 (2023-02-02)
 
@@ -9,6 +10,9 @@
 - [#188] Fix dookeeper-jwt compatibility (thanks to @zavan).
 
 ## v1.8.4 (2023-02-01)
+
+Note that v1.8.4 changed the default kid fingerprint generation from RFC 7638 to a format
+based on the SHA256 digest of the key element. To restore the previous behavior, upgrade to v1.8.6.
 
 - [#177] Replace `json-jwt` with `ruby-jwt` to align with doorkeeper-jwt (thanks to @kristof-mattei).
 - [#185] Don't call active_record_options for Doorkeeper >= 5.6.3 (thanks to @zavan).

--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -48,7 +48,7 @@ module Doorkeeper
         else
           OpenSSL::PKey.read(configuration.signing_key)
         end
-      ::JWT::JWK.new(key)
+      ::JWT::JWK.new(key, { kid_generator: JWT::JWK::Thumbprint })
     end
 
     def self.signing_key_normalized

--- a/spec/dummy/config/initializers/jwt.rb
+++ b/spec/dummy/config/initializers/jwt.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-::JWT.configuration.jwk.kid_generator_type = :rfc7638_thumbprint

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,7 +53,6 @@ RSpec.configure do |config|
 
   # Reinitialize configuration after each example
   config.after do
-    load Rails.root.join('config/initializers/jwt.rb')
     load Rails.root.join('config/initializers/doorkeeper.rb')
     load Rails.root.join('config/initializers/doorkeeper_openid_connect.rb')
   end


### PR DESCRIPTION
The switch from the `json-jwt` to `jwt` gem in #177 changed the default `kid` generation from RFC 7638
(https://www.rfc-editor.org/rfc/rfc7638) to a format based on the SHA256 digest of the key elements.

However, clients may fail if the the `kid` generated by `IdToken` does not match a key listed in JWKS discovery endpoint, which may be implemented by the application using RFC 7638-based `kid` values. To restore the previous behavior, applications have to set a global setting:

```
JWT.configuration.jwk.kid_generator_type = :rfc7638_thumbprint
```

However, relying on this global setting is not ideal since other keys may depend on the legacy `kid` values.

In keeping with semantic versioning, restore the `kid` generation to RFC 7638. Whether this should be customizable can be discussed later.

Closes #193