### PR TITLE
Add support for configurable registration endpoint in OpenID Connect discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add support for configurable registration_endpoint in OpenID Connect discovery
 - [#PR ID] Add your changelog entry here.
 
 ## v1.8.11 (2025-02-10)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ The following settings are optional:
   - Used by implementations like https://github.com/IdentityModel/oidc-client-js.
   - The block is executed in the controller's scope, so you have access to your route helpers.
 
+- `registration_endpoint`
+  - The URL for client registration endpoint, used for dynamic client registration.
+  - The block is executed in the controller's scope, so you have access to your route helpers.
+  - If not configured, the field will be omitted from the discovery document.
+
+  ```ruby
+  Doorkeeper::OpenidConnect.configure do
+    registration_endpoint -> { oauth_register_url }
+  end
+  ```
+
 - `discovery_url_options`
   - The URL options for every available endpoint to use when generating the endpoint URL in the
     discovery response. Available endpoints: `authorization`, `token`, `revocation`,

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -34,6 +34,7 @@ module Doorkeeper
           userinfo_endpoint: oauth_userinfo_url(userinfo_url_options),
           jwks_uri: oauth_discovery_keys_url(jwks_url_options),
           end_session_endpoint: instance_exec(&openid_connect.end_session_endpoint),
+          registration_endpoint: registration_endpoint,
 
           scopes_supported: doorkeeper.scopes,
 
@@ -133,6 +134,13 @@ module Doorkeeper
           Doorkeeper::OpenidConnect.configuration.issuer.call(request).to_s
         else
           Doorkeeper::OpenidConnect.configuration.issuer
+        end
+      end
+
+      def registration_endpoint
+        openid_connect = ::Doorkeeper::OpenidConnect.configuration
+        if openid_connect.registration_endpoint.present?
+          instance_exec(&openid_connect.registration_endpoint)
         end
       end
 

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -79,6 +79,10 @@ module Doorkeeper
       option :discovery_url_options, default: lambda { |*_|
         {}
       }
+
+      option :registration_endpoint, default: lambda { |*_|
+        nil
+      }
     end
   end
 end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -186,6 +186,28 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       expect(data.key?('end_session_endpoint')).to be(false)
     end
 
+    it 'does not return a registration endpoint if none is configured' do
+      get :provider
+      data = JSON.parse(response.body)
+
+      expect(data.key?('registration_endpoint')).to be(false)
+    end
+
+    it 'uses the configured registration endpoint with self as context' do
+      Doorkeeper::OpenidConnect.configure do
+        registration_endpoint -> { registration_url }
+      end
+
+      def controller.registration_url
+        'http://test.host/oauth/register'
+      end
+
+      get :provider
+      data = JSON.parse(response.body)
+
+      expect(data['registration_endpoint']).to eq 'http://test.host/oauth/register'
+    end
+
     it 'uses the configured end session endpoint with self as context' do
       Doorkeeper::OpenidConnect.configure do
         end_session_endpoint -> { logout_url }

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -229,4 +229,18 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       expect(subject.discovery_url_options.call[:authorization]).to eq(host: 'alternate-authorization-host')
     end
   end
+
+  describe 'registration_endpoint' do
+    it 'defaults to nil' do
+      expect(subject.registration_endpoint.call).to be_nil
+    end
+
+    it 'can be set to a custom url' do
+      described_class.configure do
+        registration_endpoint { 'http://test.host/oauth/register' }
+      end
+
+      expect(subject.registration_endpoint.call).to eq('http://test.host/oauth/register')
+    end
+  end
 end


### PR DESCRIPTION
- Updated CHANGELOG to reflect the new feature.
- Enhanced README with details on the `registration_endpoint` configuration.
- Implemented logic in the discovery controller to include the registration endpoint if configured.
- Added configuration option for `registration_endpoint` in the Doorkeeper OpenID Connect settings.
- Created tests to verify the behavior of the registration endpoint in the discovery response.