### PR TITLE
ci: make all tests pass again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       Ruby ${{ matrix.ruby }} (${{ matrix.gemfile }})
     env:
       CI: true
+      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
 
     runs-on: ${{ matrix.os }}
     if: |

--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7'
 
-  spec.add_runtime_dependency 'doorkeeper', '>= 5.5', '< 5.8'
+  spec.add_runtime_dependency 'doorkeeper', '>= 5.5', '< 5.9'
   spec.add_runtime_dependency 'jwt', '>= 2.5'
 
   spec.add_development_dependency 'conventional-changelog', '~> 1.2'

--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -27,8 +27,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'doorkeeper', '>= 5.5', '< 5.9'
   spec.add_runtime_dependency 'jwt', '>= 2.5'
 
+  spec.add_development_dependency 'bigdecimal'
   spec.add_development_dependency 'conventional-changelog', '~> 1.2'
+  spec.add_development_dependency 'drb'
   spec.add_development_dependency 'factory_bot'
+  spec.add_development_dependency 'mutex_m'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'sqlite3', '>= 1.3.6'

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -82,14 +82,14 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
         it 'render error when client_id is missing' do
           authorize!(client_id: nil)
 
-          expect(response).to be_successful
+          expect(response).to have_http_status(:bad_request)
           expect(response).to render_template('doorkeeper/authorizations/error')
         end
 
         it 'render error when response_type is missing' do
           authorize!(response_type: nil)
 
-          expect(response).to be_successful
+          expect(response).to have_http_status(:bad_request)
           expect(response).to render_template('doorkeeper/authorizations/error')
         end
       end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -19,7 +19,10 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  # Rails 7.1 deprecated false in favor of :none, but we need to use false for
+  # backwards compatibility: https://github.com/rails/rails/pull/45867
+  config.action_dispatch.show_exceptions =
+    Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0') ? :none : false
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   # Rails 7.1 deprecated false in favor of :none, but we need to use false for
   # backwards compatibility: https://github.com/rails/rails/pull/45867
   config.action_dispatch.show_exceptions =
-    Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0') ? :none : false
+    Rails.gem_version >= Gem::Version.new('7.1.0') ? :none : false
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
The tests were failing because the current gemspec allows sqlite3 >= 1.3.6, but the external Gemfiles used older versions.

To avoid this, BUNDLE_GEMFILE needs to be set as documented in https://github.com/ruby/setup-ruby:

To use a Gemfile which is not at the root or has a different name, set BUNDLE_GEMFILE in the env at the job level as shown in the example.