### PR TITLE
Treat `auth_time_from_resource_owner` as optional in IdToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 - Please add here
 - [#241] Fix NameError on doorkeeper master by deferring AR model loading in run_hooks (see [Doorkeeper PR](https://github.com/doorkeeper-gem/doorkeeper/pull/1804))
 - [#246] Fix `at_hash` to use correct hash algorithm based on `signing_algorithm`
-* [#250] Return configured `issuer` instead of `root_url` in WebFinger response (thanks to @sato11 for the original work in #172)
+- [#250] Return configured `issuer` instead of `root_url` in WebFinger response (thanks to @sato11 for the original work in #172)
 - [#248] Fix `max_age` always triggering reauthentication when `auth_time_from_resource_owner` returns Integer
 - [#254] **Breaking:** Omit `expires_in` from the `response_type=id_token` response (OIDC Core §3.2.2.5 — `expires_in` represents the Access Token lifetime; it is still returned for `response_type=id_token token`)
+- [#252] Treat `auth_time_from_resource_owner` as optional in `IdToken` — omit `auth_time` claim when unconfigured instead of raising `InvalidConfiguration`
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -74,6 +74,8 @@ module Doorkeeper
 
       def auth_time
         Doorkeeper::OpenidConnect.configuration.auth_time_from_resource_owner.call(@resource_owner).try(:to_i)
+      rescue Errors::InvalidConfiguration
+        nil
       end
     end
   end

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -100,6 +100,28 @@ describe Doorkeeper::OpenidConnect::IdToken do
         expect(claims[:iss]).to eq "#{user.id}-#{access_token.application.uid}"
       end
     end
+
+    context 'when auth_time_from_resource_owner is not configured' do
+      before do
+        Doorkeeper::OpenidConnect.configure do
+          issuer 'dummy'
+
+          resource_owner_from_access_token do |access_token|
+            User.find_by(id: access_token.resource_owner_id)
+          end
+
+          subject do |resource_owner|
+            resource_owner.id
+          end
+        end
+      end
+
+      it 'builds claims without raising and omits auth_time' do
+        expect { subject.claims }.not_to raise_error
+        expect(subject.claims[:auth_time]).to be_nil
+        expect(subject.as_json).not_to include(:auth_time)
+      end
+    end
   end
 
   describe '#as_json' do


### PR DESCRIPTION
The [README](https://github.com/doorkeeper-gem/doorkeeper-openid_connect#configuration) documents `auth_time_from_resource_owner` as optional:

> **`auth_time_from_resource_owner`**
> Required to support the `max_age` parameter and the `auth_time` claim.

This implies that leaving it unconfigured is valid — the user simply forgoes `max_age` support and the `auth_time` claim.

However, the default proc raises `Errors::InvalidConfiguration`:

```ruby
option :auth_time_from_resource_owner, default: lambda { |*_|
  raise Errors::InvalidConfiguration,
    I18n.translate('doorkeeper.openid_connect.errors.messages.auth_time_from_resource_owner_not_configured')
}
```

Because `IdToken#claims` unconditionally calls `#auth_time`, **every** id_token issuance fails when the option is left unset — contrary to the documented behavior.

### Fix

Rescue `Errors::InvalidConfiguration` in `IdToken#auth_time` and return `nil`. The existing `as_json` nil-filtering ensures the `auth_time` claim is simply omitted from the token.

```ruby
def auth_time
  Doorkeeper::OpenidConnect.configuration.auth_time_from_resource_owner.call(@resource_owner).try(:to_i)
rescue Errors::InvalidConfiguration
  nil
end
```

Note: the fix is scoped to `IdToken#auth_time` only. The `max_age` parameter validation in `handle_oidc_max_age_param!` invokes the same block via `instance_exec` on a separate path, so users who request `max_age` without configuring the option will still get `InvalidConfiguration` as before — only the id_token issuance path (where the claim is legitimately optional per the README) is affected.

### Tests

Added a context to `spec/lib/id_token_spec.rb` verifying that when `auth_time_from_resource_owner` is not configured:

- `claims` does not raise
- `claims[:auth_time]` is `nil`
- `as_json` does not include `:auth_time`

Closes #251 