### PR TITLE
Accept non-callable values for the `protocol` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#248] Fix `max_age` always triggering reauthentication when `auth_time_from_resource_owner` returns Integer
 - [#254] **Breaking:** Omit `expires_in` from the `response_type=id_token` response (OIDC Core §3.2.2.5 — `expires_in` represents the Access Token lifetime; it is still returned for `response_type=id_token token`)
 - [#252] Treat `auth_time_from_resource_owner` as optional in `IdToken` — omit `auth_time` claim when unconfigured instead of raising `InvalidConfiguration`
+- [#256] Accept non-callable values (symbol / string) for the `protocol` config option, matching the pattern used by `issuer` / `signing_algorithm` / `signing_key` / `expiration`
 
 ## v1.9.0 (2026-03-16)
 

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -116,7 +116,8 @@ module Doorkeeper
       end
 
       def protocol
-        Doorkeeper::OpenidConnect.configuration.protocol.call
+        configured = Doorkeeper::OpenidConnect.configuration.protocol
+        configured.respond_to?(:call) ? configured.call : configured
       end
 
       def discovery_url_options

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -270,6 +270,32 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       expect(data['authorization_endpoint']).to eq 'testing://test.host/oauth/authorize'
     end
 
+    context 'when the protocol option is configured with a non-callable value' do
+      it 'accepts a symbol' do
+        Doorkeeper::OpenidConnect.configure do
+          protocol :testing
+        end
+
+        get :provider
+        data = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:ok)
+        expect(data['authorization_endpoint']).to eq 'testing://test.host/oauth/authorize'
+      end
+
+      it 'accepts a string' do
+        Doorkeeper::OpenidConnect.configure do
+          protocol 'testing'
+        end
+
+        get :provider
+        data = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:ok)
+        expect(data['authorization_endpoint']).to eq 'testing://test.host/oauth/authorize'
+      end
+    end
+
     context 'when the discovery_url_options option is set for all endpoints' do
       before do
         Doorkeeper::OpenidConnect.configure do


### PR DESCRIPTION
Other configuration options (`issuer`, `signing_algorithm`, `signing_key`, `expiration`) accept either a plain value or a callable (block/lambda) and resolve the two shapes with a `respond_to?(:call)` check. For example, `issuer` can be configured as:

```ruby
issuer 'https://example.com'
# or
issuer { |resource_owner, application| "https://#{application.name}.example.com" }
```

The `protocol` option is inconsistent — `DiscoveryController#protocol` calls `.call` unconditionally:

```ruby
def protocol
  Doorkeeper::OpenidConnect.configuration.protocol.call
end
```

Configuring `protocol :https` (a symbol) or `protocol 'https'` (a string) produces a `NoMethodError` at request time.

### Fix

Guard with `respond_to?(:call)`, matching the pattern used by other options:

```ruby
def protocol
  configured = Doorkeeper::OpenidConnect.configuration.protocol
  configured.respond_to?(:call) ? configured.call : configured
end
```

### Tests

Added specs for both symbol and string values to `discovery_controller_spec.rb`.

Closes #255 