### PR TITLE
allow prompt=create use, but not support in this gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [#PR ID] Add your changelog entry here.
 - [#219] Test against Ruby 3.4.
 - [#216] Test against Rails 7.1, 7.2, 8.0.
+- [#221] Avoid raising invalid_request error on prompt=create
 
 ## v1.8.10 (2024-11-29)
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -79,6 +79,8 @@ module Doorkeeper
               render :new if owner
             when 'select_account'
               select_account_for_oidc_resource_owner(owner)
+            when 'create'
+              # NOTE: not supported, but not raise error.
             else
               raise Errors::InvalidRequest
             end

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -284,6 +284,14 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
 
+    context 'with a prompt=create parameter' do
+      it 'ignore it w/o returinig invalid_request error' do
+        authorize! prompt: 'create'
+
+        expect(response).to render_template('doorkeeper/authorizations/new')
+      end
+    end
+
     context 'with an unknown prompt parameter' do
       it 'returns an invalid_request error' do
         authorize! prompt: 'maybe'


### PR DESCRIPTION
to enable using this extension by RP developers, just stop raising error.
https://openid.net/specs/openid-connect-prompt-create-1_0.html

no need to support `create` value in this gem itself.