### PR TITLE
Omit `expires_in` from pure `id_token` response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#246] Fix `at_hash` to use correct hash algorithm based on `signing_algorithm`
 * [#250] Return configured `issuer` instead of `root_url` in WebFinger response (thanks to @sato11 for the original work in #172)
 - [#248] Fix `max_age` always triggering reauthentication when `auth_time_from_resource_owner` returns Integer
+- [#254] **Breaking:** Omit `expires_in` from the `response_type=id_token` response (OIDC Core §3.2.2.5 — `expires_in` represents the Access Token lifetime; it is still returned for `response_type=id_token token`)
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/oauth/id_token_response.rb
+++ b/lib/doorkeeper/oauth/id_token_response.rb
@@ -19,7 +19,6 @@ module Doorkeeper
 
       def body
         {
-          expires_in: auth.token.expires_in_seconds,
           state: pre_auth.state,
           id_token: id_token.as_jws_token
         }

--- a/lib/doorkeeper/oauth/id_token_token_response.rb
+++ b/lib/doorkeeper/oauth/id_token_token_response.rb
@@ -6,7 +6,8 @@ module Doorkeeper
       def body
         super.merge({
           access_token: auth.token.token,
-          token_type: auth.token.token_type
+          token_type: auth.token.token_type,
+          expires_in: auth.token.expires_in_seconds
         })
       end
     end

--- a/spec/lib/oauth/id_token_response_spec.rb
+++ b/spec/lib/oauth/id_token_response_spec.rb
@@ -37,24 +37,30 @@ describe Doorkeeper::OAuth::IdTokenResponse do
   let(:id_token) { Doorkeeper::OpenidConnect::IdToken.new(token, pre_auth) }
 
   describe '#body' do
-    it 'return body response for id_token' do
+    it 'returns the id_token and state only (no expires_in per OIDC Core §3.2.2.5)' do
       expect(subject.body).to eq({
-        expires_in: auth.token.expires_in_seconds,
         state: pre_auth.state,
         id_token: id_token.as_jws_token
       })
     end
+
+    it 'does not include expires_in' do
+      expect(subject.body).not_to have_key(:expires_in)
+    end
   end
 
   describe '#redirect_uri' do
-    it 'includes expires_in, id_token and state' do
-      expect(subject.redirect_uri).to include("#{pre_auth.redirect_uri}#expires_in=#{auth.token.expires_in_seconds}&" \
-        "state=#{pre_auth.state}&" \
+    it 'includes id_token and state' do
+      expect(subject.redirect_uri).to include("#{pre_auth.redirect_uri}#state=#{pre_auth.state}&" \
         "id_token=#{id_token.as_jws_token}")
     end
 
     it 'does not include access_token' do
       expect(subject.redirect_uri).not_to include('access_token')
+    end
+
+    it 'does not include expires_in' do
+      expect(subject.redirect_uri).not_to include('expires_in')
     end
   end
 end

--- a/spec/lib/oauth/id_token_token_response_spec.rb
+++ b/spec/lib/oauth/id_token_token_response_spec.rb
@@ -36,21 +36,22 @@ describe Doorkeeper::OAuth::IdTokenTokenResponse do
   describe '#body' do
     it 'return body response for id_token and access_token' do
       expect(subject.body).to eq({
-        expires_in: auth.token.expires_in_seconds,
         state: pre_auth.state,
         id_token: id_token.as_jws_token,
         access_token: auth.token.token,
-        token_type: auth.token.token_type
+        token_type: auth.token.token_type,
+        expires_in: auth.token.expires_in_seconds
       })
     end
   end
 
   describe '#redirect_uri' do
     it 'includes id_token, info of access_token and state' do
-      expect(subject.redirect_uri).to include("#{pre_auth.redirect_uri}#expires_in=#{auth.token.expires_in_seconds}&" \
-        "state=#{pre_auth.state}&" \
+      expect(subject.redirect_uri).to include("#{pre_auth.redirect_uri}#state=#{pre_auth.state}&" \
         "id_token=#{id_token.as_jws_token}&" \
-        "access_token=#{auth.token.token}&token_type=#{auth.token.token_type}")
+        "access_token=#{auth.token.token}&" \
+        "token_type=#{auth.token.token_type}&" \
+        "expires_in=#{auth.token.expires_in_seconds}")
     end
   end
 end


### PR DESCRIPTION
[OpenID Connect Core 1.0 §3.2.2.5](https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthResponse) defines the response parameters for the Implicit Flow. `expires_in` is defined as the expiration time of the **Access Token** in seconds.

When `response_type=id_token` (the pure ID Token response), no access token is returned — the existing spec (`id_token_response_spec.rb`) already verifies that `access_token` is excluded. However, `expires_in` is still included in the response body:

```ruby
# lib/doorkeeper/oauth/id_token_response.rb
def body
  {
    expires_in: auth.token.expires_in_seconds,  # ← no access_token in this response
    state: pre_auth.state,
    id_token: id_token.as_jws_token
  }
end
```

Including `expires_in` without an accompanying `access_token` is misleading — a client could misinterpret it as the ID Token's lifetime. (The authoritative value for the ID Token's lifetime is the `exp` claim inside the token itself, per OIDC Core §2.)

### Fix

Move `expires_in` from `IdTokenResponse#body` into `IdTokenTokenResponse#body`, where an access token **is** returned. The pure `id_token` response now carries only `state` and `id_token`.

### Backward compatibility

This is technically a **breaking change** to the `response_type=id_token` response shape: the `expires_in` parameter is no longer present.

However:
- `expires_in` in this response was always meaningless per the spec (it represents the Access Token lifetime, and no `access_token` is returned).
- The `response_type=id_token token` response is unaffected — `expires_in` is still returned there, where it is semantically correct.
- Clients that were (incorrectly) using this value as the ID Token lifetime should switch to the `exp` claim inside the ID Token itself, which is the authoritative value per OIDC Core §2.

### Tests

- Updated `id_token_response_spec.rb`: body and redirect_uri expectations no longer include `expires_in`, plus explicit negative assertions.
- Updated `id_token_token_response_spec.rb`: body and redirect_uri expectations now include `expires_in` via `super.merge(...)` in `IdTokenTokenResponse#body`.

Closes #253 