### PR TITLE
Test against Rails 7.1, 7.2, 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,15 @@ jobs:
           - head
         gemfile:
           - gemfiles/rails_7.0.gemfile
+          - gemfiles/rails_7.1.gemfile
+          - gemfiles/rails_7.2.gemfile
+          - gemfiles/rails_8.0.gemfile
           - gemfiles/doorkeeper_master.gemfile
+        exclude:
+          - ruby: 3.1
+            gemfile: gemfiles/rails_8.0.gemfile
+          - ruby: 3.1
+            gemfile: gemfiles/doorkeeper_master.gemfile
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Unreleased
 
 - [#PR ID] Add your changelog entry here.
+- [#216] Test against Rails 7.1, 7.2, 8.0.
 
-## v1.8.10 (2024-12-29)
+## v1.8.10 (2024-11-29)
 
 - [#215] Drop support for Ruby 2.7, 3.0 and Rails 6.
 - [#209] Configuration per IdToken expiration (thanks to @martinezcoder)

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'rails', '~> 7.1.0'
+gem 'rails-controller-testing'
+gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw x64_mingw]
+
+gemspec path: '../'

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'rails', '~> 7.2.0'
+gem 'rails-controller-testing'
+gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw x64_mingw]
+
+gemspec path: '../'

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -5,6 +5,5 @@ source 'https://rubygems.org'
 gem 'rails', '~> 8.0.0'
 gem 'rails-controller-testing'
 gem 'sqlite3', '~> 2.3', platform: %i[ruby mswin mingw x64_mingw]
-gem 'doorkeeper', git: 'https://github.com/doorkeeper-gem/doorkeeper.git'
 
 gemspec path: '../'


### PR DESCRIPTION
Rails 7.1, 7.2, 8.0 are out
corresponding gemfiles are now dispensable to ci.
https://rubyonrails.org/maintenance

This is a follow-up to what I have committed to doorkeeper gem in https://github.com/doorkeeper-gem/doorkeeper/pull/1752.
I guess it would be great if the CI setup mirrors what doorkeeper has just like https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/182 has achieved it.