### PR TITLE
Add ostruct gem to gemspec to fix ruby 3.4 warning (fixes #210)

### DIFF
--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.1'
 
   spec.add_runtime_dependency 'doorkeeper', '>= 5.5', '< 5.9'
+  spec.add_runtime_dependency 'ostruct', '>= 0.5'
   spec.add_runtime_dependency 'jwt', '>= 2.5'
 
   spec.add_development_dependency 'bigdecimal'


### PR DESCRIPTION
As per issue #210 we're seeing the following warning when testing our project on ruby 3.4.0-rc1:

    doorkeeper-openid_connect-1.8.10/lib/doorkeeper/openid_connect/claims_builder.rb:3: warning: ~/.rbenv/versions/3.4.0-rc1/lib/ruby/3.4.0+1/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
    You can add ostruct to your Gemfile or gemspec to silence this warning.

This PR adds `ostruct` as a dependency in the gemspec to remove this warning.