### PR TITLE
make prompt priority static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [#PR ID] Add your changelog entry here.
 - [#219] Test against Ruby 3.4.
 - [#216] Test against Rails 7.1, 7.2, 8.0.
+- [#220] Define priority on possible prompt values to statically & successfully process multiple prompt values
 
 ## v1.8.10 (2024-11-29)
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 # use Rails version specified by environment
-ENV['rails'] ||= '7.0.0'
+ENV['rails'] ||= '8.0.0'
 gem 'rails', "~> #{ENV['rails']}"
 gem 'rails-controller-testing'
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -67,7 +67,7 @@ module Doorkeeper
         def handle_oidc_prompt_param!(owner)
           prompt_values ||= params[:prompt].to_s.split(/ +/).uniq
 
-          priority = ['none', 'login', 'consent', 'select_account']
+          priority = ['none', 'consent', 'login', 'select_account']
           prompt_values.sort_by! do |prompt|
             priority.find_index(prompt).to_i
           end

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -69,7 +69,7 @@ module Doorkeeper
 
           priority = ['none', 'login', 'consent', 'select_account']
           prompt_values.sort_by! do |prompt|
-            priority.find_index(prompt)
+            priority.find_index(prompt).to_i
           end
 
           prompt_values.each do |prompt|

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -67,6 +67,11 @@ module Doorkeeper
         def handle_oidc_prompt_param!(owner)
           prompt_values ||= params[:prompt].to_s.split(/ +/).uniq
 
+          priority = ['none', 'login', 'consent', 'select_account']
+          prompt_values.sort_by! do |prompt|
+            priority.find_index(prompt)
+          end
+
           prompt_values.each do |prompt|
             case prompt
             when 'none'

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -307,9 +307,8 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
 
       # FIXME:
       it 'when login+consent' do
-        expect do
-          authorize! prompt: 'login consent'
-        end.to raise_error AbstractController::DoubleRenderError
+        authorize! prompt: 'login consent'
+        expect(response).to redirect_to('/reauthenticate')
       end
     end
 

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -284,6 +284,35 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
 
+    context 'with multiple prompt values' do
+      it 'when select_account+login' do
+        authorize! prompt: 'select_account login'
+        expect(response).to redirect_to('/select_account')
+      end
+
+      it 'when login+select_account' do
+        authorize! prompt: 'login select_account'
+        expect(response).to redirect_to('/select_account')
+      end
+
+      it 'when consent+select_account' do
+        authorize! prompt: 'consent select_account'
+        expect(response).to redirect_to('/select_account')
+      end
+
+      it 'when select_account+consent' do
+        authorize! prompt: 'select_account consent'
+        expect(response).to redirect_to('/select_account')
+      end
+
+      # FIXME:
+      it 'when login+consent' do
+        expect do
+          authorize! prompt: 'login consent'
+        end.to raise_error AbstractController::DoubleRenderError
+      end
+    end
+
     context 'with an unknown prompt parameter' do
       it 'returns an invalid_request error' do
         authorize! prompt: 'maybe'

--- a/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
+++ b/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
@@ -48,6 +48,10 @@ Doorkeeper::OpenidConnect.configure do
   end
 
   select_account_for_resource_owner do |_resource_owner, _return_to|
+    # NOTE: avoid double rendering
+    # ref. https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/88f2df8ec0f934611070def307afb24ac67a2f76/lib/generators/doorkeeper/openid_connect/templates/initializer.rb#L33-L38
+    self.response_body = nil
+    @_response_body = nil
     redirect_to '/select_account'
   end
 

--- a/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
+++ b/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
@@ -44,6 +44,10 @@ Doorkeeper::OpenidConnect.configure do
   end
 
   reauthenticate_resource_owner do |_resource_owner, _return_to|
+    # NOTE: avoid double rendering
+    # ref. https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/88f2df8ec0f934611070def307afb24ac67a2f76/lib/generators/doorkeeper/openid_connect/templates/initializer.rb#L33-L38
+    self.response_body = nil
+    @_response_body = nil
     redirect_to '/reauthenticate'
   end
 


### PR DESCRIPTION
current implementation behaves differently on these patterns
* `prompt=select_account+login`
* `prompt=login+select_account`

since OIDC spec doesn't mention about prompt value order matter or not, it's totally up to implementation.
however, in most cases, developer will expect this behavior regardless of the order.

1. `prompt=login` clears current authenticated session
2. then `prompt=select_account` tries to render account selector
3. if account selector cannot list-up accounts, show login page etc
    * this is application specific behaviour, not related to this gem

so, this pull request is trying to make the prompt handling order static based on the priority of each prompt value.