### PR TITLE
feat: implements customizable OpenID request class and updates references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [#229] Allow to application manage signing key and algorithm
 - [#230] Add dynamic client registration
 - [#233] fix: handle DoubleRenderError in library instead of requiring consumer workaround
+- [#232] Implements customizable OpenID request class
 
 ## v1.8.11 (2025-02-10)
 

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -81,6 +81,12 @@ module Doorkeeper
       }
 
       option :dynamic_client_registration, default: false
+
+      option :open_id_request_class, default: 'Doorkeeper::OpenidConnect::Request'
+
+      def open_id_request_model
+        open_id_request_class.to_s.constantize
+      end
     end
   end
 end

--- a/lib/doorkeeper/openid_connect/oauth/authorization/code.rb
+++ b/lib/doorkeeper/openid_connect/oauth/authorization/code.rb
@@ -25,7 +25,7 @@ module Doorkeeper
           private
 
           def create_openid_request(access_grant)
-            ::Doorkeeper::OpenidConnect::Request.create!(
+            ::Doorkeeper::OpenidConnect.configuration.open_id_request_model.create!(
               access_grant: access_grant,
               nonce: pre_auth.nonce
             )

--- a/lib/doorkeeper/openid_connect/orm/active_record.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record.rb
@@ -9,6 +9,10 @@ module Doorkeeper
 
     module Orm
       module ActiveRecord
+        module Mixins
+          autoload :OpenidRequest, "doorkeeper/openid_connect/orm/active_record/mixins/openid_request"
+        end
+
         def run_hooks
           super
 
@@ -19,7 +23,7 @@ module Doorkeeper
           end
 
           if Doorkeeper.configuration.respond_to?(:active_record_options) && Doorkeeper.configuration.active_record_options[:establish_connection]
-            [Doorkeeper::OpenidConnect::Request].each do |c|
+            [Doorkeeper::OpenidConnect.configuration.open_id_request_model].each do |c|
               c.send :establish_connection, Doorkeeper.configuration.active_record_options[:establish_connection]
             end
           end
@@ -38,7 +42,7 @@ module Doorkeeper
             end
 
             if Doorkeeper.configuration.active_record_options[:establish_connection]
-              [Doorkeeper::OpenidConnect::Request].each do |c|
+              [Doorkeeper::OpenidConnect.configuration.open_id_request_model].each do |c|
                 c.send :establish_connection, Doorkeeper.configuration.active_record_options[:establish_connection]
               end
             end

--- a/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       def self.prepended(base)
         base.class_eval do
           has_one :openid_request,
-            class_name: 'Doorkeeper::OpenidConnect::Request',
+            class_name: Doorkeeper::OpenidConnect.configuration.open_id_request_class,
             foreign_key: 'access_grant_id',
             inverse_of: :access_grant,
             dependent: :delete

--- a/lib/doorkeeper/openid_connect/orm/active_record/mixins/openid_request.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/mixins/openid_request.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OpenidConnect
+    module Orm
+      module ActiveRecord
+        module Mixins
+          module OpenidRequest
+            extend ::ActiveSupport::Concern
+
+            included do
+              self.table_name = "#{table_name_prefix}oauth_openid_requests#{table_name_suffix}".to_sym
+
+              validates :access_grant_id, :nonce, presence: true
+
+              if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.0')
+                belongs_to :access_grant,
+                           class_name: Doorkeeper.config.access_grant_class.to_s,
+                           inverse_of: :openid_request
+              else
+                belongs_to :access_grant,
+                           class_name: 'Doorkeeper::AccessGrant',
+                           inverse_of: :openid_request
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/openid_connect/orm/active_record/request.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/request.rb
@@ -1,21 +1,11 @@
 # frozen_string_literal: true
 
+require 'doorkeeper/openid_connect/orm/active_record/mixins/openid_request'
+
 module Doorkeeper
   module OpenidConnect
     class Request < ::ActiveRecord::Base
-      self.table_name = "#{table_name_prefix}oauth_openid_requests#{table_name_suffix}".to_sym
-
-      validates :access_grant_id, :nonce, presence: true
-
-      if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.0')
-        belongs_to :access_grant,
-                   class_name: Doorkeeper.config.access_grant_class.to_s,
-                   inverse_of: :openid_request
-      else
-        belongs_to :access_grant,
-                   class_name: 'Doorkeeper::AccessGrant',
-                   inverse_of: :openid_request
-      end
+      include Orm::ActiveRecord::Mixins::OpenidRequest
     end
   end
 end

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -56,6 +56,25 @@ Doorkeeper::OpenidConnect.configure do
   # Enable dynamic client registration (default false)
   # dynamic_client_registration true
 
+  # You can use your own model class if you need to extend (or even override) the default
+  # Doorkeeper::OpenidConnect::Request model (e.g. to use a different database connection).
+  #
+  # By default Doorkeeper OpenID Connect uses:
+  #
+  # open_id_request_class "Doorkeeper::OpenidConnect::Request"
+  #
+  # Don't forget to include the OpenID Connect ORM mixin into your custom model:
+  #
+  #   * ::Doorkeeper::OpenidConnect::Orm::ActiveRecord::Mixins::OpenidRequest
+  #
+  # For example:
+  #
+  # open_id_request_class "MyOpenidRequest"
+  #
+  # class MyOpenidRequest < ApplicationRecord
+  #   include ::Doorkeeper::OpenidConnect::Orm::ActiveRecord::Mixins::OpenidRequest
+  # end
+
   # Example claims:
   # claims do
   #   normal_claim :_foo_ do |resource_owner|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
     current_sign_in_at { Time.zone.at(23) }
   end
 
-  factory :openid_request, class: 'Doorkeeper::OpenidConnect::Request' do
+  factory :openid_request, class: Doorkeeper::OpenidConnect.configuration.open_id_request_model do
     access_grant
     sequence(:nonce, &:to_s)
   end

--- a/spec/lib/oauth/authorization/code_spec.rb
+++ b/spec/lib/oauth/authorization/code_spec.rb
@@ -9,6 +9,7 @@ describe Doorkeeper::OpenidConnect::OAuth::Authorization::Code do
   let(:access_grant) { create :access_grant }
   let(:pre_auth) { double }
   let(:client) { double }
+  let(:openid_request_class) { Doorkeeper::OpenidConnect.configuration.open_id_request_model }
 
   describe '#issue_token' do
     before do
@@ -22,13 +23,13 @@ describe Doorkeeper::OpenidConnect::OAuth::Authorization::Code do
       allow(client).to receive(:id).and_return('client_id')
 
       allow(Doorkeeper::AccessGrant).to receive(:create!) { access_grant }
-      allow(Doorkeeper::OpenidConnect::Request).to receive(:create!)
+      allow(openid_request_class).to receive(:create!)
     end
 
     it 'stores the nonce' do
       subject.issue_token
 
-      expect(Doorkeeper::OpenidConnect::Request).to have_received(:create!).with({
+      expect(openid_request_class).to have_received(:create!).with({
         access_grant: access_grant,
         nonce: '123456'
       })
@@ -38,14 +39,14 @@ describe Doorkeeper::OpenidConnect::OAuth::Authorization::Code do
       allow(pre_auth).to receive(:nonce).and_return(nil)
       subject.issue_token
 
-      expect(Doorkeeper::OpenidConnect::Request).not_to have_received(:create!)
+      expect(openid_request_class).not_to have_received(:create!)
     end
 
     it 'does not store the nonce if blank' do
       allow(pre_auth).to receive(:nonce).and_return(' ')
       subject.issue_token
 
-      expect(Doorkeeper::OpenidConnect::Request).not_to have_received(:create!)
+      expect(openid_request_class).not_to have_received(:create!)
     end
 
     it 'returns the created grant' do

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -16,6 +16,7 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
   let(:openid_request) { create :openid_request, nonce: '123456' }
   let(:token) { create :access_token }
   let(:response) { Doorkeeper::OAuth::TokenResponse.new token }
+  let(:openid_request_class) { Doorkeeper::OpenidConnect.configuration.open_id_request_model }
 
   describe '#after_successful_response' do
     it 'adds the ID token to the response' do
@@ -30,7 +31,7 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
 
       expect do
         subject.send :after_successful_response
-      end.to change { Doorkeeper::OpenidConnect::Request.count }.by(-1)
+      end.to change { openid_request_class.count }.by(-1)
     end
 
     it 'skips the nonce if not present' do

--- a/spec/models/access_grant_spec.rb
+++ b/spec/models/access_grant_spec.rb
@@ -4,12 +4,14 @@ require 'rails_helper'
 
 describe Doorkeeper::OpenidConnect::AccessGrant do
   subject { Doorkeeper::AccessGrant.new }
+  let(:openid_request_class_name) { Doorkeeper::OpenidConnect.configuration.open_id_request_class }
+  let(:openid_request_class) { Doorkeeper::OpenidConnect.configuration.open_id_request_model }
 
   it 'has one openid_request' do
     association = subject.class.reflect_on_association :openid_request
 
     expect(association.options).to eq({
-      class_name: 'Doorkeeper::OpenidConnect::Request',
+      class_name: openid_request_class_name,
       inverse_of: :access_grant,
       foreign_key: "access_grant_id",
       dependent: :delete,
@@ -27,7 +29,7 @@ describe Doorkeeper::OpenidConnect::AccessGrant do
         create(:openid_request, access_grant: access_grant)
 
         expect { access_grant.delete }
-          .to(change { Doorkeeper::OpenidConnect::Request.count }.by(-1))
+          .to(change { openid_request_class.count }.by(-1))
       else
         skip <<-MSG.strip
           Needs Rails 6 for foreign key support with sqlite3:

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -3,6 +3,13 @@
 require 'rails_helper'
 
 describe Doorkeeper::OpenidConnect::Request do
+  let(:expected_access_grant_class_name) do
+    if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.0')
+      Doorkeeper.config.access_grant_class.to_s
+    else
+      'Doorkeeper::AccessGrant'
+    end
+  end
   describe 'validations' do
     it 'requires an access grant' do
       subject.access_grant_id = nil
@@ -24,7 +31,7 @@ describe Doorkeeper::OpenidConnect::Request do
       association = subject.class.reflect_on_association :access_grant
 
       expect(association.options).to eq({
-        class_name: 'Doorkeeper::AccessGrant',
+        class_name: expected_access_grant_class_name,
         inverse_of: :openid_request,
       })
     end


### PR DESCRIPTION
This adds a config option for the openid-request class, following same mixin principles of the base Doorkeeper gem. 

I had an issue where my app connects to multiple dbs, so I had to bypass nonce persistence completely, since I can't have this model in the default db. 

This PR addresses that issue. 