### PR TITLE
Skip IdToken construction on password grants without `openid` scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#254] **Breaking:** Omit `expires_in` from the `response_type=id_token` response (OIDC Core §3.2.2.5 — `expires_in` represents the Access Token lifetime; it is still returned for `response_type=id_token token`)
 - [#252] Treat `auth_time_from_resource_owner` as optional in `IdToken` — omit `auth_time` claim when unconfigured instead of raising `InvalidConfiguration`
 - [#256] Accept non-callable values (symbol / string) for the `protocol` config option, matching the pattern used by `issuer` / `signing_algorithm` / `signing_key` / `expiration`
+- [#258] Skip `IdToken` construction on password grants without the `openid` scope
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
@@ -21,8 +21,10 @@ module Doorkeeper
         private
 
         def after_successful_response
-          id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
-          @response.id_token = id_token
+          if access_token.includes_scope?('openid')
+            id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
+            @response.id_token = id_token
+          end
           super
         end
       end

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -13,7 +13,7 @@ describe Doorkeeper::OpenidConnect::OAuth::PasswordAccessTokenRequest do
   let(:client) { double }
   let(:credentials) { }
   let(:resource_owner) { create :user }
-  let(:token) { create :access_token }
+  let(:token) { create :access_token, scopes: 'openid' }
   let(:response) { Doorkeeper::OAuth::TokenResponse.new token }
 
   describe '#initialize' do
@@ -23,13 +23,28 @@ describe Doorkeeper::OpenidConnect::OAuth::PasswordAccessTokenRequest do
   end
 
   describe '#after_successful_response' do
-    it 'adds the ID token to the response' do
+    it 'adds the ID token to the response when the openid scope is granted' do
       subject.instance_variable_set '@response', response
       subject.instance_variable_set '@access_token', token
       subject.send :after_successful_response
 
       expect(response.id_token).to be_a Doorkeeper::OpenidConnect::IdToken
       expect(response.id_token.nonce).to eq '123456'
+    end
+
+    context 'when the access token does not include the openid scope' do
+      let(:token) { create :access_token, scopes: 'public' }
+
+      it 'does not build an ID token' do
+        subject.instance_variable_set '@response', response
+        subject.instance_variable_set '@access_token', token
+
+        expect(Doorkeeper::OpenidConnect::IdToken).not_to receive(:new)
+
+        subject.send :after_successful_response
+
+        expect(response.id_token).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
`PasswordAccessTokenRequest#after_successful_response` unconditionally instantiates `Doorkeeper::OpenidConnect::IdToken` for every password grant:

```ruby
def after_successful_response
  id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
  @response.id_token = id_token
  super
end
```

`IdToken#initialize` eagerly invokes `resource_owner_from_access_token`, so non-OIDC password grants (without the `openid` scope) pay for the resource owner lookup on every request. If `resource_owner_from_access_token` is not configured at all, the request fails outright.

Note that `TokenResponse#body` already checks `token.includes_scope?('openid')` before serializing the `id_token` — but the object is still constructed regardless.

### Fix

Guard the `IdToken` construction with the same scope check used in `TokenResponse#body`:

```ruby
def after_successful_response
  if access_token.includes_scope?('openid')
    id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
    @response.id_token = id_token
  end
  super
end
```

The original code used `access_token.scopes.exists?('openid')` — this also works (`Doorkeeper::OAuth::Scopes#exists?` is a PORO method, not an ActiveRecord query), but `includes_scope?` is used here for consistency with `TokenResponse#body`. In fact, `includes_scope?` [delegates to `scopes.exists?` internally](https://github.com/doorkeeper-gem/doorkeeper/blob/88aea0f7080eb6699cf80f9de57938b44eb28235/lib/doorkeeper/models/concerns/scopes.rb#L23), so the behavior is identical.

### Note

- `AuthorizationCodeRequest` has the same pattern (unconditional `IdToken.new`). That will be addressed in a follow-up PR to keep this change small and focused.

### Tests

- Existing test updated to explicitly set `scopes: 'openid'` on the access token. (The previous test passed without it because `IdToken.new` was invoked regardless of scope; with the guard, the fixture must explicitly grant `openid` to exercise the same code path.)
- New context for non-openid scope verifying `IdToken` is not instantiated and `response.id_token` is `nil`.

Closes #257 