### PR TITLE
Webfinger now returns issuer location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Please add here
 - [#241] Fix NameError on doorkeeper master by deferring AR model loading in run_hooks (see [Doorkeeper PR](https://github.com/doorkeeper-gem/doorkeeper/pull/1804))
 - [#246] Fix `at_hash` to use correct hash algorithm based on `signing_algorithm`
+* [#250] Return configured `issuer` instead of `root_url` in WebFinger response (thanks to @sato11 for the original work in #172)
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The following settings are optional:
 - `discovery_url_options`
   - The URL options for every available endpoint to use when generating the endpoint URL in the
     discovery response. Available endpoints: `authorization`, `token`, `revocation`,
-    `introspection`, `userinfo`, `jwks`, `webfinger`.
+    `introspection`, `userinfo`, `jwks`.
   - This option requires option keys with an available endpoint and
     [URL options](https://api.rubyonrails.org/v6.0.3.3/classes/ActionDispatch/Routing/UrlFor.html#method-i-url_for)
     as value.

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -96,7 +96,7 @@ module Doorkeeper
           links: [
             {
               rel: WEBFINGER_RELATION,
-              href: root_url(webfinger_url_options),
+              href: issuer,
             }
           ]
         }
@@ -133,7 +133,7 @@ module Doorkeeper
         Doorkeeper::OpenidConnect.resolve_issuer(request: request)
       end
 
-      %i[authorization token revocation introspection userinfo jwks webfinger dynamic_client_registration].each do |endpoint|
+      %i[authorization token revocation introspection userinfo jwks dynamic_client_registration].each do |endpoint|
         define_method :"#{endpoint}_url_options" do
           discovery_url_default_options.merge(discovery_url_options[endpoint.to_sym] || {})
         end

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -219,6 +219,24 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       end
     end
 
+    context 'when the issuer is configured to a non-root URL' do
+      let(:non_root_issuer) { 'http://test.host/issuer/with/path' }
+
+      before do
+        value = non_root_issuer
+        Doorkeeper::OpenidConnect.configure do
+          issuer value
+        end
+      end
+
+      it 'returns the configured issuer in the webfinger response' do
+        get :webfinger, params: { resource: 'user@example.com' }
+        data = JSON.parse(response.body)
+
+        expect(data['links'].first['href']).to eq non_root_issuer
+      end
+    end
+
     context 'when client_credentials is configured with both from_basic and from_params' do
       before { Doorkeeper.configure { client_credentials :from_basic, :from_params } }
 

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -366,26 +366,9 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
         'subject' => 'user@example.com',
         'links' => [
           'rel' => 'http://openid.net/specs/connect/1.0/issuer',
-          'href' => 'http://test.host/',
+          'href' => 'dummy',
         ],
       }.sort)
-    end
-
-    context 'when the discovery_url_options option is set for webfinger endpoint' do
-      before do
-        Doorkeeper::OpenidConnect.configure do
-          discovery_url_options do |request|
-            { webfinger: { host: 'alternate-webfinger.host' } }
-          end
-        end
-      end
-
-      it 'uses the discovery_url_options option when generating the webfinger endpoint url' do
-        get :webfinger, params: { resource: 'user@example.com' }
-        data = JSON.parse(response.body)
-
-        expect(data['links'].first['href']).to eq 'http://alternate-webfinger.host/'
-      end
     end
 
     context 'when the discovery_url_options option uses the request for an endpoint' do


### PR DESCRIPTION
Closes #171. Supersedes #172.

This PR takes over the work originally submitted by @sato11 in #172,
which had gone stale with unresolved conflicts.

## Changes

### From @sato11's original commit (cherry-picked):
- Return the configured `issuer` value instead of `root_url` in the WebFinger response
- Remove `webfinger_url_options` generation and related configurability
- Update specs and README accordingly

### Additional:
- Add spec for non-root issuer URL to cover the regression scenario described in #171

## Background

As described in #171, the previous implementation used `root_url` for the
WebFinger `links[].href` value, which can violate the OIDC Discovery
specification when the issuer is configured to a URL that differs from
the application root (e.g., includes a path component).