### PR TITLE
Configuration per IdToken expiration

### DIFF
--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -7,11 +7,12 @@ module Doorkeeper
 
       attr_reader :nonce
 
-      def initialize(access_token, nonce = nil)
+      def initialize(access_token, nonce = nil, expires_in = Doorkeeper::OpenidConnect.configuration.expiration)
         @access_token = access_token
         @nonce = nonce
         @resource_owner = Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(access_token)
         @issued_at = Time.zone.now
+        @expires_in = expires_in
       end
 
       def claims
@@ -57,7 +58,7 @@ module Doorkeeper
       end
 
       def expiration
-        (@issued_at.utc + Doorkeeper::OpenidConnect.configuration.expiration).to_i
+        (@issued_at.utc + @expires_in).to_i
       end
 
       def issued_at

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -34,6 +34,16 @@ describe Doorkeeper::OpenidConnect::IdToken do
       )
     end
 
+    context 'when expires_in is specified for the token' do
+      subject { described_class.new(access_token, nonce, expires_in) }
+
+      let(:expires_in) { 10 }
+
+      it 'returns expiration claim with the specified value' do
+        expect(subject.claims[:exp]).to eq(subject.claims[:iat] + expires_in)
+      end
+    end
+
     context 'when application is not set on the access token' do
       before do
         access_token.application = nil


### PR DESCRIPTION
In some use cases we need to specify a different expiration time for specific tokens, e.g. in our company we create tokens for admins who can access the applications as if they were the customer by using what we call "impersonated sessions". In this scenario we want shorter IdTokens.

I imagine there could be multiple scenarios where we don't want to use the global expiration time configured. I hope this will help. 
