### PR TITLE
Determine client confidentiality from `token_endpoint_auth_method` in dynamic registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#258] Skip `IdToken` construction on password grants without the `openid` scope
 - [#259] Skip `IdToken` construction on authorization code grants without the `openid` scope
 - [#261] Fix obsolete RuboCop configuration (`require:` → `plugins:`, `RSpec/FilePath` split, remove `Capybara/FeatureMethods`)
+- [#262] **Breaking:** Determine client confidentiality from `token_endpoint_auth_method` in dynamic registration — previously all clients were registered as public (`confidential: false`); now defaults to confidential (`client_secret_basic`) per RFC 7591 §2. Also renames response field from `token_endpoint_auth_methods_supported` to `token_endpoint_auth_method` per RFC 7591 §3.2.1 (fixes #249). Derive supported auth methods from `Doorkeeper.configuration.client_credentials_methods` via shared `TokenEndpointAuthMethodsMixin`, keeping discovery and registration in sync.
 
 ## v1.9.0 (2026-03-16)
 

--- a/app/controllers/concerns/doorkeeper/openid_connect/token_endpoint_auth_methods_mixin.rb
+++ b/app/controllers/concerns/doorkeeper/openid_connect/token_endpoint_auth_methods_mixin.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OpenidConnect
+    module TokenEndpointAuthMethodsMixin
+      private
+
+      # Maps Doorkeeper's client_credentials configuration to OIDC auth method names.
+      # Shared by DiscoveryController and DynamicClientRegistrationController
+      # to keep advertised and accepted auth methods in sync.
+      AUTH_METHOD_MAPPING = {
+        from_basic: 'client_secret_basic',
+        from_params: 'client_secret_post',
+      }.freeze
+
+      def token_endpoint_auth_methods_supported(doorkeeper = ::Doorkeeper.configuration)
+        doorkeeper.client_credentials_methods.filter_map { |method| AUTH_METHOD_MAPPING[method] }
+      end
+    end
+  end
+end

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -5,6 +5,7 @@ module Doorkeeper
     class DiscoveryController < ::Doorkeeper::ApplicationMetalController
       include Doorkeeper::Helpers::Controller
       include GrantTypesSupportedMixin
+      include TokenEndpointAuthMethodsMixin
 
       WEBFINGER_RELATION = 'http://openid.net/specs/connect/1.0/issuer'
 
@@ -77,11 +78,6 @@ module Doorkeeper
 
       def response_modes_supported(doorkeeper)
         doorkeeper.authorization_response_flows.flat_map(&:response_mode_matches).uniq
-      end
-
-      def token_endpoint_auth_methods_supported(doorkeeper)
-        mapping = { from_basic: 'client_secret_basic', from_params: 'client_secret_post' }
-        doorkeeper.client_credentials_methods.filter_map { |method| mapping[method] }
       end
 
       def code_challenge_methods_supported(doorkeeper)

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -4,8 +4,19 @@ module Doorkeeper
   module OpenidConnect
     class DynamicClientRegistrationController < ::Doorkeeper::ApplicationMetalController
       include GrantTypesSupportedMixin
+      include TokenEndpointAuthMethodsMixin
 
       def register
+        unless valid_token_endpoint_auth_method?
+          supported = token_endpoint_auth_methods_supported + ["none"]
+          render json: {
+            error: "invalid_client_metadata",
+            error_description: "token_endpoint_auth_method '#{requested_token_endpoint_auth_method}' is not supported. " \
+                               "Supported methods are: #{supported.join(', ')}",
+          }, status: :bad_request
+          return
+        end
+
         client = Doorkeeper::Application.create!(application_params)
         render json: registration_response(client), status: :created
       rescue ActiveRecord::RecordInvalid => e
@@ -20,24 +31,45 @@ module Doorkeeper
           name: params.dig(:client_name),
           redirect_uri: params.dig(:redirect_uris) || [],
           scopes: params.dig(:scope),
-          confidential: false,
+          confidential: confidential?,
         }
+      end
+
+      def requested_token_endpoint_auth_method
+        params[:token_endpoint_auth_method] || "client_secret_basic"
+      end
+
+      def confidential?
+        requested_token_endpoint_auth_method != "none"
+      end
+
+      def valid_token_endpoint_auth_method?
+        auth_method = params[:token_endpoint_auth_method]
+        return true if auth_method.blank?
+
+        supported = token_endpoint_auth_methods_supported + ["none"]
+        supported.include?(auth_method)
       end
 
       def registration_response(doorkeeper_application)
         doorkeeper_config = ::Doorkeeper.configuration
 
-        {
-          client_secret: doorkeeper_application.plaintext_secret || doorkeeper_application.secret,
+        response = {
           client_id: doorkeeper_application.uid,
           client_id_issued_at: doorkeeper_application.created_at.to_i,
           redirect_uris: doorkeeper_application.redirect_uri.split,
-          token_endpoint_auth_methods_supported: %w[client_secret_basic client_secret_post],
+          token_endpoint_auth_method: requested_token_endpoint_auth_method,
           response_types: doorkeeper_config.authorization_response_types,
           grant_types: grant_types_supported(doorkeeper_config),
           scope: doorkeeper_application.scopes.to_s,
-          application_type: "web"
+          application_type: "web",
         }
+
+        if confidential?
+          response[:client_secret] = doorkeeper_application.plaintext_secret || doorkeeper_application.secret
+        end
+
+        response
       end
     end
   end

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -3,6 +3,13 @@
 require 'rails_helper'
 
 describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :controller do
+  let(:redirect_uris) do
+    [
+      'https://test.host/registration_success',
+      'https://test.host/registration_success_second_location',
+    ]
+  end
+
   before do
     Doorkeeper::OpenidConnect.configure do
       issuer "dummy"
@@ -13,50 +20,170 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
   end
 
   describe "#register" do
-    it "creates a Doorkeeper::Application" do
-      redirect_uris = [
-        'https://test.host/registration_success',
-        'https://test.host/registration_success_second_location',
-      ]
+    context "without token_endpoint_auth_method (defaults to client_secret_basic)" do
+      it "creates a confidential Doorkeeper::Application" do
+        post :register, params: {
+          client_name: "dummy_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+        }
 
-      post :register, params: {
-        client_name: "dummy_client",
-        redirect_uris: redirect_uris,
-        scope: "public"
-      }
+        expect(response.status).to eq 201
+        expect(Doorkeeper::Application.count).to eq(1)
 
-      expect(response.status).to eq 201
-      expect(Doorkeeper::Application.count).to eq(1)
+        doorkeeper_application = Doorkeeper::Application.first
+        expect(doorkeeper_application.confidential).to be true
 
-      doorkeeper_application = Doorkeeper::Application.first
-      expect(JSON.parse(response.body)).to eq({
-        'client_secret' => doorkeeper_application.plaintext_secret || doorkeeper_application.secret,
-        'client_id' => doorkeeper_application.uid,
-        'client_id_issued_at' => doorkeeper_application.created_at.to_i,
-        'redirect_uris' => redirect_uris,
-        'token_endpoint_auth_methods_supported' => %w[client_secret_basic client_secret_post],
-        'response_types' => ['code', 'token', 'id_token', 'id_token token'],
-        'grant_types' => %w[authorization_code client_credentials implicit_oidc],
-        'scope' => "public",
-        'application_type' => "web"
-      })
+        body = JSON.parse(response.body)
+        expect(body).to eq({
+          'client_secret' => doorkeeper_application.plaintext_secret || doorkeeper_application.secret,
+          'client_id' => doorkeeper_application.uid,
+          'client_id_issued_at' => doorkeeper_application.created_at.to_i,
+          'redirect_uris' => redirect_uris,
+          'token_endpoint_auth_method' => 'client_secret_basic',
+          'response_types' => ['code', 'token', 'id_token', 'id_token token'],
+          'grant_types' => %w[authorization_code client_credentials implicit_oidc],
+          'scope' => "public",
+          'application_type' => "web",
+        })
+      end
     end
 
-    it "errors and returns errors" do
-      post :register, params: {
-        client_name: "dummy_client",
-        redirect_uris: [
-          'http://test.host/registration_success',
-        ],
-        scopes: "openid"
-      }
+    context "with token_endpoint_auth_method 'client_secret_basic'" do
+      it "creates a confidential Doorkeeper::Application" do
+        post :register, params: {
+          client_name: "basic_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          token_endpoint_auth_method: "client_secret_basic",
+        }
 
-      expect(response.status).to eq 400
-      expect(Doorkeeper::Application.count).to eq(0)
-      expect(JSON.parse(response.body)).to eq({
-        "error" => "invalid_client_params",
-        "error_description" => "Redirect URI must be an HTTPS/SSL URI."
-      })
+        expect(response.status).to eq 201
+
+        doorkeeper_application = Doorkeeper::Application.first
+        expect(doorkeeper_application.confidential).to be true
+
+        body = JSON.parse(response.body)
+        expect(body['token_endpoint_auth_method']).to eq('client_secret_basic')
+        expect(body['client_secret']).to be_present
+      end
+    end
+
+    context "with token_endpoint_auth_method 'client_secret_post'" do
+      it "creates a confidential Doorkeeper::Application" do
+        post :register, params: {
+          client_name: "post_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          token_endpoint_auth_method: "client_secret_post",
+        }
+
+        expect(response.status).to eq 201
+
+        doorkeeper_application = Doorkeeper::Application.first
+        expect(doorkeeper_application.confidential).to be true
+
+        body = JSON.parse(response.body)
+        expect(body['token_endpoint_auth_method']).to eq('client_secret_post')
+        expect(body['client_secret']).to be_present
+      end
+    end
+
+    context "with token_endpoint_auth_method 'none'" do
+      it "creates a public Doorkeeper::Application without client_secret" do
+        post :register, params: {
+          client_name: "public_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          token_endpoint_auth_method: "none",
+        }
+
+        expect(response.status).to eq 201
+
+        doorkeeper_application = Doorkeeper::Application.first
+        expect(doorkeeper_application.confidential).to be false
+
+        body = JSON.parse(response.body)
+        expect(body['token_endpoint_auth_method']).to eq('none')
+        expect(body).not_to have_key('client_secret')
+      end
+    end
+
+    context "with unsupported token_endpoint_auth_method" do
+      it "returns an error" do
+        post :register, params: {
+          client_name: "jwt_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          token_endpoint_auth_method: "private_key_jwt",
+        }
+
+        expect(response.status).to eq 400
+        expect(Doorkeeper::Application.count).to eq(0)
+
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq('invalid_client_metadata')
+        expect(body['error_description']).to include('private_key_jwt')
+      end
+    end
+
+    context "when Doorkeeper client_credentials is restricted to :from_basic" do
+      before do
+        Doorkeeper.configure do
+          client_credentials :from_basic
+        end
+        Rails.application.reload_routes!
+      end
+
+      it "accepts client_secret_basic" do
+        post :register, params: {
+          client_name: 'restricted_basic_client',
+          redirect_uris: ['https://example.com/callback'],
+          token_endpoint_auth_method: 'client_secret_basic',
+        }
+        expect(response).to have_http_status(:created)
+      end
+
+      it "rejects client_secret_post" do
+        post :register, params: {
+          client_name: 'restricted_post_client',
+          redirect_uris: ['https://example.com/callback'],
+          token_endpoint_auth_method: 'client_secret_post',
+        }
+        expect(response).to have_http_status(:bad_request)
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq('invalid_client_metadata')
+      end
+
+      it "still accepts none for public clients" do
+        post :register, params: {
+          client_name: 'restricted_public_client',
+          redirect_uris: ['https://example.com/callback'],
+          token_endpoint_auth_method: 'none',
+        }
+        expect(response).to have_http_status(:created)
+        body = JSON.parse(response.body)
+        expect(body['token_endpoint_auth_method']).to eq('none')
+      end
+    end
+
+    context "with invalid redirect_uris" do
+      it "returns an error" do
+        post :register, params: {
+          client_name: "dummy_client",
+          redirect_uris: [
+            'http://test.host/registration_success',
+          ],
+          scope: "openid",
+        }
+
+        expect(response.status).to eq 400
+        expect(Doorkeeper::Application.count).to eq(0)
+        expect(JSON.parse(response.body)).to eq({
+          "error" => "invalid_client_params",
+          "error_description" => "Redirect URI must be an HTTPS/SSL URI.",
+        })
+      end
     end
   end
 end


### PR DESCRIPTION
Refs #249 (point 1 — `confidential` hardcoded to `false`).

## Problem

The dynamic client registration endpoint hardcodes `confidential: false` for all registered clients. Per [RFC 7591 §2](https://datatracker.ietf.org/doc/html/rfc7591#section-2), the default `token_endpoint_auth_method` is `client_secret_basic`, which implies a **confidential** client. The current behavior creates a mismatch: the discovery response advertises `client_secret_basic`/`client_secret_post`, a `client_secret` is issued, but Doorkeeper does not actually require it at the token endpoint.

## Changes

**Controller:**

- Derive `confidential` from the client-requested `token_endpoint_auth_method` (`"none"` → public, otherwise → confidential). Defaults to `client_secret_basic` when omitted, matching RFC 7591 §2.
- Return `token_endpoint_auth_method` (singular) in the registration response instead of `token_endpoint_auth_methods_supported` (plural), aligning with [RFC 7591 §3.2.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1) which defines the per-client field as singular.
- Omit `client_secret` from the response when the client is public (`token_endpoint_auth_method: "none"`).
- Reject unsupported auth methods (e.g. `private_key_jwt`) with `invalid_client_metadata` / 400, per [RFC 7591 §3.2.2](https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.2).

**Tests:** expanded from 2 to 6 examples covering each supported auth method, the public client path, unsupported method rejection, and the existing redirect URI validation.

## ⚠️ Breaking changes

1. **Default confidentiality flipped:** Previously all dynamically registered clients were **public** (`confidential: false`). After this change, the default is **confidential** (`confidential: true`), matching RFC 7591. Clients that require public registration must now explicitly send `token_endpoint_auth_method: "none"`.

2. **Response field renamed:** The registration response previously returned `token_endpoint_auth_methods_supported` (plural). This is a discovery metadata field name ([OIDC Discovery §3](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata)); the per-client registration response should use `token_endpoint_auth_method` (singular) per [RFC 7591 §3.2.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1). Clients parsing the old field name will need to update.

## Note

`SUPPORTED_AUTH_METHODS` is currently a static constant. Ideally this should be derived from `Doorkeeper.configuration.client_credentials_methods` to stay consistent with the discovery endpoint ([`discovery_controller.rb:82–85`](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/master/app/controllers/doorkeeper/openid_connect/discovery_controller.rb#L82-L85)). I kept it simple for now and can align them in a follow-up if preferred.

## Out of scope

Points 2 (ignored client metadata parameters) and 3 (unauthenticated endpoint / Initial Access Token) from #249 are intentionally left for separate PRs to keep this change focused.
