### PR TITLE
priority on max age and prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#216] Test against Rails 7.1, 7.2, 8.0.
 - [#221] Avoid raising invalid_request error on prompt=create
 - [#220] Define priority on possible prompt values to statically & successfully process multiple prompt values
+- [#224] Define priority between max_age & prompt
 
 ## v1.8.10 (2024-11-29)
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -17,8 +17,8 @@ module Doorkeeper
           super.tap do |owner|
             next unless oidc_authorization_request?
 
-            handle_oidc_prompt_param!(owner)
             handle_oidc_max_age_param!(owner)
+            handle_oidc_prompt_param!(owner)
           end
         rescue Errors::OpenidConnectError => e
           handle_oidc_error!(e)

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -313,7 +313,6 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
         expect(response).to redirect_to('/select_account')
       end
 
-      # FIXME:
       it 'when login+consent' do
         authorize! prompt: 'login consent'
         expect(response).to redirect_to('/reauthenticate')

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -373,6 +373,15 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
         expect(response).to redirect_to '/reauthenticate'
       end
     end
+
+    context 'when used along with prompt=select_account' do
+      it 'renders the authorization form' do
+        user.update! current_sign_in_at: 5.seconds.ago
+        authorize! max_age: 1, prompt: 'select_account'
+
+        expect(response).to redirect_to '/select_account'
+      end
+    end
   end
 
   describe '#reauthenticate_oidc_resource_owner' do


### PR DESCRIPTION
since max_age is very similar with prompt=login, it should be proceeded before other prompt values like select_account, concent etc.
