### PR TITLE
Respect Doorkeeper's configured `pkce_code_challenge_methods`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#236] Derive token_endpoint_auth_methods_supported from Doorkeeper's client_credentials config
 - [#225] Allow configuration of id_token expiration using a block.
 - [#237] Fix dynamic client registration returning hashed secret when `hash_application_secrets` is enabled
+- [#226] Respect Doorkeeper's configured `pkce_code_challenge_methods`
 
 ## v1.8.11 (2025-02-10)
 

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -87,7 +87,7 @@ module Doorkeeper
       def code_challenge_methods_supported(doorkeeper)
         return unless doorkeeper.access_grant_model.pkce_supported?
 
-        %w[plain S256]
+        doorkeeper.pkce_code_challenge_methods
       end
 
       def webfinger_response

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -136,7 +136,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       end
     end
 
-    context 'when grant_flows is configed with only client_credentials' do
+    context 'when grant_flows is configured with only client_credentials' do
       before { Doorkeeper.configure { grant_flows %w[client_credentials] } }
 
       it 'return empty response_modes_supported' do
@@ -147,7 +147,29 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       end
     end
 
-    context 'when grant_flows is configed only implicit flow' do
+    context 'when pkce_code_challenge_methods is configured with only S256' do
+      before { Doorkeeper.configure { pkce_code_challenge_methods %w[S256] } }
+
+      it 'return only S256 in code_challenge_methods_supported' do
+        get :provider
+        data = JSON.parse(response.body)
+
+        expect(data['code_challenge_methods_supported']).to eq %w[S256]
+      end
+    end
+
+    context 'when pkce_code_challenge_methods is configured with only plain' do
+      before { Doorkeeper.configure { pkce_code_challenge_methods %w[plain] } }
+
+      it 'return only plain in code_challenge_methods_supported' do
+        get :provider
+        data = JSON.parse(response.body)
+
+        expect(data['code_challenge_methods_supported']).to eq %w[plain]
+      end
+    end
+
+    context 'when grant_flows is configured only implicit flow' do
       before { Doorkeeper.configure { grant_flows %w[implicit_oidc] } }
 
       it 'return fragment and form_post as response_modes_supported' do
@@ -191,7 +213,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       end
     end
 
-    context 'when grant_flows is configed with authorization_code and implicit flow' do
+    context 'when grant_flows is configured with authorization_code and implicit flow' do
       before { Doorkeeper.configure { grant_flows %w[authorization_code implicit_oidc] } }
 
       it 'return query, fragment and form_post as response_modes_supported' do


### PR DESCRIPTION
Currently the `pkce_code_challenge_methods_supported` are hardcoded to `["plain", "S256"]`. This could cause a mismatch between the configured challenge methods in the base Doorkeeper configuration and those that are advertised at the `/.well-known/openid-configuration` endpoint.

Updates the method to delegate to `doorkeeper#pkce_code_challenge_methods` so that the supported methods exposed via the `DiscoveryController` will match the methods that have been configured by the main Doorkeeper configuration.