### PR TITLE
Update for doorkeeper 5.6.8

### DIFF
--- a/lib/doorkeeper/oauth/id_token_request.rb
+++ b/lib/doorkeeper/oauth/id_token_request.rb
@@ -21,7 +21,7 @@ module Doorkeeper
       end
 
       def deny
-        pre_auth.error = :access_denied
+        pre_auth.error = Errors::AccessDenied
         pre_auth.error_response
       end
 


### PR DESCRIPTION
Doorkeeper patch version 5.6.8 replaced using symbols for errors with objects.

Closes #203 
