### PR TITLE
Fix obsolete RuboCop RSpec configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from: .rubocop_todo.yml
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
@@ -61,11 +61,11 @@ RSpec/DescribeClass:
   Enabled: false
 RSpec/ExampleLength:
   Enabled: false
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
+  Enabled: false
+RSpec/SpecFilePathSuffix:
   Enabled: false
 RSpec/MultipleExpectations:
   Enabled: false
 RSpec/NestedGroups:
-  Enabled: false
-Capybara/FeatureMethods:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#256] Accept non-callable values (symbol / string) for the `protocol` config option, matching the pattern used by `issuer` / `signing_algorithm` / `signing_key` / `expiration`
 - [#258] Skip `IdToken` construction on password grants without the `openid` scope
 - [#259] Skip `IdToken` construction on authorization code grants without the `openid` scope
+- [#261] Fix obsolete RuboCop configuration (`require:` → `plugins:`, `RSpec/FilePath` split, remove `Capybara/FeatureMethods`)
 
 ## v1.9.0 (2026-03-16)
 


### PR DESCRIPTION
`bundle exec rubocop` currently fails due to outdated settings in `.rubocop.yml`:

1. `require:` → `plugins:`
   (rubocop-rspec now uses the plugin system)

2. `RSpec/FilePath` → `RSpec/SpecFilePathFormat` + `RSpec/SpecFilePathSuffix`
   (the cop was split and the old name is no longer recognized)

3. Remove `Capybara/FeatureMethods`
   (moved to rubocop-capybara, which is not in the Gemfile)

After this change, `bundle exec rubocop` runs without configuration errors.