### PR TITLE
Add back typ=JWT to header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /pkg
 gemfiles/*.lock
 *.gem
+
+.idea/

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -34,7 +34,7 @@ module Doorkeeper
         ::JWT.encode(as_json,
           Doorkeeper::OpenidConnect.signing_key.keypair,
           Doorkeeper::OpenidConnect.signing_algorithm.to_s,
-          { kid: Doorkeeper::OpenidConnect.signing_key.kid }
+          { typ: 'JWT', kid: Doorkeeper::OpenidConnect.signing_key.kid }
         ).to_s
       end
 


### PR DESCRIPTION
Along with #193, upgrade from 1.8.3 -> 1.8.5 caused and incident for us because of the underlying library changing and not having `typ: 'JWT'` in the header any more

While that's an optional part of the JWT spec, some client libraries are expecting that so I propose we add it back