### PR TITLE
Bump the range of supported Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
           - head
         gemfile:
           - gemfiles/rails_7.0.gemfile
@@ -37,6 +38,8 @@ jobs:
             gemfile: gemfiles/rails_8.0.gemfile
           - ruby: 3.1
             gemfile: gemfiles/doorkeeper_master.gemfile
+          - ruby: head
+            gemfile: gemfiles/rails_7.0.gemfile
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [#PR ID] Add your changelog entry here.
+- [#219] Test against Ruby 3.4.
 - [#216] Test against Rails 7.1, 7.2, 8.0.
 
 ## v1.8.10 (2024-11-29)

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -5,5 +5,6 @@ source 'https://rubygems.org'
 gem 'rails', '~> 7.0.0'
 gem 'rails-controller-testing'
 gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw x64_mingw]
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: '../'


### PR DESCRIPTION
## Ruby 3.4 is out
### 1. concurrent-ruby 1.3.5 don't work on Rails 7.0

> NameError:
>  uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger

See: https://github.com/ruby-concurrency/concurrent-ruby/pull/1062

### 2. concurrent-ruby 1.3.4 don't work on Ruby head

> LoadError:
> cannot load such file -- logger

Exclude the combination of Ruby head and Rails 7.0

This is a follow-up to what I have committed to doorkeeper gem in https://github.com/doorkeeper-gem/doorkeeper/pull/1760.
I guess it would be great if the CI setup mirrors what doorkeeper has just like https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/215 has achieved it.