### PR TITLE
Fix `max_age` always triggering reauthentication when `auth_time_from_resource_owner` returns Integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#241] Fix NameError on doorkeeper master by deferring AR model loading in run_hooks (see [Doorkeeper PR](https://github.com/doorkeeper-gem/doorkeeper/pull/1804))
 - [#246] Fix `at_hash` to use correct hash algorithm based on `signing_algorithm`
 * [#250] Return configured `issuer` instead of `root_url` in WebFinger response (thanks to @sato11 for the original work in #172)
+- [#248] Fix `max_age` always triggering reauthentication when `auth_time_from_resource_owner` returns Integer
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -104,6 +104,13 @@ module Doorkeeper
             &Doorkeeper::OpenidConnect.configuration.auth_time_from_resource_owner
           )
 
+          # Normalize non-Time values (e.g. an Integer epoch) so that the
+          # subtraction below yields a Float of elapsed seconds rather than a
+          # shifted Time value.
+          if auth_time && !auth_time.is_a?(Time) && !auth_time.is_a?(DateTime)
+            auth_time = Time.zone.at(auth_time.to_i)
+          end
+
           # NOTE: clock skew
           max_age = [1, max_age].max
 

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -382,25 +382,31 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
 
-    context 'when auth_time_from_resource_owner returns an Integer (epoch seconds)' do
-      before do
-        allow(Doorkeeper::OpenidConnect.configuration)
-          .to receive(:auth_time_from_resource_owner)
-          .and_return(->(resource_owner) { resource_owner.current_sign_in_at.to_i })
-      end
+    {
+      'an Integer (epoch seconds)' => ->(time) { time.to_i },
+      'a Time' => ->(time) { time.getlocal },
+      'an ActiveSupport::TimeWithZone' => ->(time) { time.in_time_zone },
+    }.each do |type_description, converter|
+      context "when auth_time_from_resource_owner returns #{type_description}" do
+        before do
+          allow(Doorkeeper::OpenidConnect.configuration)
+            .to receive(:auth_time_from_resource_owner)
+            .and_return(->(resource_owner) { converter.call(resource_owner.current_sign_in_at) })
+        end
 
-      it 'renders the authorization form if the last login is within max_age' do
-        user.update! current_sign_in_at: 5.seconds.ago
-        authorize! max_age: 10
+        it 'renders the authorization form if the last login is within max_age' do
+          user.update! current_sign_in_at: 5.seconds.ago
+          authorize! max_age: 10
 
-        expect_authorization_form!
-      end
+          expect_authorization_form!
+        end
 
-      it 'reauthenticates the user if the last login is older than max_age' do
-        user.update! current_sign_in_at: 15.seconds.ago
-        authorize! max_age: 10
+        it 'reauthenticates the user if the last login is older than max_age' do
+          user.update! current_sign_in_at: 15.seconds.ago
+          authorize! max_age: 10
 
-        expect(response).to redirect_to '/reauthenticate'
+          expect(response).to redirect_to '/reauthenticate'
+        end
       end
     end
 

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -382,6 +382,28 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
 
+    context 'when auth_time_from_resource_owner returns an Integer (epoch seconds)' do
+      before do
+        allow(Doorkeeper::OpenidConnect.configuration)
+          .to receive(:auth_time_from_resource_owner)
+          .and_return(->(resource_owner) { resource_owner.current_sign_in_at.to_i })
+      end
+
+      it 'renders the authorization form if the last login is within max_age' do
+        user.update! current_sign_in_at: 5.seconds.ago
+        authorize! max_age: 10
+
+        expect_authorization_form!
+      end
+
+      it 'reauthenticates the user if the last login is older than max_age' do
+        user.update! current_sign_in_at: 15.seconds.ago
+        authorize! max_age: 10
+
+        expect(response).to redirect_to '/reauthenticate'
+      end
+    end
+
     context 'when used along with prompt=select_account' do
       it 'renders the authorization form' do
         user.update! current_sign_in_at: 5.seconds.ago


### PR DESCRIPTION
## Summary

When `auth_time_from_resource_owner` returns an Integer (Unix epoch), the `max_age` check always forces reauthentication — even if the user logged in seconds ago.

The [README](https://github.com/doorkeeper-gem/doorkeeper-openid_connect#configuration) states this callback can return "a `Time`, `DateTime`, or any other class that responds to `to_i`", but the implementation does not handle the Integer case correctly.

## Root cause

In `lib/doorkeeper/openid_connect/helpers/controller.rb`:

```ruby
if !auth_time || (Time.zone.now - auth_time) > max_age
```

- `Time.zone.now - Time` → `Float` (elapsed seconds) ✅
- `Time.zone.now - Integer` → shifted `Time` object (not seconds) ❌

The shifted `Time` compared against an integer `max_age` via `>` effectively always returns `true`.

Note: The `auth_time` claim in `IdToken` uses `.try(:to_i)` and works correctly with Integer values, creating an asymmetry where the claim is correct but `max_age` enforcement is broken.

## Changes

- **`lib/doorkeeper/openid_connect/helpers/controller.rb`**: Normalize `auth_time` to a `Time` via `Time.zone.at(auth_time.to_i)` when it is neither a `Time` nor a `DateTime`. This matches the README's promise that the callback may return "any other class that responds to `to_i`".
- **`spec/controllers/doorkeeper/authorizations_controller_spec.rb`**: Add tests for `auth_time_from_resource_owner` returning Integer — verifies reauthentication is triggered correctly based on elapsed time.
- **`CHANGELOG.md`**: Add changelog entry.

## Before

```ruby
auth_time = user.current_sign_in_at.to_i  # 5 seconds ago
max_age = 3600
(Time.zone.now - auth_time) > max_age
#=> true (WRONG — always reauthenticates)
```

## After

```ruby
auth_time = user.current_sign_in_at.to_i  # 5 seconds ago
auth_time = Time.zone.at(auth_time.to_i)  # normalized
max_age = 3600
(Time.zone.now - auth_time) > max_age
#=> false (correct — 5s < 3600s)
```

Closes #247