### PR TITLE
Skip IdToken construction on authorization code grants without `openid` scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#252] Treat `auth_time_from_resource_owner` as optional in `IdToken` — omit `auth_time` claim when unconfigured instead of raising `InvalidConfiguration`
 - [#256] Accept non-callable values (symbol / string) for the `protocol` config option, matching the pattern used by `issuer` / `signing_algorithm` / `signing_key` / `expiration`
 - [#258] Skip `IdToken` construction on password grants without the `openid` scope
+- [#259] Skip `IdToken` construction on authorization code grants without the `openid` scope
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/authorization_code_request.rb
@@ -9,11 +9,11 @@ module Doorkeeper
         def after_successful_response
           super
 
-          nonce =
-            if (openid_request = grant.openid_request)
-              openid_request.destroy!
-              openid_request.nonce
-            end
+          openid_request = grant.openid_request
+          nonce = openid_request&.nonce
+          openid_request&.destroy!
+
+          return unless access_token.includes_scope?('openid')
 
           id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
           @response.id_token = id_token

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -14,12 +14,12 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
   let(:client) { double }
   let(:grant) { create :access_grant, openid_request: openid_request }
   let(:openid_request) { create :openid_request, nonce: '123456' }
-  let(:token) { create :access_token }
+  let(:token) { create :access_token, scopes: 'openid' }
   let(:response) { Doorkeeper::OAuth::TokenResponse.new token }
   let(:openid_request_class) { Doorkeeper::OpenidConnect.configuration.open_id_request_model }
 
   describe '#after_successful_response' do
-    it 'adds the ID token to the response' do
+    it 'adds the ID token to the response when the openid scope is granted' do
       subject.send :after_successful_response
 
       expect(response.id_token).to be_a Doorkeeper::OpenidConnect::IdToken
@@ -39,6 +39,39 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
       subject.send :after_successful_response
 
       expect(response.id_token.nonce).to be_nil
+    end
+
+    context 'when the access token does not include the openid scope' do
+      let(:token) { create :access_token, scopes: 'public' }
+      let(:grant) { create :access_grant, openid_request: nil }
+
+      it 'does not build an ID token' do
+        expect(Doorkeeper::OpenidConnect::IdToken).not_to receive(:new)
+
+        subject.send :after_successful_response
+
+        expect(response.id_token).to be_nil
+      end
+    end
+
+    context 'when the grant has an OpenID request but the token lacks the openid scope' do
+      let(:token) { create :access_token, scopes: 'public' }
+
+      it 'destroys the OpenID request record' do
+        grant.save!
+
+        expect do
+          subject.send :after_successful_response
+        end.to change { openid_request_class.count }.by(-1)
+      end
+
+      it 'does not build an ID token' do
+        expect(Doorkeeper::OpenidConnect::IdToken).not_to receive(:new)
+
+        subject.send :after_successful_response
+
+        expect(response.id_token).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Follow-up to #258, as [noted there](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/258#issue-4328313640).

`AuthorizationCodeRequest#after_successful_response` unconditionally instantiates `Doorkeeper::OpenidConnect::IdToken` for every authorization code exchange:

```ruby
def after_successful_response
  super

  nonce =
    if (openid_request = grant.openid_request)
      openid_request.destroy!
      openid_request.nonce
    end

  id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
  @response.id_token = id_token
end
```

`IdToken#initialize` eagerly invokes `resource_owner_from_access_token`, so non-OIDC authorization code exchanges (without the `openid` scope) pay for the resource owner lookup on every request. If `resource_owner_from_access_token` is not configured at all, the request fails outright.

Note that `TokenResponse#body` already checks `token.includes_scope?('openid')` before serializing the `id_token` — but the object is still constructed regardless.

### Fix

Guard the `IdToken` construction with the same scope check used in `TokenResponse#body` (identical approach to #258):

```ruby
def after_successful_response
  super

  if access_token.includes_scope?('openid')
    nonce =
      if (openid_request = grant.openid_request)
        openid_request.destroy!
        openid_request.nonce
      end

    id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
    @response.id_token = id_token
  end
end
```

### Tests

* Existing test updated to explicitly set `scopes: 'openid'` on the access token. (The previous test passed without it because `IdToken.new` was invoked regardless of scope; with the guard, the fixture must explicitly grant `openid` to exercise the same code path.)
* New context for non-openid scope verifying `IdToken` is not instantiated and `response.id_token` is `nil`.

Closes #259 