### PR TITLE
Fix DiscoveryController#provider_response for Ruby 3.0

### DIFF
--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -27,12 +27,12 @@ module Doorkeeper
 
         {
           issuer: issuer,
-          authorization_endpoint: oauth_authorization_url(authorization_url_options),
-          token_endpoint: oauth_token_url(token_url_options),
-          revocation_endpoint: oauth_revoke_url(revocation_url_options),
+          authorization_endpoint: oauth_authorization_url(**authorization_url_options),
+          token_endpoint: oauth_token_url(**token_url_options),
+          revocation_endpoint: oauth_revoke_url(**revocation_url_options),
           introspection_endpoint: respond_to?(:oauth_introspect_url) ? oauth_introspect_url(introspection_url_options) : nil,
-          userinfo_endpoint: oauth_userinfo_url(userinfo_url_options),
-          jwks_uri: oauth_discovery_keys_url(jwks_url_options),
+          userinfo_endpoint: oauth_userinfo_url(**userinfo_url_options),
+          jwks_uri: oauth_discovery_keys_url(**jwks_url_options),
           end_session_endpoint: instance_exec(&openid_connect.end_session_endpoint),
 
           scopes_supported: doorkeeper.scopes,


### PR DESCRIPTION
This PR aims to fix the warning message on DiscoveryController:

```
Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

These methods expect keword arguments instead of hashes, so we need to use the `**` operator.