### PR TITLE
Bump the range of supported Ruby and Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,11 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         ruby:
-          - 2.7
-          - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
           - head
         gemfile:
-          - gemfiles/rails_6.0.gemfile
-          - gemfiles/rails_6.1.gemfile
           - gemfiles/rails_7.0.gemfile
           - gemfiles/doorkeeper_master.gemfile
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   Exclude:
     - "spec/dummy/bin/*"
     - "spec/dummy/db/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [#PR ID] Add your changelog entry here.
+- [#215] Drop support for Ruby 2.7, 3.0 and Rails 6.
 
 ## v1.8.9 (2024-05-07)
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 # use Rails version specified by environment
-ENV['rails'] ||= '6.0.0'
+ENV['rails'] ||= '7.0.0'
 gem 'rails', "~> #{ENV['rails']}"
 gem 'rails-controller-testing'
 

--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_runtime_dependency 'doorkeeper', '>= 5.5', '< 5.9'
   spec.add_runtime_dependency 'jwt', '>= 2.5'

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 6.0.0'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw x64_mingw]
-
-gemspec path: '../'

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 6.1.0'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw x64_mingw]
-
-gemspec path: '../'


### PR DESCRIPTION
Ruby 3.3 is out and 2.7, 3.0 has reached the EOL:
https://www.ruby-lang.org/en/downloads/branches/

Also since Rails 6 has been dropped support for and corresponding gemfiles are now dispensable to ci.
https://rubyonrails.org/maintenance