### PR TITLE
accept max_age=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [#PR ID] Add your changelog entry here.
 - [#219] Test against Ruby 3.4.
 - [#216] Test against Rails 7.1, 7.2, 8.0.
+- [#222] Support max_age=0
 
 ## v1.8.10 (2024-11-29)
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -94,6 +94,9 @@ module Doorkeeper
             &Doorkeeper::OpenidConnect.configuration.auth_time_from_resource_owner
           )
 
+          # NOTE: clock skew
+          max_age = [1, max_age].max
+
           if !auth_time || (Time.zone.now - auth_time) > max_age
             reauthenticate_oidc_resource_owner(owner)
           end

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -87,7 +87,7 @@ module Doorkeeper
 
         def handle_oidc_max_age_param!(owner)
           max_age = params[:max_age].to_i
-          return unless max_age > 0 && owner
+          return unless (params[:max_age].to_s == '0' || max_age > 0) && owner
 
           auth_time = instance_exec(
             owner,

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -307,11 +307,20 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
   describe '#handle_oidc_max_age_param!' do
     context 'with an invalid max_age parameter' do
       it 'renders the authorization form' do
-        %w[0 -1 -23 foobar].each do |max_age|
+        %w[-1 -23 foobar].each do |max_age|
           authorize! max_age: max_age
 
           expect_authorization_form!
         end
+      end
+    end
+
+    context 'with a max_age=0 parameter' do
+      it 'renders the authorization form if the users last login was within 10 seconds' do
+        user.update! current_sign_in_at: 5.seconds.ago
+        authorize! max_age: 0
+
+        expect(response).to redirect_to '/reauthenticate'
       end
     end
 


### PR DESCRIPTION
`max_age=0` is explicitly defined as "Note that max_age=0 is equivalent to prompt=login." in the spec.
https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest