### PR TITLE
Fix `at_hash` to use correct hash algorithm based on `signing_algorithm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Please add here
 - [#241] Fix NameError on doorkeeper master by deferring AR model loading in run_hooks (see [Doorkeeper PR](https://github.com/doorkeeper-gem/doorkeeper/pull/1804))
+- [#246] Fix `at_hash` to use correct hash algorithm based on `signing_algorithm`
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/id_token_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token_token.rb
@@ -24,11 +24,18 @@ module Doorkeeper
       #   access_token value with SHA-256, then take the left-most 128 bits and
       #   base64url-encode them. The at_hash value is a case-sensitive string.
       def at_hash
-        sha256 = Digest::SHA256.new
-        token = @access_token.token
-        hashed_token = sha256.digest(token)
+        hashed_token = at_hash_digest.digest(@access_token.token)
         first_half = hashed_token[0...hashed_token.length / 2]
         Base64.urlsafe_encode64(first_half).tr('=', '')
+      end
+
+      def at_hash_digest
+        case Doorkeeper::OpenidConnect.signing_algorithm.to_s
+        when /256\z/ then Digest::SHA256
+        when /384\z/ then Digest::SHA384
+        when /512\z/ then Digest::SHA512
+        else Digest::SHA256
+        end
       end
     end
   end

--- a/spec/lib/id_token_token_spec.rb
+++ b/spec/lib/id_token_token_spec.rb
@@ -33,4 +33,37 @@ describe Doorkeeper::OpenidConnect::IdTokenToken do
       })
     end
   end
+
+  describe '#at_hash' do
+    # Per OIDC Core 1.0 §3.1.3.6 / §3.2.2.9, at_hash must use the hash algorithm
+    # that matches the alg of the ID Token's JOSE header (e.g. HS512 -> SHA-512).
+    let(:token_value) { 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y' }
+
+    before { access_token.update(token: token_value) }
+
+    def expected_at_hash(token, hasher)
+      digest = hasher.digest(token)
+      Base64.urlsafe_encode64(digest[0, digest.length / 2]).tr('=', '')
+    end
+
+    it 'uses SHA-256 for the default RS256 signing algorithm' do
+      expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA256))
+    end
+
+    context 'when signing_algorithm is HS512' do
+      before { configure_hmac }
+
+      it 'uses SHA-512' do
+        expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA512))
+      end
+    end
+
+    context 'when signing_algorithm is ES512' do
+      before { configure_ec }
+
+      it 'uses SHA-512' do
+        expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA512))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`IdTokenToken#at_hash` hardcodes `Digest::SHA256` for computing the access token hash, regardless of the configured `signing_algorithm`. This violates [OIDC Core 1.0 §3.1.3.6](https://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken) and [§3.2.2.9](https://openid.net/specs/openid-connect-core-1_0.html#ImplicitIDTValidation).

The spec requires the hash algorithm to match the signing algorithm:

| Signing Algorithm | Required Hash | Left-half bits |
|---|---|---|
| RS256 / ES256 / HS256 | SHA-256 | 128 |
| RS384 / ES384 / HS384 | SHA-384 | 192 |
| RS512 / ES512 / HS512 | SHA-512 | 256 |

When using HS512 or ES512, the `at_hash` in the ID Token is computed with SHA-256 instead of SHA-512. Strict clients verifying the `at_hash` will reject the ID Token.

## Changes

- **`lib/doorkeeper/openid_connect/id_token_token.rb`**: Select digest algorithm dynamically based on the suffix of `signing_algorithm` (256/384/512).
- **`spec/lib/id_token_token_spec.rb`**: Add tests verifying correct `at_hash` for HS512 and ES512 signing algorithms.

## Before

```ruby
# signing_algorithm: :HS512
at_hash = "77QmUPtjPfzWtF2AnpK9RQ"  # SHA-256, 128-bit (WRONG)
```

## After

```ruby
# signing_algorithm: :HS512
at_hash = "q7nS86GgvvFaZkzALLWqJYaJIKw2wCDAVfCAsm5CrBM"  # SHA-512, 256-bit (CORRECT)
```

Closes #245