### PR TITLE
Dynamic client registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [#229] Allow to application manage signing key and algorithm
+- [#230] Add dynamic client registration
 
 ## v1.8.11 (2025-02-10)
 

--- a/app/controllers/concerns/doorkeeper/openid_connect/grant_types_supported_mixin.rb
+++ b/app/controllers/concerns/doorkeeper/openid_connect/grant_types_supported_mixin.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OpenidConnect
+    module GrantTypesSupportedMixin
+      def grant_types_supported(doorkeeper)
+        grant_types_supported = doorkeeper.grant_flows.dup
+        grant_types_supported << 'refresh_token' if doorkeeper.refresh_token_enabled?
+        grant_types_supported
+      end
+    end
+  end
+end

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OpenidConnect
+    class DynamicClientRegistrationController < ::Doorkeeper::ApplicationMetalController
+      include GrantTypesSupportedMixin
+
+      def register
+        client = Doorkeeper::Application.create!(application_params)
+        render json: registration_response(client), status: :created
+      rescue ActiveRecord::RecordInvalid => e
+        render json: { error: "invalid_client_params", error_description: e.record.errors.full_messages.join(", ") },
+          status: :bad_request
+      end
+
+      private
+
+      def application_params
+        {
+          name: params.dig(:client_name),
+          redirect_uri: params.dig(:redirect_uris) || [],
+          scopes: params.dig(:scope),
+          confidential: false,
+        }
+      end
+
+      def registration_response(doorkeeper_application)
+        doorkeeper_config = ::Doorkeeper.configuration
+
+        {
+          client_secret: doorkeeper_application.secret,
+          client_id: doorkeeper_application.uid,
+          client_id_issued_at: doorkeeper_application.created_at.to_i,
+          redirect_uris: doorkeeper_application.redirect_uri.split,
+          token_endpoint_auth_methods_supported: %w[client_secret_basic client_secret_post],
+          response_types: doorkeeper_config.authorization_response_types,
+          grant_types: grant_types_supported(doorkeeper_config),
+          scope: doorkeeper_application.scopes.to_s,
+          application_type: "web"
+        }
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -79,6 +79,8 @@ module Doorkeeper
       option :discovery_url_options, default: lambda { |*_|
         {}
       }
+
+      option :dynamic_client_registration, default: false
     end
   end
 end

--- a/lib/doorkeeper/openid_connect/rails/routes.rb
+++ b/lib/doorkeeper/openid_connect/rails/routes.rb
@@ -26,9 +26,15 @@ module Doorkeeper
 
         def generate_routes!(options)
           @mapping = Mapper.new.map(&@block)
+          openid_connect = ::Doorkeeper::OpenidConnect.configuration
+
           routes.scope options[:scope] || 'oauth', as: 'oauth' do
             map_route(:userinfo, :userinfo_routes)
             map_route(:discovery, :discovery_routes)
+
+            if openid_connect.dynamic_client_registration
+              map_route(:dynamic_client_registration, :dynamic_client_registration_routes)
+            end
           end
 
           routes.scope as: 'oauth' do
@@ -65,6 +71,10 @@ module Doorkeeper
             routes.get :provider, path: 'oauth-authorization-server'
             routes.get :webfinger
           end
+        end
+
+        def dynamic_client_registration_routes
+          routes.post :register, path: 'registration', as: ''
         end
       end
     end

--- a/lib/doorkeeper/openid_connect/rails/routes/mapping.rb
+++ b/lib/doorkeeper/openid_connect/rails/routes/mapping.rb
@@ -10,12 +10,14 @@ module Doorkeeper
           def initialize
             @controllers = {
               userinfo: 'doorkeeper/openid_connect/userinfo',
-              discovery: 'doorkeeper/openid_connect/discovery'
+              discovery: 'doorkeeper/openid_connect/discovery',
+              dynamic_client_registration: 'doorkeeper/openid_connect/dynamic_client_registration'
             }
 
             @as = {
               userinfo: :userinfo,
-              discovery: :discovery
+              discovery: :discovery,
+              dynamic_client_registration: :dynamic_client_registration
             }
 
             @skips = []

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -59,6 +59,9 @@ Doorkeeper::OpenidConnect.configure do
   # Expiration time on or after which the ID Token MUST NOT be accepted for processing. (default 120 seconds).
   # expiration 600
 
+  # Enable dynamic client registration (default false)
+  # dynamic_client_registration true
+
   # Example claims:
   # claims do
   #   normal_claim :_foo_ do |resource_owner|

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -59,6 +59,61 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       }.sort)
     end
 
