### PR TITLE
Security: Determine client confidentiality from token_endpoint_auth_method per RFC 7591

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#258] Skip `IdToken` construction on password grants without the `openid` scope
 - [#259] Skip `IdToken` construction on authorization code grants without the `openid` scope
 - [#261] Fix obsolete RuboCop configuration (`require:` → `plugins:`, `RSpec/FilePath` split, remove `Capybara/FeatureMethods`)
+- [#263] **Security/Breaking:** Determine dynamically registered client's `confidential` flag from `token_endpoint_auth_method` per RFC 7591 — previously every dynamically registered client was created as public (`confidential: false`), which let callers authenticate with only `client_id` (`by_uid_and_secret(uid, nil)` bypass). Default is now `client_secret_basic` (confidential); `none` produces a public client; unsupported values (e.g. `private_key_jwt`) are rejected with `invalid_client_metadata`. Also derive `token_endpoint_auth_methods_supported` in the response from `Doorkeeper.configuration.client_credentials_methods` instead of a hardcoded list, matching #236
 
 ## v1.9.0 (2026-03-16)
 

--- a/app/controllers/concerns/doorkeeper/openid_connect/token_endpoint_auth_methods_supported_mixin.rb
+++ b/app/controllers/concerns/doorkeeper/openid_connect/token_endpoint_auth_methods_supported_mixin.rb
@@ -8,8 +8,8 @@ module Doorkeeper
         from_params: 'client_secret_post',
       }.freeze
 
-      def token_endpoint_auth_methods_supported(doorkeeper)
-        doorkeeper.client_credentials_methods.filter_map { |method| CLIENT_CREDENTIALS_METHOD_MAPPING[method] }
+      def token_endpoint_auth_methods_supported
+        ::Doorkeeper.config.client_credentials_methods.filter_map { |method| CLIENT_CREDENTIALS_METHOD_MAPPING[method] }
       end
     end
   end

--- a/app/controllers/concerns/doorkeeper/openid_connect/token_endpoint_auth_methods_supported_mixin.rb
+++ b/app/controllers/concerns/doorkeeper/openid_connect/token_endpoint_auth_methods_supported_mixin.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OpenidConnect
+    module TokenEndpointAuthMethodsSupportedMixin
+      CLIENT_CREDENTIALS_METHOD_MAPPING = {
+        from_basic: 'client_secret_basic',
+        from_params: 'client_secret_post',
+      }.freeze
+
+      def token_endpoint_auth_methods_supported(doorkeeper)
+        doorkeeper.client_credentials_methods.filter_map { |method| CLIENT_CREDENTIALS_METHOD_MAPPING[method] }
+      end
+    end
+  end
+end

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -48,7 +48,7 @@ module Doorkeeper
           # TODO: look into doorkeeper-jwt_assertion for these
           #  'client_secret_jwt',
           #  'private_key_jwt'
-          token_endpoint_auth_methods_supported: token_endpoint_auth_methods_supported(doorkeeper),
+          token_endpoint_auth_methods_supported: token_endpoint_auth_methods_supported,
 
           subject_types_supported: openid_connect.subject_types_supported,
 

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -5,6 +5,7 @@ module Doorkeeper
     class DiscoveryController < ::Doorkeeper::ApplicationMetalController
       include Doorkeeper::Helpers::Controller
       include GrantTypesSupportedMixin
+      include TokenEndpointAuthMethodsSupportedMixin
 
       WEBFINGER_RELATION = 'http://openid.net/specs/connect/1.0/issuer'
 
@@ -77,11 +78,6 @@ module Doorkeeper
 
       def response_modes_supported(doorkeeper)
         doorkeeper.authorization_response_flows.flat_map(&:response_mode_matches).uniq
-      end
-
-      def token_endpoint_auth_methods_supported(doorkeeper)
-        mapping = { from_basic: 'client_secret_basic', from_params: 'client_secret_post' }
-        doorkeeper.client_credentials_methods.filter_map { |method| mapping[method] }
       end
 
       def code_challenge_methods_supported(doorkeeper)

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -46,7 +46,7 @@ module Doorkeeper
       end
 
       def supported_auth_methods
-        token_endpoint_auth_methods_supported(::Doorkeeper.configuration) + [PUBLIC_CLIENT_AUTH_METHOD]
+        token_endpoint_auth_methods_supported + [PUBLIC_CLIENT_AUTH_METHOD]
       end
 
       def registration_response(doorkeeper_application)
@@ -57,7 +57,7 @@ module Doorkeeper
           client_id_issued_at: doorkeeper_application.created_at.to_i,
           redirect_uris: doorkeeper_application.redirect_uri.split,
           token_endpoint_auth_method: requested_auth_method,
-          token_endpoint_auth_methods_supported: token_endpoint_auth_methods_supported(doorkeeper_config),
+          token_endpoint_auth_methods_supported: token_endpoint_auth_methods_supported,
           response_types: doorkeeper_config.authorization_response_types,
           grant_types: grant_types_supported(doorkeeper_config),
           scope: doorkeeper_application.scopes.to_s,

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -4,8 +4,21 @@ module Doorkeeper
   module OpenidConnect
     class DynamicClientRegistrationController < ::Doorkeeper::ApplicationMetalController
       include GrantTypesSupportedMixin
+      include TokenEndpointAuthMethodsSupportedMixin
+
+      DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD = 'client_secret_basic'
+      PUBLIC_CLIENT_AUTH_METHOD = 'none'
 
       def register
+        unless supported_auth_methods.include?(requested_auth_method)
+          render json: {
+            error: 'invalid_client_metadata',
+            error_description: "token_endpoint_auth_method '#{requested_auth_method}' is not supported. " \
+                               "Supported methods: #{supported_auth_methods.join(', ')}",
+          }, status: :bad_request
+          return
+        end
+
         client = Doorkeeper::Application.create!(application_params)
         render json: registration_response(client), status: :created
       rescue ActiveRecord::RecordInvalid => e
@@ -20,24 +33,42 @@ module Doorkeeper
           name: params.dig(:client_name),
           redirect_uri: params.dig(:redirect_uris) || [],
           scopes: params.dig(:scope),
-          confidential: false,
+          confidential: confidential_client?,
         }
+      end
+
+      def requested_auth_method
+        params[:token_endpoint_auth_method].presence || DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD
+      end
+
+      def confidential_client?
+        requested_auth_method != PUBLIC_CLIENT_AUTH_METHOD
+      end
+
+      def supported_auth_methods
+        token_endpoint_auth_methods_supported(::Doorkeeper.configuration) + [PUBLIC_CLIENT_AUTH_METHOD]
       end
 
       def registration_response(doorkeeper_application)
         doorkeeper_config = ::Doorkeeper.configuration
 
-        {
-          client_secret: doorkeeper_application.plaintext_secret || doorkeeper_application.secret,
+        response = {
           client_id: doorkeeper_application.uid,
           client_id_issued_at: doorkeeper_application.created_at.to_i,
           redirect_uris: doorkeeper_application.redirect_uri.split,
-          token_endpoint_auth_methods_supported: %w[client_secret_basic client_secret_post],
+          token_endpoint_auth_method: requested_auth_method,
+          token_endpoint_auth_methods_supported: token_endpoint_auth_methods_supported(doorkeeper_config),
           response_types: doorkeeper_config.authorization_response_types,
           grant_types: grant_types_supported(doorkeeper_config),
           scope: doorkeeper_application.scopes.to_s,
-          application_type: "web"
+          application_type: 'web',
         }
+
+        if confidential_client?
+          response[:client_secret] = doorkeeper_application.plaintext_secret || doorkeeper_application.secret
+        end
+
+        response
       end
     end
   end

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -3,6 +3,13 @@
 require 'rails_helper'
 
 describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :controller do
+  let(:redirect_uris) do
+    [
+      'https://test.host/registration_success',
+      'https://test.host/registration_success_second_location',
+    ]
+  end
+
   before do
     Doorkeeper::OpenidConnect.configure do
       issuer "dummy"
@@ -13,50 +20,199 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
   end
 
   describe "#register" do
-    it "creates a Doorkeeper::Application" do
-      redirect_uris = [
-        'https://test.host/registration_success',
-        'https://test.host/registration_success_second_location',
-      ]
+    context "when token_endpoint_auth_method is omitted" do
+      it "defaults to client_secret_basic and creates a confidential client with a secret" do
+        post :register, params: {
+          client_name: "dummy_client",
+          redirect_uris: redirect_uris,
+          scope: "public"
+        }
 
-      post :register, params: {
-        client_name: "dummy_client",
-        redirect_uris: redirect_uris,
-        scope: "public"
-      }
+        expect(response.status).to eq 201
+        expect(Doorkeeper::Application.count).to eq(1)
 
-      expect(response.status).to eq 201
-      expect(Doorkeeper::Application.count).to eq(1)
+        doorkeeper_application = Doorkeeper::Application.first
+        expect(doorkeeper_application.confidential).to be true
 
-      doorkeeper_application = Doorkeeper::Application.first
-      expect(JSON.parse(response.body)).to eq({
-        'client_secret' => doorkeeper_application.plaintext_secret || doorkeeper_application.secret,
-        'client_id' => doorkeeper_application.uid,
-        'client_id_issued_at' => doorkeeper_application.created_at.to_i,
-        'redirect_uris' => redirect_uris,
-        'token_endpoint_auth_methods_supported' => %w[client_secret_basic client_secret_post],
-        'response_types' => ['code', 'token', 'id_token', 'id_token token'],
-        'grant_types' => %w[authorization_code client_credentials implicit_oidc],
-        'scope' => "public",
-        'application_type' => "web"
-      })
+        body = JSON.parse(response.body)
+        expect(body).to eq({
+          'client_secret' => doorkeeper_application.plaintext_secret || doorkeeper_application.secret,
+          'client_id' => doorkeeper_application.uid,
+          'client_id_issued_at' => doorkeeper_application.created_at.to_i,
+          'redirect_uris' => redirect_uris,
+          'token_endpoint_auth_method' => 'client_secret_basic',
+          'token_endpoint_auth_methods_supported' => %w[client_secret_basic client_secret_post],
+          'response_types' => ['code', 'token', 'id_token', 'id_token token'],
+          'grant_types' => %w[authorization_code client_credentials implicit_oidc],
+          'scope' => "public",
+          'application_type' => "web",
+        })
+      end
     end
 
-    it "errors and returns errors" do
-      post :register, params: {
-        client_name: "dummy_client",
-        redirect_uris: [
-          'http://test.host/registration_success',
-        ],
-        scopes: "openid"
-      }
+    context "when token_endpoint_auth_method is client_secret_basic" do
+      it "creates a confidential client with a secret" do
+        post :register, params: {
+          client_name: "basic_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          token_endpoint_auth_method: "client_secret_basic",
+        }
 
-      expect(response.status).to eq 400
-      expect(Doorkeeper::Application.count).to eq(0)
-      expect(JSON.parse(response.body)).to eq({
-        "error" => "invalid_client_params",
-        "error_description" => "Redirect URI must be an HTTPS/SSL URI."
-      })
+        expect(response.status).to eq 201
+
+        doorkeeper_application = Doorkeeper::Application.first
+        expect(doorkeeper_application.confidential).to be true
+
+        body = JSON.parse(response.body)
+        expect(body['token_endpoint_auth_method']).to eq('client_secret_basic')
+        expect(body['client_secret']).to be_present
+      end
+    end
+
+    context "when token_endpoint_auth_method is client_secret_post" do
+      it "creates a confidential client with a secret" do
+        post :register, params: {
+          client_name: "post_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          token_endpoint_auth_method: "client_secret_post",
+        }
+
+        expect(response.status).to eq 201
+
+        doorkeeper_application = Doorkeeper::Application.first
+        expect(doorkeeper_application.confidential).to be true
+
+        body = JSON.parse(response.body)
+        expect(body['token_endpoint_auth_method']).to eq('client_secret_post')
+        expect(body['client_secret']).to be_present
+      end
+    end
+
+    context "when token_endpoint_auth_method is none" do
+      it "creates a public client and omits client_secret from the response" do
+        post :register, params: {
+          client_name: "public_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          token_endpoint_auth_method: "none",
+        }
+
+        expect(response.status).to eq 201
+
+        doorkeeper_application = Doorkeeper::Application.first
+        expect(doorkeeper_application.confidential).to be false
+
+        body = JSON.parse(response.body)
+        expect(body['token_endpoint_auth_method']).to eq('none')
+        expect(body).not_to have_key('client_secret')
+      end
+    end
+
+    context "when token_endpoint_auth_method is private_key_jwt" do
+      it "rejects the request with invalid_client_metadata" do
+        post :register, params: {
+          client_name: "jwt_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          token_endpoint_auth_method: "private_key_jwt",
+        }
+
+        expect(response.status).to eq 400
+        expect(Doorkeeper::Application.count).to eq(0)
+
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq('invalid_client_metadata')
+        expect(body['error_description']).to include('private_key_jwt')
+      end
+    end
+
+    context "when token_endpoint_auth_method is an unknown value" do
+      it "rejects the request with invalid_client_metadata" do
+        post :register, params: {
+          client_name: "weird_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          token_endpoint_auth_method: "unknown_value",
+        }
+
+        expect(response.status).to eq 400
+        expect(Doorkeeper::Application.count).to eq(0)
+
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq('invalid_client_metadata')
+        expect(body['error_description']).to include('unknown_value')
+      end
+    end
+
+    context "token_endpoint_auth_methods_supported in the response" do
+      it "matches the server's configured client_credentials methods" do
+        Doorkeeper.configure do
+          orm :active_record
+          client_credentials :from_basic
+        end
+
+        post :register, params: {
+          client_name: "cfg_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+        }
+
+        expect(response.status).to eq 201
+        body = JSON.parse(response.body)
+        expect(body['token_endpoint_auth_methods_supported']).to eq(%w[client_secret_basic])
+      end
+    end
+
+    context "security regression: confidential client cannot bypass credentials" do
+      it "is not returned by by_uid_and_secret(uid, nil)" do
+        post :register, params: {
+          client_name: "secure_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+        }
+
+        expect(response.status).to eq 201
+        doorkeeper_application = Doorkeeper::Application.first
+        expect(doorkeeper_application.confidential).to be true
+
+        expect(Doorkeeper::Application.by_uid_and_secret(doorkeeper_application.uid, nil)).to be_nil
+      end
+
+      it "is returned by by_uid_and_secret(uid, nil) when token_endpoint_auth_method is none" do
+        post :register, params: {
+          client_name: "intentionally_public",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          token_endpoint_auth_method: "none",
+        }
+
+        expect(response.status).to eq 201
+        doorkeeper_application = Doorkeeper::Application.first
+        expect(doorkeeper_application.confidential).to be false
+
+        expect(Doorkeeper::Application.by_uid_and_secret(doorkeeper_application.uid, nil)).to eq(doorkeeper_application)
+      end
+    end
+
+    context "with invalid redirect_uris" do
+      it "errors and returns errors" do
+        post :register, params: {
+          client_name: "dummy_client",
+          redirect_uris: [
+            'http://test.host/registration_success',
+          ],
+          scope: "openid"
+        }
+
+        expect(response.status).to eq 400
+        expect(Doorkeeper::Application.count).to eq(0)
+        expect(JSON.parse(response.body)).to eq({
+          "error" => "invalid_client_params",
+          "error_description" => "Redirect URI must be an HTTPS/SSL URI."
+        })
+      end
     end
   end
 end


### PR DESCRIPTION
Follows up on the private disclosure discussion with @nbulaj (via email).

## Problem

`DynamicClientRegistrationController#register` hard-codes `confidential: false` for every dynamically registered client, yet the response includes a `client_secret` and advertises `client_secret_basic` / `client_secret_post`.

Because Doorkeeper's `Application.by_uid_and_secret` treats a blank/missing secret as valid for non-confidential clients, a caller who knows only the `client_id` can authenticate at the token endpoint — including obtaining tokens via `client_credentials` without any secret.

Dynamic Client Registration is opt-in (`default: false`), so only OPs that explicitly enable it are affected.

## Changes

As agreed, this PR implements RFC 7591 `token_endpoint_auth_method` handling:

1. Accept `token_endpoint_auth_method` from the registration request, defaulting to `client_secret_basic` (RFC 7591 §2)
2. `client_secret_basic` / `client_secret_post` → `confidential: true`, secret generated and returned
3. `none` → `confidential: false`, `client_secret` omitted from response
4. Unsupported values (e.g. `private_key_jwt`) → `invalid_client_metadata` error (RFC 7591 §3.2.2). Doorkeeper's `client_credentials_methods` only maps to `client_secret_basic` / `client_secret_post`, so the supported set is derived from that config plus `none`
5. Derive `token_endpoint_auth_methods_supported` in the registration response from `Doorkeeper.configuration.client_credentials_methods` instead of a hardcoded list — matching the Discovery endpoint fix in #236. The shared mapping is extracted into `TokenEndpointAuthMethodsSupportedMixin`

## Tests

10 specs (up from 2), covering:

- Default (omitted) → confidential + secret
- Explicit `client_secret_basic` / `client_secret_post` → confidential + secret
- `none` → public, no secret in response
- `private_key_jwt` / unknown value → `invalid_client_metadata` rejection
- `token_endpoint_auth_methods_supported` reflects server config
- **Security regression**: `by_uid_and_secret(uid, nil)` returns `nil` for confidential clients, confirming the credentials bypass is closed
- Invalid `redirect_uris` error handling (preserved from original spec)

All 222 examples pass (baseline was 214).

## Note

`oauth_applications.secret` has a `NOT NULL` constraint, so even public clients get a secret generated at the DB level. The controller simply omits it from the response. This is consistent with RFC 7591 and does not affect the security fix — `by_uid_and_secret` correctly bypasses secret checks only for `!app.confidential?`.