+    it 'returns the provider configuration with client registration url' do
+      Doorkeeper::OpenidConnect.configure do
+        issuer "dummy"
+        dynamic_client_registration true
+      end
+
+      Rails.application.reload_routes!
+
+      get :provider
+      data = JSON.parse(response.body)
+
+      expect(data.sort).to match({
+        'issuer' => 'dummy',
+        'authorization_endpoint' => 'http://test.host/oauth/authorize',
+        'token_endpoint' => 'http://test.host/oauth/token',
+        'revocation_endpoint' => 'http://test.host/oauth/revoke',
+        'introspection_endpoint' => 'http://test.host/oauth/introspect',
+        'userinfo_endpoint' => 'http://test.host/oauth/userinfo',
+        'jwks_uri' => 'http://test.host/oauth/discovery/keys',
+        'registration_endpoint' => 'http://test.host/oauth/registration',
+
+        'scopes_supported' => ['openid'],
+        'response_types_supported' => ['code', 'token', 'id_token', 'id_token token'],
+        'response_modes_supported' => %w[query fragment form_post],
+        'grant_types_supported' => %w[authorization_code client_credentials implicit_oidc],
+
+        'token_endpoint_auth_methods_supported' => %w[client_secret_basic client_secret_post],
+
+        'subject_types_supported' => [
+          'public',
+        ],
+
+        'id_token_signing_alg_values_supported' => [
+          'RS256',
+        ],
+
+        'claim_types_supported' => [
+          'normal',
+        ],
+
+        'claims_supported' => %w[
+          iss
+          sub
+          aud
+          exp
+          iat
+        ],
+
+        'code_challenge_methods_supported' => %w[
+          plain
+          S256
+        ],
+      }.sort)
+    end
+
     context 'when refresh_token grant type is enabled' do
       before { Doorkeeper.configure { use_refresh_token } }
 

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :controller do
+  before do
+    Doorkeeper::OpenidConnect.configure do
+      issuer "dummy"
+      dynamic_client_registration true
+    end
+
+    Rails.application.reload_routes!
+  end
+
+  describe "#register" do
+    it "creates a Doorkeeper::Application" do
+      redirect_uris = [
+        'https://test.host/registration_success',
+        'https://test.host/registration_success_second_location',
+      ]
+
+      post :register, params: {
+        client_name: "dummy_client",
+        redirect_uris: redirect_uris,
+        scope: "public"
+      }
+
+      expect(response.status).to eq 201
+      expect(Doorkeeper::Application.count).to eq(1)
+
+      doorkeeper_application = Doorkeeper::Application.first
+      expect(JSON.parse(response.body)).to eq({
+        'client_secret' => doorkeeper_application.secret,
+        'client_id' => doorkeeper_application.uid,
+        'client_id_issued_at' => doorkeeper_application.created_at.to_i,
+        'redirect_uris' => redirect_uris,
+        'token_endpoint_auth_methods_supported' => %w[client_secret_basic client_secret_post],
+        'response_types' => ['code', 'token', 'id_token', 'id_token token'],
+        'grant_types' => %w[authorization_code client_credentials implicit_oidc],
+        'scope' => "public",
+        'application_type' => "web"
+      })
+    end
+
+    it "errors and returns errors" do
+      post :register, params: {
+        client_name: "dummy_client",
+        redirect_uris: [
+          'http://test.host/registration_success',
+        ],
+        scopes: "openid"
+      }
+
+      expect(response.status).to eq 400
+      expect(Doorkeeper::Application.count).to eq(0)
+      expect(JSON.parse(response.body)).to eq({
+        "error" => "invalid_client_params",
+        "error_description" => "Redirect URI must be an HTTPS/SSL URI."
+      })
+    end
+  end
+end

--- a/spec/lib/routes_spec.rb
+++ b/spec/lib/routes_spec.rb
@@ -41,4 +41,25 @@ describe Doorkeeper::OpenidConnect::Rails::Routes, type: :routing do
       )
     end
   end
+
+  describe 'dynamic_client_registration' do
+    it 'doesn\'t map by default' do
+      Rails.application.reload_routes!
+
+      expect(post: 'oauth/registration').not_to be_routable
+    end
+
+    it 'maps POST #register' do
+      Doorkeeper::OpenidConnect.configure do
+        dynamic_client_registration true
+      end
+
+      Rails.application.reload_routes!
+
+      expect(post: 'oauth/registration').to route_to(
+        controller: 'doorkeeper/openid_connect/dynamic_client_registration',
+        action: 'register'
+      )
+    end
+  end
 end


### PR DESCRIPTION
This PR adds dynamic client registration as an optional feature that can be enabled through a configuration value.

I currently have it working in my own application and wanted to contribute it upstream so it can be refined as needed and potentially benefit other users of this gem.

Please let me know if I’ve missed anything or if you have any feedback.