### PR TITLE
Apply safe RuboCop autocorrections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,10 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Exclude:
     - spec/dummy/db/**/*
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
 Style/FrozenStringLiteralComment:
   Enabled: true
 Style/SymbolArray:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#259] Skip `IdToken` construction on authorization code grants without the `openid` scope
 - [#261] Fix obsolete RuboCop configuration (`require:` → `plugins:`, `RSpec/FilePath` split, remove `Capybara/FeatureMethods`)
 - [#263] **Security/Breaking:** Determine dynamically registered client's `confidential` flag from `token_endpoint_auth_method` per RFC 7591 — previously every dynamically registered client was created as public (`confidential: false`), which let callers authenticate with only `client_id` (`by_uid_and_secret(uid, nil)` bypass). Default is now `client_secret_basic` (confidential); `none` produces a public client; unsupported values (e.g. `private_key_jwt`) are rejected with `invalid_client_metadata`. Also derive `token_endpoint_auth_methods_supported` in the response from `Doorkeeper.configuration.client_credentials_methods` instead of a hardcoded list, matching #236
+- [#264] Apply safe RuboCop autocorrections and fix resulting artifacts
 
 ## v1.9.0 (2026-03-16)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # use Rails version specified by environment
-ENV['rails'] ||= '8.0.0'
-gem 'rails', "~> #{ENV['rails']}"
-gem 'rails-controller-testing'
+ENV["rails"] ||= "8.0.0"
+gem "rails", "~> #{ENV["rails"]}"
+gem "rails-controller-testing"
 
-gem 'rubocop', '~> 1.6'
-gem 'rubocop-performance', require: false
-gem 'rubocop-rails', require: false
-gem 'rubocop-rspec', require: false
+gem "rubocop", "~> 1.6"
+gem "rubocop-performance", require: false
+gem "rubocop-rails", require: false
+gem "rubocop-rspec", require: false
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
-ENV['RAILS_ENV'] ||= 'test'
+ENV["RAILS_ENV"] ||= "test"
 
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new
 
 task default: :spec
 task test: :spec
 
-desc 'Generate and run migrations in the test application'
+desc "Generate and run migrations in the test application"
 task :migrate do
-  Dir.chdir('spec/dummy') do
-    system('bin/rails generate doorkeeper:openid_connect:migration')
-    system('bin/rake db:migrate')
+  Dir.chdir("spec/dummy") do
+    system("bin/rails generate doorkeeper:openid_connect:migration")
+    system("bin/rake db:migrate")
   end
 end
 
-desc 'Run server in the test application'
+desc "Run server in the test application"
 task :server do
-  Dir.chdir('spec/dummy') do
-    system('bin/rails server')
+  Dir.chdir("spec/dummy") do
+    system("bin/rails server")
   end
 end

--- a/app/controllers/concerns/doorkeeper/openid_connect/authorizations_extension.rb
+++ b/app/controllers/concerns/doorkeeper/openid_connect/authorizations_extension.rb
@@ -9,4 +9,3 @@ module Doorkeeper
     end
   end
 end
-

--- a/app/controllers/concerns/doorkeeper/openid_connect/grant_types_supported_mixin.rb
+++ b/app/controllers/concerns/doorkeeper/openid_connect/grant_types_supported_mixin.rb
@@ -5,7 +5,7 @@ module Doorkeeper
     module GrantTypesSupportedMixin
       def grant_types_supported(doorkeeper)
         grant_types_supported = doorkeeper.grant_flows.dup
-        grant_types_supported << 'refresh_token' if doorkeeper.refresh_token_enabled?
+        grant_types_supported << "refresh_token" if doorkeeper.refresh_token_enabled?
         grant_types_supported
       end
     end

--- a/app/controllers/concerns/doorkeeper/openid_connect/token_endpoint_auth_methods_supported_mixin.rb
+++ b/app/controllers/concerns/doorkeeper/openid_connect/token_endpoint_auth_methods_supported_mixin.rb
@@ -4,12 +4,14 @@ module Doorkeeper
   module OpenidConnect
     module TokenEndpointAuthMethodsSupportedMixin
       CLIENT_CREDENTIALS_METHOD_MAPPING = {
-        from_basic: 'client_secret_basic',
-        from_params: 'client_secret_post',
+        from_basic: "client_secret_basic",
+        from_params: "client_secret_post",
       }.freeze
 
       def token_endpoint_auth_methods_supported
-        ::Doorkeeper.config.client_credentials_methods.filter_map { |method| CLIENT_CREDENTIALS_METHOD_MAPPING[method] }
+        ::Doorkeeper.config.client_credentials_methods.filter_map do |method|
+          CLIENT_CREDENTIALS_METHOD_MAPPING[method]
+        end
       end
     end
   end

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -7,7 +7,7 @@ module Doorkeeper
       include GrantTypesSupportedMixin
       include TokenEndpointAuthMethodsSupportedMixin
 
-      WEBFINGER_RELATION = 'http://openid.net/specs/connect/1.0/issuer'
+      WEBFINGER_RELATION = "http://openid.net/specs/connect/1.0/issuer"
 
       def provider
         render json: provider_response
@@ -57,7 +57,7 @@ module Doorkeeper
           ],
 
           claim_types_supported: [
-            'normal',
+            "normal",
 
             # TODO: support these
             # 'aggregated',
@@ -104,7 +104,7 @@ module Doorkeeper
         {
           keys: [
             signing_key.merge(
-              use: 'sig',
+              use: "sig",
               alg: Doorkeeper::OpenidConnect.signing_algorithm
             )
           ]
@@ -130,7 +130,8 @@ module Doorkeeper
         Doorkeeper::OpenidConnect.resolve_issuer(request: request)
       end
 
-      %i[authorization token revocation introspection userinfo jwks dynamic_client_registration].each do |endpoint|
+      %i[authorization token revocation introspection userinfo jwks
+         dynamic_client_registration].each do |endpoint|
         define_method :"#{endpoint}_url_options" do
           discovery_url_default_options.merge(discovery_url_options[endpoint.to_sym] || {})
         end

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -6,15 +6,15 @@ module Doorkeeper
       include GrantTypesSupportedMixin
       include TokenEndpointAuthMethodsSupportedMixin
 
-      DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD = 'client_secret_basic'
-      PUBLIC_CLIENT_AUTH_METHOD = 'none'
+      DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD = "client_secret_basic"
+      PUBLIC_CLIENT_AUTH_METHOD = "none"
 
       def register
         unless supported_auth_methods.include?(requested_auth_method)
           render json: {
-            error: 'invalid_client_metadata',
+            error: "invalid_client_metadata",
             error_description: "token_endpoint_auth_method '#{requested_auth_method}' is not supported. " \
-                               "Supported methods: #{supported_auth_methods.join(', ')}",
+                               "Supported methods: #{supported_auth_methods.join(", ")}",
           }, status: :bad_request
           return
         end
@@ -61,11 +61,12 @@ module Doorkeeper
           response_types: doorkeeper_config.authorization_response_types,
           grant_types: grant_types_supported(doorkeeper_config),
           scope: doorkeeper_application.scopes.to_s,
-          application_type: 'web',
+          application_type: "web",
         }
 
         if confidential_client?
-          response[:client_secret] = doorkeeper_application.plaintext_secret || doorkeeper_application.secret
+          response[:client_secret] =
+            doorkeeper_application.plaintext_secret || doorkeeper_application.secret
         end
 
         response

--- a/bin/console
+++ b/bin/console
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler/setup'
+require "bundler/setup"
 Bundler.require :default
 
-require 'doorkeeper/openid_connect'
+require "doorkeeper/openid_connect"
 
-require 'pry'
+require "pry"
 Pry.start

--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path('lib', __dir__)
-require 'doorkeeper/openid_connect/version'
+$LOAD_PATH.push File.expand_path("lib", __dir__)
+require "doorkeeper/openid_connect/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'doorkeeper-openid_connect'
+  spec.name          = "doorkeeper-openid_connect"
   spec.version       = Doorkeeper::OpenidConnect::VERSION
-  spec.authors       = ['Sam Dengler', 'Markus Koller', 'Nikita Bulai']
-  spec.email         = ['sam.dengler@playonsports.com', 'markus-koller@gmx.ch', 'bulajnikita@gmail.com']
-  spec.homepage      = 'https://github.com/doorkeeper-gem/doorkeeper-openid_connect'
-  spec.summary       = 'OpenID Connect extension for Doorkeeper.'
-  spec.description   = 'OpenID Connect extension for Doorkeeper.'
-  spec.license       = 'MIT'
+  spec.authors       = ["Sam Dengler", "Markus Koller", "Nikita Bulai"]
+  spec.email         = ["sam.dengler@playonsports.com", "markus-koller@gmx.ch",
+                        "bulajnikita@gmail.com"]
+  spec.homepage      = "https://github.com/doorkeeper-gem/doorkeeper-openid_connect"
+  spec.summary       = "OpenID Connect extension for Doorkeeper."
+  spec.description   = "OpenID Connect extension for Doorkeeper."
+  spec.license       = "MIT"
 
   spec.metadata = {
     "homepage_uri" => "https://github.com/doorkeeper-gem/doorkeeper-openid_connect",
@@ -28,20 +29,20 @@ Gem::Specification.new do |spec|
     "README.md",
   ]
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = ">= 3.1"
 
-  spec.add_runtime_dependency 'doorkeeper', '>= 5.5', '< 6.0'
-  spec.add_runtime_dependency 'ostruct', '>= 0.5'
-  spec.add_runtime_dependency 'jwt', '>= 2.5'
+  spec.add_runtime_dependency "doorkeeper", ">= 5.5", "< 6.0"
+  spec.add_runtime_dependency "jwt", ">= 2.5"
+  spec.add_runtime_dependency "ostruct", ">= 0.5"
 
-  spec.add_development_dependency 'bigdecimal'
-  spec.add_development_dependency 'conventional-changelog', '~> 1.2'
-  spec.add_development_dependency 'drb'
-  spec.add_development_dependency 'factory_bot'
-  spec.add_development_dependency 'mutex_m'
-  spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rspec-rails'
-  spec.add_development_dependency 'sqlite3', '>= 1.3.6'
+  spec.add_development_dependency "bigdecimal"
+  spec.add_development_dependency "conventional-changelog", "~> 1.2"
+  spec.add_development_dependency "drb"
+  spec.add_development_dependency "factory_bot"
+  spec.add_development_dependency "mutex_m"
+  spec.add_development_dependency "pry-byebug"
+  spec.add_development_dependency "rspec-rails"
+  spec.add_development_dependency "sqlite3", ">= 1.3.6"
 end

--- a/gemfiles/doorkeeper_master.gemfile
+++ b/gemfiles/doorkeeper_master.gemfile
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', '~> 8.0.0'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 2.3', platform: %i[ruby mswin mingw x64_mingw]
-gem 'doorkeeper', git: 'https://github.com/doorkeeper-gem/doorkeeper.git'
+gem "doorkeeper", git: "https://github.com/doorkeeper-gem/doorkeeper.git"
+gem "rails", "~> 8.0.0"
+gem "rails-controller-testing"
+gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', '~> 7.0.0'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw x64_mingw]
 gem "concurrent-ruby", "1.3.4"
+gem "rails", "~> 7.0.0"
+gem "rails-controller-testing"
+gem "sqlite3", "~> 1.4", platform: %i[ruby mswin mingw x64_mingw]
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', '~> 7.1.0'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw x64_mingw]
+gem "rails", "~> 7.1.0"
+gem "rails-controller-testing"
+gem "sqlite3", "~> 1.4", platform: %i[ruby mswin mingw x64_mingw]
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', '~> 7.2.0'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw x64_mingw]
+gem "rails", "~> 7.2.0"
+gem "rails-controller-testing"
+gem "sqlite3", "~> 1.4", platform: %i[ruby mswin mingw x64_mingw]
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', '~> 8.0.0'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 2.3', platform: %i[ruby mswin mingw x64_mingw]
+gem "rails", "~> 8.0.0"
+gem "rails-controller-testing"
+gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
 
-gemspec path: '../'
+gemspec path: "../"

--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -1,57 +1,57 @@
 # frozen_string_literal: true
 
-require 'doorkeeper'
-require 'active_model'
-require 'jwt'
+require "doorkeeper"
+require "active_model"
+require "jwt"
 
-require 'doorkeeper/request'
-require 'doorkeeper/request/id_token'
-require 'doorkeeper/request/id_token_token'
-require 'doorkeeper/oauth/id_token_request'
-require 'doorkeeper/oauth/id_token_token_request'
-require 'doorkeeper/oauth/id_token_response'
-require 'doorkeeper/oauth/id_token_token_response'
+require "doorkeeper/request"
+require "doorkeeper/request/id_token"
+require "doorkeeper/request/id_token_token"
+require "doorkeeper/oauth/id_token_request"
+require "doorkeeper/oauth/id_token_token_request"
+require "doorkeeper/oauth/id_token_response"
+require "doorkeeper/oauth/id_token_token_response"
 
-require 'doorkeeper/openid_connect/claims_builder'
-require 'doorkeeper/openid_connect/claims/claim'
-require 'doorkeeper/openid_connect/claims/normal_claim'
-require 'doorkeeper/openid_connect/config'
-require 'doorkeeper/openid_connect/engine'
-require 'doorkeeper/openid_connect/errors'
-require 'doorkeeper/openid_connect/id_token'
-require 'doorkeeper/openid_connect/id_token_token'
-require 'doorkeeper/openid_connect/user_info'
-require 'doorkeeper/openid_connect/version'
+require "doorkeeper/openid_connect/claims_builder"
+require "doorkeeper/openid_connect/claims/claim"
+require "doorkeeper/openid_connect/claims/normal_claim"
+require "doorkeeper/openid_connect/config"
+require "doorkeeper/openid_connect/engine"
+require "doorkeeper/openid_connect/errors"
+require "doorkeeper/openid_connect/id_token"
+require "doorkeeper/openid_connect/id_token_token"
+require "doorkeeper/openid_connect/user_info"
+require "doorkeeper/openid_connect/version"
 
-require 'doorkeeper/openid_connect/helpers/controller'
+require "doorkeeper/openid_connect/helpers/controller"
 
-require 'doorkeeper/openid_connect/oauth/authorization/code'
-require 'doorkeeper/openid_connect/oauth/authorization_code_request'
-require 'doorkeeper/openid_connect/oauth/password_access_token_request'
-require 'doorkeeper/openid_connect/oauth/pre_authorization'
-require 'doorkeeper/openid_connect/oauth/token_response'
+require "doorkeeper/openid_connect/oauth/authorization/code"
+require "doorkeeper/openid_connect/oauth/authorization_code_request"
+require "doorkeeper/openid_connect/oauth/password_access_token_request"
+require "doorkeeper/openid_connect/oauth/pre_authorization"
+require "doorkeeper/openid_connect/oauth/token_response"
 
-require 'doorkeeper/openid_connect/orm/active_record'
+require "doorkeeper/openid_connect/orm/active_record"
 
-require 'doorkeeper/openid_connect/rails/routes'
+require "doorkeeper/openid_connect/rails/routes"
 
 module Doorkeeper
   module OpenidConnect
     def self.signing_algorithm
       algo = if configuration.signing_algorithm.respond_to?(:call)
-        configuration.signing_algorithm.call
-      else
-        configuration.signing_algorithm
-      end
+               configuration.signing_algorithm.call
+             else
+               configuration.signing_algorithm
+             end
       algo.to_s.upcase.to_sym
     end
 
     def self.signing_key
       key_value = if configuration.signing_key.respond_to?(:call)
-        configuration.signing_key.call
-      else
-        configuration.signing_key
-      end
+                    configuration.signing_key.call
+                  else
+                    configuration.signing_key
+                  end
 
       key =
         if %i[HS256 HS384 HS512].include?(signing_algorithm)
@@ -91,20 +91,20 @@ module Doorkeeper
 
     Doorkeeper::GrantFlow.register(
       :id_token,
-      response_type_matches: 'id_token',
+      response_type_matches: "id_token",
       response_mode_matches: %w[fragment form_post],
       response_type_strategy: Doorkeeper::Request::IdToken,
     )
 
     Doorkeeper::GrantFlow.register(
-      'id_token token',
-      response_type_matches: 'id_token token',
+      "id_token token",
+      response_type_matches: "id_token token",
       response_mode_matches: %w[fragment form_post],
       response_type_strategy: Doorkeeper::Request::IdTokenToken,
     )
 
     Doorkeeper::GrantFlow.register_alias(
-      'implicit_oidc', as: ['implicit', 'id_token', 'id_token token']
+      "implicit_oidc", as: ["implicit", "id_token", "id_token token"]
     )
   end
 end

--- a/lib/doorkeeper/openid_connect/claims_builder.rb
+++ b/lib/doorkeeper/openid_connect/claims_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ostruct'
+require "ostruct"
 
 module Doorkeeper
   module OpenidConnect

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -4,7 +4,8 @@ module Doorkeeper
   module OpenidConnect
     def self.configure(&block)
       if Doorkeeper.configuration.orm != :active_record
-        raise Errors::InvalidConfiguration, 'Doorkeeper OpenID Connect currently only supports the ActiveRecord ORM adapter'
+        raise Errors::InvalidConfiguration,
+"Doorkeeper OpenID Connect currently only supports the ActiveRecord ORM adapter"
       end
 
       @config = Config::Builder.new(&block).build
@@ -26,11 +27,11 @@ module Doorkeeper
         end
 
         def jws_public_key(*_args)
-          puts 'DEPRECATION WARNING: `jws_public_key` is not needed anymore and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb'
+          puts "DEPRECATION WARNING: `jws_public_key` is not needed anymore and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb"
         end
 
         def jws_private_key(*args)
-          puts 'DEPRECATION WARNING: `jws_private_key` has been replaced by `signing_key` and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb'
+          puts "DEPRECATION WARNING: `jws_private_key` has been replaced by `signing_key` and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb"
           signing_key(*args)
         end
       end
@@ -45,23 +46,23 @@ module Doorkeeper
       option :subject_types_supported, default: [:public]
 
       option :resource_owner_from_access_token, default: lambda { |*_|
-        raise Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.resource_owner_from_access_token_not_configured')
+        raise Errors::InvalidConfiguration, I18n.translate("doorkeeper.openid_connect.errors.messages.resource_owner_from_access_token_not_configured")
       }
 
       option :auth_time_from_resource_owner, default: lambda { |*_|
-        raise Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.auth_time_from_resource_owner_not_configured')
+        raise Errors::InvalidConfiguration, I18n.translate("doorkeeper.openid_connect.errors.messages.auth_time_from_resource_owner_not_configured")
       }
 
       option :reauthenticate_resource_owner, default: lambda { |*_|
-        raise Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.reauthenticate_resource_owner_not_configured')
+        raise Errors::InvalidConfiguration, I18n.translate("doorkeeper.openid_connect.errors.messages.reauthenticate_resource_owner_not_configured")
       }
 
       option :select_account_for_resource_owner, default: lambda { |*_|
-        raise Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.select_account_for_resource_owner_not_configured')
+        raise Errors::InvalidConfiguration, I18n.translate("doorkeeper.openid_connect.errors.messages.select_account_for_resource_owner_not_configured")
       }
 
       option :subject, default: lambda { |*_|
-        raise Errors::InvalidConfiguration, I18n.translate('doorkeeper.openid_connect.errors.messages.subject_not_configured')
+        raise Errors::InvalidConfiguration, I18n.translate("doorkeeper.openid_connect.errors.messages.subject_not_configured")
       }
 
       option :expiration, default: 120
@@ -82,7 +83,7 @@ module Doorkeeper
 
       option :dynamic_client_registration, default: false
 
-      option :open_id_request_class, default: 'Doorkeeper::OpenidConnect::Request'
+      option :open_id_request_class, default: "Doorkeeper::OpenidConnect::Request"
 
       # Doorkeeper OpenID Request model class.
       #

--- a/lib/doorkeeper/openid_connect/engine.rb
+++ b/lib/doorkeeper/openid_connect/engine.rb
@@ -3,7 +3,7 @@
 module Doorkeeper
   module OpenidConnect
     class Engine < ::Rails::Engine
-      initializer 'doorkeeper.openid_connect.routes' do
+      initializer "doorkeeper.openid_connect.routes" do
         Doorkeeper::OpenidConnect::Rails::Routes.install!
       end
 

--- a/lib/doorkeeper/openid_connect/errors.rb
+++ b/lib/doorkeeper/openid_connect/errors.rb
@@ -11,9 +11,10 @@ module Doorkeeper
 
       # internal errors
       class InvalidConfiguration < OpenidConnectError; end
+
       class MissingConfiguration < OpenidConnectError
         def initialize
-          super('Configuration for Doorkeeper OpenID Connect missing. Do you have doorkeeper_openid_connect initializer?')
+          super("Configuration for Doorkeeper OpenID Connect missing. Do you have doorkeeper_openid_connect initializer?")
         end
       end
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -26,9 +26,9 @@ module Doorkeeper
 
         def oidc_authorization_request?
           controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] &&
-            action_name == 'new' &&
+            action_name == "new" &&
             pre_auth.valid? &&
-            pre_auth.scopes.include?('openid')
+            pre_auth.scopes.include?("openid")
         end
 
         def handle_oidc_error!(exception)
@@ -67,27 +67,27 @@ module Doorkeeper
         def handle_oidc_prompt_param!(owner)
           prompt_values ||= params[:prompt].to_s.split(/ +/).uniq
 
-          priority = ['none', 'consent', 'login', 'select_account']
+          priority = %w[none consent login select_account]
           prompt_values.sort_by! do |prompt|
             priority.find_index(prompt).to_i
           end
 
           prompt_values.each do |prompt|
             case prompt
-            when 'none'
-              raise Errors::InvalidRequest if (prompt_values - ['none']).any?
+            when "none"
+              raise Errors::InvalidRequest if (prompt_values - ["none"]).any?
               raise Errors::LoginRequired unless owner
               raise Errors::ConsentRequired if oidc_consent_required?
-            when 'login'
+            when "login"
               reauthenticate_oidc_resource_owner(owner) if owner
-            when 'consent'
+            when "consent"
               if owner
                 clear_oidc_response
                 render :new
               end
-            when 'select_account'
+            when "select_account"
               select_account_for_oidc_resource_owner(owner)
-            when 'create'
+            when "create"
               # NOTE: not supported, but not raise error.
             else
               raise Errors::InvalidRequest
@@ -97,7 +97,7 @@ module Doorkeeper
 
         def handle_oidc_max_age_param!(owner)
           max_age = params[:max_age].to_i
-          return unless (params[:max_age].to_s == '0' || max_age > 0) && owner
+          return unless (params[:max_age].to_s == "0" || max_age > 0) && owner
 
           auth_time = instance_exec(
             owner,
@@ -114,16 +114,16 @@ module Doorkeeper
           # NOTE: clock skew
           max_age = [1, max_age].max
 
-          if !auth_time || (Time.zone.now - auth_time) > max_age
-            reauthenticate_oidc_resource_owner(owner)
-          end
+          return unless !auth_time || (Time.zone.now - auth_time) > max_age
+
+          reauthenticate_oidc_resource_owner(owner)
         end
 
         def return_without_oidc_prompt_param(prompt_value)
           return_to = URI.parse(request.path)
           return_to.query = request.query_parameters.tap do |params|
-            params['prompt'] = params['prompt'].to_s.sub(/\b#{prompt_value}\s*\b/, '').strip
-            params.delete('prompt') if params['prompt'].blank?
+            params["prompt"] = params["prompt"].to_s.sub(/\b#{prompt_value}\s*\b/, "").strip
+            params.delete("prompt") if params["prompt"].blank?
           end.to_query
           return_to.to_s
         end
@@ -135,7 +135,7 @@ module Doorkeeper
 
         def reauthenticate_oidc_resource_owner(owner)
           clear_oidc_response
-          return_to = return_without_oidc_prompt_param('login')
+          return_to = return_without_oidc_prompt_param("login")
 
           instance_exec(
             owner,
@@ -152,7 +152,7 @@ module Doorkeeper
 
         def select_account_for_oidc_resource_owner(owner)
           clear_oidc_response
-          return_to = return_without_oidc_prompt_param('select_account')
+          return_to = return_without_oidc_prompt_param("select_account")
 
           instance_exec(
             owner,

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -28,15 +28,14 @@ module Doorkeeper
       end
 
       def as_json(*_)
-        claims.reject { |_, value| value.nil? || value == '' }
+        claims.reject { |_, value| value.nil? || value == "" }
       end
 
       def as_jws_token
         ::JWT.encode(as_json,
           Doorkeeper::OpenidConnect.signing_key.keypair,
           Doorkeeper::OpenidConnect.signing_algorithm.to_s,
-          { typ: 'JWT', kid: Doorkeeper::OpenidConnect.signing_key.kid }
-        ).to_s
+          { typ: "JWT", kid: Doorkeeper::OpenidConnect.signing_key.kid }).to_s
       end
 
       private
@@ -49,7 +48,8 @@ module Doorkeeper
       end
 
       def subject
-        Doorkeeper::OpenidConnect.configuration.subject.call(@resource_owner, @access_token.application).to_s
+        Doorkeeper::OpenidConnect.configuration.subject.call(@resource_owner,
+@access_token.application).to_s
       end
 
       def audience

--- a/lib/doorkeeper/openid_connect/id_token_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token_token.rb
@@ -26,7 +26,7 @@ module Doorkeeper
       def at_hash
         hashed_token = at_hash_digest.digest(@access_token.token)
         first_half = hashed_token[0...hashed_token.length / 2]
-        Base64.urlsafe_encode64(first_half).tr('=', '')
+        Base64.urlsafe_encode64(first_half).tr("=", "")
       end
 
       def at_hash_digest

--- a/lib/doorkeeper/openid_connect/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/authorization_code_request.rb
@@ -13,7 +13,7 @@ module Doorkeeper
           nonce = openid_request&.nonce
           openid_request&.destroy!
 
-          return unless access_token.includes_scope?('openid')
+          return unless access_token.includes_scope?("openid")
 
           id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
           @response.id_token = id_token

--- a/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       module PasswordAccessTokenRequest
         attr_reader :nonce
 
-        if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.1')
+        if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.1")
           def initialize(server, client, credentials, resource_owner, parameters = {})
             super
             @nonce = parameters[:nonce]
@@ -21,7 +21,7 @@ module Doorkeeper
         private
 
         def after_successful_response
-          if access_token.includes_scope?('openid')
+          if access_token.includes_scope?("openid")
             id_token = Doorkeeper::OpenidConnect::IdToken.new(access_token, nonce)
             @response.id_token = id_token
           end

--- a/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/openid_connect/oauth/pre_authorization.rb
@@ -14,13 +14,13 @@ module Doorkeeper
         # NOTE: Auto get default response_mode of specified response_type if response_mode is not
         #   yet present. We can delete this method after Doorkeeper's minimize version support it.
         def response_on_fragment?
-          return response_mode == 'fragment' if response_mode.present?
+          return response_mode == "fragment" if response_mode.present?
 
           grant_flow = server.authorization_response_flows.detect do |flow|
             flow.matches_response_type?(response_type)
           end
 
-          grant_flow&.default_response_mode == 'fragment'
+          grant_flow&.default_response_mode == "fragment"
         end
       end
     end

--- a/lib/doorkeeper/openid_connect/oauth/token_response.rb
+++ b/lib/doorkeeper/openid_connect/oauth/token_response.rb
@@ -7,7 +7,7 @@ module Doorkeeper
         attr_accessor :id_token
 
         def body
-          if token.includes_scope? 'openid'
+          if token.includes_scope? "openid"
             id_token = self.id_token || Doorkeeper::OpenidConnect::IdToken.new(token)
 
             super

--- a/lib/doorkeeper/openid_connect/orm/active_record.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/lazy_load_hooks'
+require "active_support/lazy_load_hooks"
 
 module Doorkeeper
   module OpenidConnect
@@ -10,14 +10,15 @@ module Doorkeeper
     module Orm
       module ActiveRecord
         module Mixins
-          autoload :OpenidRequest, "doorkeeper/openid_connect/orm/active_record/mixins/openid_request"
+          autoload :OpenidRequest,
+"doorkeeper/openid_connect/orm/active_record/mixins/openid_request"
         end
 
         def run_hooks
           super
 
           ActiveSupport.on_load(:active_record) do
-            if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.0')
+            if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.0")
               Doorkeeper.config.access_grant_model.prepend Doorkeeper::OpenidConnect::AccessGrant
             else
               Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
@@ -25,7 +26,8 @@ module Doorkeeper
 
             if Doorkeeper.configuration.respond_to?(:active_record_options) && Doorkeeper.configuration.active_record_options[:establish_connection]
               [Doorkeeper::OpenidConnect.configuration.open_id_request_model].each do |c|
-                c.send :establish_connection, Doorkeeper.configuration.active_record_options[:establish_connection]
+                c.send :establish_connection,
+Doorkeeper.configuration.active_record_options[:establish_connection]
               end
             end
           end
@@ -34,10 +36,10 @@ module Doorkeeper
         def initialize_models!
           super
           ActiveSupport.on_load(:active_record) do
-            require 'doorkeeper/openid_connect/orm/active_record/access_grant'
-            require 'doorkeeper/openid_connect/orm/active_record/request'
+            require "doorkeeper/openid_connect/orm/active_record/access_grant"
+            require "doorkeeper/openid_connect/orm/active_record/request"
 
-            if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.0')
+            if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.0")
               Doorkeeper.config.access_grant_model.prepend Doorkeeper::OpenidConnect::AccessGrant
             else
               Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
@@ -45,7 +47,8 @@ module Doorkeeper
 
             if Doorkeeper.configuration.active_record_options[:establish_connection]
               [Doorkeeper::OpenidConnect.configuration.open_id_request_model].each do |c|
-                c.send :establish_connection, Doorkeeper.configuration.active_record_options[:establish_connection]
+                c.send :establish_connection,
+Doorkeeper.configuration.active_record_options[:establish_connection]
               end
             end
           end

--- a/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb
@@ -7,7 +7,7 @@ module Doorkeeper
         base.class_eval do
           has_one :openid_request,
             class_name: Doorkeeper::OpenidConnect.configuration.open_id_request_class,
-            foreign_key: 'access_grant_id',
+            foreign_key: "access_grant_id",
             inverse_of: :access_grant,
             dependent: :delete
         end

--- a/lib/doorkeeper/openid_connect/orm/active_record/mixins/openid_request.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/mixins/openid_request.rb
@@ -13,13 +13,13 @@ module Doorkeeper
 
               validates :access_grant_id, :nonce, presence: true
 
-              if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.0')
+              if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.0")
                 belongs_to :access_grant,
                            class_name: Doorkeeper.config.access_grant_class.to_s,
                            inverse_of: :openid_request
               else
                 belongs_to :access_grant,
-                           class_name: 'Doorkeeper::AccessGrant',
+                           class_name: "Doorkeeper::AccessGrant",
                            inverse_of: :openid_request
               end
             end

--- a/lib/doorkeeper/openid_connect/orm/active_record/request.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/request.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'doorkeeper/openid_connect/orm/active_record/mixins/openid_request'
+require "doorkeeper/openid_connect/orm/active_record/mixins/openid_request"
 
 module Doorkeeper
   module OpenidConnect

--- a/lib/doorkeeper/openid_connect/rails/routes.rb
+++ b/lib/doorkeeper/openid_connect/rails/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'doorkeeper/openid_connect/rails/routes/mapping'
-require 'doorkeeper/openid_connect/rails/routes/mapper'
+require "doorkeeper/openid_connect/rails/routes/mapping"
+require "doorkeeper/openid_connect/rails/routes/mapper"
 
 module Doorkeeper
   module OpenidConnect
@@ -28,7 +28,7 @@ module Doorkeeper
           @mapping = Mapper.new.map(&@block)
           openid_connect = ::Doorkeeper::OpenidConnect.configuration
 
-          routes.scope options[:scope] || 'oauth', as: 'oauth' do
+          routes.scope options[:scope] || "oauth", as: "oauth" do
             map_route(:userinfo, :userinfo_routes)
             map_route(:discovery, :discovery_routes)
 
@@ -37,7 +37,7 @@ module Doorkeeper
             end
           end
 
-          routes.scope as: 'oauth' do
+          routes.scope as: "oauth" do
             map_route(:discovery, :discovery_well_known_routes)
           end
         end
@@ -55,26 +55,26 @@ module Doorkeeper
         end
 
         def userinfo_routes
-          routes.get :show, path: 'userinfo', as: ''
-          routes.post :show, path: 'userinfo', as: nil
+          routes.get :show, path: "userinfo", as: ""
+          routes.post :show, path: "userinfo", as: nil
         end
 
         def discovery_routes
-          routes.scope path: 'discovery' do
+          routes.scope path: "discovery" do
             routes.get :keys
           end
         end
 
         def discovery_well_known_routes
-          routes.scope path: '.well-known' do
-            routes.get :provider, path: 'openid-configuration'
-            routes.get :provider, path: 'oauth-authorization-server'
+          routes.scope path: ".well-known" do
+            routes.get :provider, path: "openid-configuration"
+            routes.get :provider, path: "oauth-authorization-server"
             routes.get :webfinger
           end
         end
 
         def dynamic_client_registration_routes
-          routes.post :register, path: 'registration', as: ''
+          routes.post :register, path: "registration", as: ""
         end
       end
     end

--- a/lib/doorkeeper/openid_connect/rails/routes/mapping.rb
+++ b/lib/doorkeeper/openid_connect/rails/routes/mapping.rb
@@ -9,9 +9,9 @@ module Doorkeeper
 
           def initialize
             @controllers = {
-              userinfo: 'doorkeeper/openid_connect/userinfo',
-              discovery: 'doorkeeper/openid_connect/discovery',
-              dynamic_client_registration: 'doorkeeper/openid_connect/dynamic_client_registration'
+              userinfo: "doorkeeper/openid_connect/userinfo",
+              discovery: "doorkeeper/openid_connect/discovery",
+              dynamic_client_registration: "doorkeeper/openid_connect/dynamic_client_registration"
             }
 
             @as = {

--- a/lib/doorkeeper/openid_connect/user_info.rb
+++ b/lib/doorkeeper/openid_connect/user_info.rb
@@ -16,7 +16,7 @@ module Doorkeeper
       end
 
       def as_json(*_)
-        claims.reject { |_, value| value.nil? || value == '' }
+        claims.reject { |_, value| value.nil? || value == "" }
       end
 
       private

--- a/lib/doorkeeper/request/id_token.rb
+++ b/lib/doorkeeper/request/id_token.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'doorkeeper/request/strategy'
+require "doorkeeper/request/strategy"
 
 module Doorkeeper
   module Request

--- a/lib/doorkeeper/request/id_token_token.rb
+++ b/lib/doorkeeper/request/id_token_token.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'doorkeeper/request/strategy'
+require "doorkeeper/request/strategy"
 
 module Doorkeeper
   module Request

--- a/lib/generators/doorkeeper/openid_connect/install_generator.rb
+++ b/lib/generators/doorkeeper/openid_connect/install_generator.rb
@@ -4,13 +4,14 @@ module Doorkeeper
   module OpenidConnect
     class InstallGenerator < ::Rails::Generators::Base
       include ::Rails::Generators::Migration
-      source_root File.expand_path('templates', __dir__)
-      desc 'Installs Doorkeeper OpenID Connect.'
+      source_root File.expand_path("templates", __dir__)
+      desc "Installs Doorkeeper OpenID Connect."
 
       def install
-        template 'initializer.rb', 'config/initializers/doorkeeper_openid_connect.rb'
-        copy_file File.expand_path('../../../../config/locales/en.yml', __dir__), 'config/locales/doorkeeper_openid_connect.en.yml'
-        route 'use_doorkeeper_openid_connect'
+        template "initializer.rb", "config/initializers/doorkeeper_openid_connect.rb"
+        copy_file File.expand_path("../../../../config/locales/en.yml", __dir__),
+"config/locales/doorkeeper_openid_connect.en.yml"
+        route "use_doorkeeper_openid_connect"
       end
     end
   end

--- a/lib/generators/doorkeeper/openid_connect/migration_generator.rb
+++ b/lib/generators/doorkeeper/openid_connect/migration_generator.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require 'rails/generators/active_record'
+require "rails/generators/active_record"
 
 module Doorkeeper
   module OpenidConnect
     class MigrationGenerator < ::Rails::Generators::Base
       include ::Rails::Generators::Migration
-      source_root File.expand_path('templates', __dir__)
-      desc 'Installs Doorkeeper OpenID Connect migration file.'
+      source_root File.expand_path("templates", __dir__)
+      desc "Installs Doorkeeper OpenID Connect migration file."
 
       def install
         migration_template(
-          'migration.rb.erb',
-          'db/migrate/create_doorkeeper_openid_connect_tables.rb',
+          "migration.rb.erb",
+          "db/migrate/create_doorkeeper_openid_connect_tables.rb",
           migration_version: migration_version
         )
       end
@@ -24,9 +24,9 @@ module Doorkeeper
       private
 
       def migration_version
-        if ActiveRecord::VERSION::MAJOR >= 5
-          "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
-        end
+        return unless ActiveRecord::VERSION::MAJOR >= 5
+
+        "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
       end
     end
   end

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 Doorkeeper::OpenidConnect.configure do
-  issuer do |resource_owner, application, request|
+  issuer do |_resource_owner, _application, _request|
     # Example implementation:
     # request&.base_url || 'https://example.com'
-    'issuer string'
+    "issuer string"
   end
 
   signing_key <<~KEY

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -1,42 +1,42 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
-  describe '#provider' do
-    it 'returns the provider configuration' do
+  describe "#provider" do
+    it "returns the provider configuration" do
       get :provider
       data = JSON.parse(response.body)
 
       expect(data.sort).to match({
-        'issuer' => 'dummy',
-        'authorization_endpoint' => 'http://test.host/oauth/authorize',
-        'token_endpoint' => 'http://test.host/oauth/token',
-        'revocation_endpoint' => 'http://test.host/oauth/revoke',
-        'introspection_endpoint' => 'http://test.host/oauth/introspect',
-        'userinfo_endpoint' => 'http://test.host/oauth/userinfo',
-        'jwks_uri' => 'http://test.host/oauth/discovery/keys',
+        "issuer" => "dummy",
+        "authorization_endpoint" => "http://test.host/oauth/authorize",
+        "token_endpoint" => "http://test.host/oauth/token",
+        "revocation_endpoint" => "http://test.host/oauth/revoke",
+        "introspection_endpoint" => "http://test.host/oauth/introspect",
+        "userinfo_endpoint" => "http://test.host/oauth/userinfo",
+        "jwks_uri" => "http://test.host/oauth/discovery/keys",
 
-        'scopes_supported' => ['openid'],
-        'response_types_supported' => ['code', 'token', 'id_token', 'id_token token'],
-        'response_modes_supported' => %w[query fragment form_post],
-        'grant_types_supported' => %w[authorization_code client_credentials implicit_oidc],
+        "scopes_supported" => ["openid"],
+        "response_types_supported" => ["code", "token", "id_token", "id_token token"],
+        "response_modes_supported" => %w[query fragment form_post],
+        "grant_types_supported" => %w[authorization_code client_credentials implicit_oidc],
 
-        'token_endpoint_auth_methods_supported' => %w[client_secret_basic client_secret_post],
+        "token_endpoint_auth_methods_supported" => %w[client_secret_basic client_secret_post],
 
-        'subject_types_supported' => [
-          'public',
+        "subject_types_supported" => [
+          "public",
         ],
 
-        'id_token_signing_alg_values_supported' => [
-          'RS256',
+        "id_token_signing_alg_values_supported" => [
+          "RS256",
         ],
 
-        'claim_types_supported' => [
-          'normal',
+        "claim_types_supported" => [
+          "normal",
         ],
 
-        'claims_supported' => %w[
+        "claims_supported" => %w[
           iss
           sub
           aud
@@ -52,14 +52,14 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
           user_info_response
         ],
 
-        'code_challenge_methods_supported' => %w[
+        "code_challenge_methods_supported" => %w[
           plain
           S256
         ],
       }.sort)
     end
 
-    it 'returns the provider configuration with client registration url' do
+    it "returns the provider configuration with client registration url" do
       Doorkeeper::OpenidConnect.configure do
         issuer "dummy"
         dynamic_client_registration true
@@ -71,35 +71,35 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       data = JSON.parse(response.body)
 
       expect(data.sort).to match({
-        'issuer' => 'dummy',
-        'authorization_endpoint' => 'http://test.host/oauth/authorize',
-        'token_endpoint' => 'http://test.host/oauth/token',
-        'revocation_endpoint' => 'http://test.host/oauth/revoke',
-        'introspection_endpoint' => 'http://test.host/oauth/introspect',
-        'userinfo_endpoint' => 'http://test.host/oauth/userinfo',
-        'jwks_uri' => 'http://test.host/oauth/discovery/keys',
-        'registration_endpoint' => 'http://test.host/oauth/registration',
+        "issuer" => "dummy",
+        "authorization_endpoint" => "http://test.host/oauth/authorize",
+        "token_endpoint" => "http://test.host/oauth/token",
+        "revocation_endpoint" => "http://test.host/oauth/revoke",
+        "introspection_endpoint" => "http://test.host/oauth/introspect",
+        "userinfo_endpoint" => "http://test.host/oauth/userinfo",
+        "jwks_uri" => "http://test.host/oauth/discovery/keys",
+        "registration_endpoint" => "http://test.host/oauth/registration",
 
-        'scopes_supported' => ['openid'],
-        'response_types_supported' => ['code', 'token', 'id_token', 'id_token token'],
-        'response_modes_supported' => %w[query fragment form_post],
-        'grant_types_supported' => %w[authorization_code client_credentials implicit_oidc],
+        "scopes_supported" => ["openid"],
+        "response_types_supported" => ["code", "token", "id_token", "id_token token"],
+        "response_modes_supported" => %w[query fragment form_post],
+        "grant_types_supported" => %w[authorization_code client_credentials implicit_oidc],
 
-        'token_endpoint_auth_methods_supported' => %w[client_secret_basic client_secret_post],
+        "token_endpoint_auth_methods_supported" => %w[client_secret_basic client_secret_post],
 
-        'subject_types_supported' => [
-          'public',
+        "subject_types_supported" => [
+          "public",
         ],
 
-        'id_token_signing_alg_values_supported' => [
-          'RS256',
+        "id_token_signing_alg_values_supported" => [
+          "RS256",
         ],
 
-        'claim_types_supported' => [
-          'normal',
+        "claim_types_supported" => [
+          "normal",
         ],
 
-        'claims_supported' => %w[
+        "claims_supported" => %w[
           iss
           sub
           aud
@@ -107,36 +107,36 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
           iat
         ],
 
-        'code_challenge_methods_supported' => %w[
+        "code_challenge_methods_supported" => %w[
           plain
           S256
         ],
       }.sort)
     end
 
-    context 'when refresh_token grant type is enabled' do
+    context "when refresh_token grant type is enabled" do
       before { Doorkeeper.configure { use_refresh_token } }
 
-      it 'add refresh_token to grant_types_supported' do
+      it "add refresh_token to grant_types_supported" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['grant_types_supported']).to eq %w[authorization_code client_credentials refresh_token]
+        expect(data["grant_types_supported"]).to eq %w[authorization_code client_credentials refresh_token]
       end
     end
 
-    context 'when issuer block' do
-      before { Doorkeeper::OpenidConnect.configure { issuer do |r, a| "test-issuer" end } }
+    context "when issuer block" do
+      before { Doorkeeper::OpenidConnect.configure { issuer { |_r, _a| "test-issuer" } } }
 
-      it 'return blocks result' do
+      it "return blocks result" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['issuer']).to eq "test-issuer"
+        expect(data["issuer"]).to eq "test-issuer"
       end
     end
 
-    context 'when issuer block has arity 3 with request' do
+    context "when issuer block has arity 3 with request" do
       before do
         Doorkeeper::OpenidConnect.configure do
           issuer do |_resource_owner, _application, request|
@@ -145,82 +145,82 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
         end
       end
 
-      it 'passes the request object to the issuer block' do
+      it "passes the request object to the issuer block" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['issuer']).to eq 'http://test.host'
+        expect(data["issuer"]).to eq "http://test.host"
       end
     end
 
-    context 'when grant_flows is configured with only client_credentials' do
+    context "when grant_flows is configured with only client_credentials" do
       before { Doorkeeper.configure { grant_flows %w[client_credentials] } }
 
-      it 'return empty response_modes_supported' do
+      it "return empty response_modes_supported" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['response_modes_supported']).to eq []
+        expect(data["response_modes_supported"]).to eq []
       end
     end
 
-    context 'when pkce_code_challenge_methods is configured with only S256' do
+    context "when pkce_code_challenge_methods is configured with only S256" do
       before { Doorkeeper.configure { pkce_code_challenge_methods %w[S256] } }
 
-      it 'return only S256 in code_challenge_methods_supported' do
+      it "return only S256 in code_challenge_methods_supported" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['code_challenge_methods_supported']).to eq %w[S256]
+        expect(data["code_challenge_methods_supported"]).to eq %w[S256]
       end
     end
 
-    context 'when pkce_code_challenge_methods is configured with only plain' do
+    context "when pkce_code_challenge_methods is configured with only plain" do
       before { Doorkeeper.configure { pkce_code_challenge_methods %w[plain] } }
 
-      it 'return only plain in code_challenge_methods_supported' do
+      it "return only plain in code_challenge_methods_supported" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['code_challenge_methods_supported']).to eq %w[plain]
+        expect(data["code_challenge_methods_supported"]).to eq %w[plain]
       end
     end
 
-    context 'when grant_flows is configured only implicit flow' do
+    context "when grant_flows is configured only implicit flow" do
       before { Doorkeeper.configure { grant_flows %w[implicit_oidc] } }
 
-      it 'return fragment and form_post as response_modes_supported' do
+      it "return fragment and form_post as response_modes_supported" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['response_modes_supported']).to eq %w[fragment form_post]
+        expect(data["response_modes_supported"]).to eq %w[fragment form_post]
       end
     end
 
-    context 'when client_credentials is configured with only from_basic' do
+    context "when client_credentials is configured with only from_basic" do
       before { Doorkeeper.configure { client_credentials :from_basic } }
 
-      it 'returns only client_secret_basic in token_endpoint_auth_methods_supported' do
+      it "returns only client_secret_basic in token_endpoint_auth_methods_supported" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['token_endpoint_auth_methods_supported']).to eq %w[client_secret_basic]
+        expect(data["token_endpoint_auth_methods_supported"]).to eq %w[client_secret_basic]
       end
     end
 
-    context 'when client_credentials is configured with only from_params' do
+    context "when client_credentials is configured with only from_params" do
       before { Doorkeeper.configure { client_credentials :from_params } }
 
-      it 'returns only client_secret_post in token_endpoint_auth_methods_supported' do
+      it "returns only client_secret_post in token_endpoint_auth_methods_supported" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['token_endpoint_auth_methods_supported']).to eq %w[client_secret_post]
+        expect(data["token_endpoint_auth_methods_supported"]).to eq %w[client_secret_post]
       end
     end
 
-    context 'when the issuer is configured to a non-root URL' do
-      let(:non_root_issuer) { 'http://test.host/issuer/with/path' }
+    context "when the issuer is configured to a non-root URL" do
+      let(:non_root_issuer) { "http://test.host/issuer/with/path" }
 
       before do
         value = non_root_issuer
@@ -229,37 +229,37 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
         end
       end
 
-      it 'returns the configured issuer in the webfinger response' do
-        get :webfinger, params: { resource: 'user@example.com' }
+      it "returns the configured issuer in the webfinger response" do
+        get :webfinger, params: { resource: "user@example.com" }
         data = JSON.parse(response.body)
 
-        expect(data['links'].first['href']).to eq non_root_issuer
+        expect(data["links"].first["href"]).to eq non_root_issuer
       end
     end
 
-    context 'when client_credentials is configured with both from_basic and from_params' do
+    context "when client_credentials is configured with both from_basic and from_params" do
       before { Doorkeeper.configure { client_credentials :from_basic, :from_params } }
 
-      it 'returns both client_secret_basic and client_secret_post in token_endpoint_auth_methods_supported' do
+      it "returns both client_secret_basic and client_secret_post in token_endpoint_auth_methods_supported" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['token_endpoint_auth_methods_supported']).to eq %w[client_secret_basic client_secret_post]
+        expect(data["token_endpoint_auth_methods_supported"]).to eq %w[client_secret_basic client_secret_post]
       end
     end
 
-    context 'when grant_flows is configured with authorization_code and implicit flow' do
+    context "when grant_flows is configured with authorization_code and implicit flow" do
       before { Doorkeeper.configure { grant_flows %w[authorization_code implicit_oidc] } }
 
-      it 'return query, fragment and form_post as response_modes_supported' do
+      it "return query, fragment and form_post as response_modes_supported" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['response_modes_supported']).to eq %w[query fragment form_post]
+        expect(data["response_modes_supported"]).to eq %w[query fragment form_post]
       end
     end
 
-    it 'uses the protocol option for generating URLs' do
+    it "uses the protocol option for generating URLs" do
       Doorkeeper::OpenidConnect.configure do
         protocol { :testing }
       end
@@ -267,11 +267,11 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       get :provider
       data = JSON.parse(response.body)
 
-      expect(data['authorization_endpoint']).to eq 'testing://test.host/oauth/authorize'
+      expect(data["authorization_endpoint"]).to eq "testing://test.host/oauth/authorize"
     end
 
-    context 'when the protocol option is configured with a non-callable value' do
-      it 'accepts a symbol' do
+    context "when the protocol option is configured with a non-callable value" do
+      it "accepts a symbol" do
         Doorkeeper::OpenidConnect.configure do
           protocol :testing
         end
@@ -280,99 +280,99 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
         data = JSON.parse(response.body)
 
         expect(response).to have_http_status(:ok)
-        expect(data['authorization_endpoint']).to eq 'testing://test.host/oauth/authorize'
+        expect(data["authorization_endpoint"]).to eq "testing://test.host/oauth/authorize"
       end
 
-      it 'accepts a string' do
+      it "accepts a string" do
         Doorkeeper::OpenidConnect.configure do
-          protocol 'testing'
+          protocol "testing"
         end
 
         get :provider
         data = JSON.parse(response.body)
 
         expect(response).to have_http_status(:ok)
-        expect(data['authorization_endpoint']).to eq 'testing://test.host/oauth/authorize'
+        expect(data["authorization_endpoint"]).to eq "testing://test.host/oauth/authorize"
       end
     end
 
-    context 'when the discovery_url_options option is set for all endpoints' do
+    context "when the discovery_url_options option is set for all endpoints" do
       before do
         Doorkeeper::OpenidConnect.configure do
-          discovery_url_options do |request|
+          discovery_url_options do |_request|
             {
-              authorization: { host: 'alternate-authorization.host' },
-              token: { host: 'alternate-token.host' },
-              revocation: { host: 'alternate-revocation.host' },
-              introspection: { host: 'alternate-introspection.host' },
-              userinfo: { host: 'alternate-userinfo.host' },
-              jwks: { host: 'alternate-jwks.host' }
+              authorization: { host: "alternate-authorization.host" },
+              token: { host: "alternate-token.host" },
+              revocation: { host: "alternate-revocation.host" },
+              introspection: { host: "alternate-introspection.host" },
+              userinfo: { host: "alternate-userinfo.host" },
+              jwks: { host: "alternate-jwks.host" }
             }
           end
         end
       end
 
-      it 'uses the discovery_url_options option when generating the endpoint urls' do
+      it "uses the discovery_url_options option when generating the endpoint urls" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['authorization_endpoint']).to eq 'http://alternate-authorization.host/oauth/authorize'
-        expect(data['token_endpoint']).to eq 'http://alternate-token.host/oauth/token'
-        expect(data['revocation_endpoint']).to eq 'http://alternate-revocation.host/oauth/revoke'
-        expect(data['introspection_endpoint']).to eq 'http://alternate-introspection.host/oauth/introspect'
-        expect(data['userinfo_endpoint']).to eq 'http://alternate-userinfo.host/oauth/userinfo'
-        expect(data['jwks_uri']).to eq 'http://alternate-jwks.host/oauth/discovery/keys'
+        expect(data["authorization_endpoint"]).to eq "http://alternate-authorization.host/oauth/authorize"
+        expect(data["token_endpoint"]).to eq "http://alternate-token.host/oauth/token"
+        expect(data["revocation_endpoint"]).to eq "http://alternate-revocation.host/oauth/revoke"
+        expect(data["introspection_endpoint"]).to eq "http://alternate-introspection.host/oauth/introspect"
+        expect(data["userinfo_endpoint"]).to eq "http://alternate-userinfo.host/oauth/userinfo"
+        expect(data["jwks_uri"]).to eq "http://alternate-jwks.host/oauth/discovery/keys"
       end
     end
 
-    context 'when the discovery_url_options option is only set for some endpoints' do
+    context "when the discovery_url_options option is only set for some endpoints" do
       before do
         Doorkeeper::OpenidConnect.configure do
-          discovery_url_options do |request|
-            { authorization: { host: 'alternate-authorization.host' } }
+          discovery_url_options do |_request|
+            { authorization: { host: "alternate-authorization.host" } }
           end
         end
       end
 
-      it 'does not use the discovery_url_options option when generating other URLs' do
+      it "does not use the discovery_url_options option when generating other URLs" do
         get :provider
         data = JSON.parse(response.body)
 
         {
-          'token_endpoint' => 'http://test.host/oauth/token',
-          'revocation_endpoint' => 'http://test.host/oauth/revoke',
-          'introspection_endpoint' => 'http://test.host/oauth/introspect',
-          'userinfo_endpoint' => 'http://test.host/oauth/userinfo',
-          'jwks_uri' => 'http://test.host/oauth/discovery/keys',
+          "token_endpoint" => "http://test.host/oauth/token",
+          "revocation_endpoint" => "http://test.host/oauth/revoke",
+          "introspection_endpoint" => "http://test.host/oauth/introspect",
+          "userinfo_endpoint" => "http://test.host/oauth/userinfo",
+          "jwks_uri" => "http://test.host/oauth/discovery/keys",
         }.each do |endpoint, expected_url|
           expect(data[endpoint]).to eq expected_url
         end
       end
     end
 
-    it 'does not return an end session endpoint if none is configured' do
+    it "does not return an end session endpoint if none is configured" do
       get :provider
       data = JSON.parse(response.body)
 
-      expect(data.key?('end_session_endpoint')).to be(false)
+      expect(data.key?("end_session_endpoint")).to be(false)
     end
 
-    it 'uses the configured end session endpoint with self as context' do
+    it "uses the configured end session endpoint with self as context" do
       Doorkeeper::OpenidConnect.configure do
         end_session_endpoint -> { logout_url }
       end
 
       def controller.logout_url
-        'http://test.host/logout'
+        "http://test.host/logout"
       end
 
       get :provider
       data = JSON.parse(response.body)
 
-      expect(data['end_session_endpoint']).to eq 'http://test.host/logout'
+      expect(data["end_session_endpoint"]).to eq "http://test.host/logout"
     end
 
-    context 'when token inspection is disallowed' do
+    context "when token inspection is disallowed" do
       let(:doorkeeper_config) { Doorkeeper.config }
       let!(:allow_token_introspection) { doorkeeper_config.allow_token_introspection }
 
@@ -386,85 +386,87 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
         Rails.application.reload_routes!
       end
 
-      it 'does not return introspection_endpoint' do
+      it "does not return introspection_endpoint" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data.key?('introspection_endpoint')).to be(false)
+        expect(data.key?("introspection_endpoint")).to be(false)
       end
     end
   end
 
-  describe '#webfinger' do
-    it 'requires the resource parameter' do
+  describe "#webfinger" do
+    it "requires the resource parameter" do
       expect do
         get :webfinger
       end.to raise_error ActionController::ParameterMissing
     end
 
-    it 'returns the OpenID Connect relation' do
-      get :webfinger, params: { resource: 'user@example.com' }
+    it "returns the OpenID Connect relation" do
+      get :webfinger, params: { resource: "user@example.com" }
       data = JSON.parse(response.body)
 
       expect(data.sort).to eq({
-        'subject' => 'user@example.com',
-        'links' => [
-          'rel' => 'http://openid.net/specs/connect/1.0/issuer',
-          'href' => 'dummy',
+        "subject" => "user@example.com",
+        "links" => [
+          {
+          "rel" => "http://openid.net/specs/connect/1.0/issuer",
+          "href" => "dummy"
+          },
         ],
       }.sort)
     end
 
-    context 'when the discovery_url_options option uses the request for an endpoint' do
+    context "when the discovery_url_options option uses the request for an endpoint" do
       before do
         Doorkeeper::OpenidConnect.configure do
           discovery_url_options do |request|
             {
-              authorization: { host: 'alternate-authorization.host',
+              authorization: { host: "alternate-authorization.host",
                                protocol: request.ssl? ? :https : :testing }
             }
           end
         end
       end
 
-      it 'uses the discovery_url_options option when generating the webfinger endpoint url' do
+      it "uses the discovery_url_options option when generating the webfinger endpoint url" do
         get :provider
         data = JSON.parse(response.body)
 
-        expect(data['authorization_endpoint']).to eq 'testing://alternate-authorization.host/oauth/authorize'
+        expect(data["authorization_endpoint"]).to eq "testing://alternate-authorization.host/oauth/authorize"
       end
     end
   end
 
-  describe '#keys' do
+  describe "#keys" do
     subject { get :keys }
 
-    shared_examples 'a key response' do |options|
+    shared_examples "a key response" do |options|
       expected_parameters = options[:expected_parameters]
 
-      it "includes only #{expected_parameters.join(', ')} parameters" do
+      it "includes only #{expected_parameters.join(", ")} parameters" do
         subject
         data = JSON.parse(response.body)
-        key = data['keys'].first
+        key = data["keys"].first
 
         expect(key.keys.map(&:to_sym)).to match_array(expected_parameters)
       end
     end
 
-    context 'when using an RSA key' do
-      it_behaves_like 'a key response', expected_parameters: %i[kty kid e n use alg]
+    context "when using an RSA key" do
+      it_behaves_like "a key response", expected_parameters: %i[kty kid e n use alg]
     end
 
-    context 'when using an EC key' do
+    context "when using an EC key" do
       before { configure_ec }
 
-      it_behaves_like 'a key response', expected_parameters: %i[kty kid crv x y use alg]
+      it_behaves_like "a key response", expected_parameters: %i[kty kid crv x y use alg]
     end
 
-    context 'when using an HMAC key' do
+    context "when using an HMAC key" do
       before { configure_hmac }
 
-      it_behaves_like 'a key response', expected_parameters: %i[kty kid use alg]
+      it_behaves_like "a key response", expected_parameters: %i[kty kid use alg]
     end
   end
 end

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::AuthorizationsController, type: :controller do
   let(:user) { create :user }
   let(:application) { create :application, scopes: default_scopes }
-  let(:default_scopes) { 'openid profile' }
+  let(:default_scopes) { "openid profile" }
   let(:token_attributes) { { application_id: application.id, resource_owner_id: user.id, scopes: default_scopes } }
 
   def authorize!(params = {})
     get :new, params: {
-      response_type: 'code',
-      response_mode: '',
+      response_type: "code",
+      response_mode: "",
       current_user: user.id,
       client_id: application.uid,
       scope: default_scopes,
@@ -19,11 +19,11 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
     }.merge(params)
   end
 
-  def build_redirect_uri(params = {}, type: 'query')
+  def build_redirect_uri(params = {}, type: "query")
     case type
-    when 'query'
+    when "query"
       Doorkeeper::OAuth::Authorization::URIBuilder.uri_with_query(application.redirect_uri, params)
-    when 'fragment'
+    when "fragment"
       Doorkeeper::OAuth::Authorization::URIBuilder.uri_with_fragment(application.redirect_uri, params)
     else
       raise ArgumentError, "Unsupported uri type #{type}"
@@ -32,7 +32,7 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
 
   def expect_authorization_form!
     expect(response).to be_successful
-    expect(response).to render_template('doorkeeper/authorizations/new')
+    expect(response).to render_template("doorkeeper/authorizations/new")
   end
 
   def expect_successful_callback!
@@ -40,114 +40,114 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
     expect(response.location).to match(/^#{Regexp.quote application.redirect_uri}\?code=[-\w]+$/)
   end
 
-  describe '#authenticate_resource_owner!' do
-    it 'redirects to login form when not logged in' do
+  describe "#authenticate_resource_owner!" do
+    it "redirects to login form when not logged in" do
       authorize! current_user: nil
 
-      expect(response).to redirect_to '/login'
+      expect(response).to redirect_to "/login"
     end
 
-    context 'with OIDC requests' do
+    context "with OIDC requests" do
       before do
         expect(controller).to receive(:handle_oidc_prompt_param!)
         expect(controller).to receive(:handle_oidc_max_age_param!)
       end
 
-      it 'renders the authorization form if logged in' do
+      it "renders the authorization form if logged in" do
         authorize!
 
         expect_authorization_form!
       end
     end
 
-    context 'with non-OIDC requests' do
+    context "with non-OIDC requests" do
       before do
         expect(controller).not_to receive(:handle_oidc_prompt_param!)
         expect(controller).not_to receive(:handle_oidc_max_age_param!)
       end
 
-      it 'when action is not :new' do
+      it "when action is not :new" do
         get :show, params: {
-          response_type: 'code',
+          response_type: "code",
           current_user: user.id,
           client_id: application.uid,
           scope: default_scopes,
           redirect_uri: application.redirect_uri,
         }
 
-        expect(response).to render_template('doorkeeper/authorizations/show')
+        expect(response).to render_template("doorkeeper/authorizations/show")
       end
 
-      context 'when pre_authorization is invalid' do
-        it 'render error when client_id is missing' do
+      context "when pre_authorization is invalid" do
+        it "render error when client_id is missing" do
           authorize!(client_id: nil)
 
           expect(response).to have_http_status(:bad_request)
-          expect(response).to render_template('doorkeeper/authorizations/error')
+          expect(response).to render_template("doorkeeper/authorizations/error")
         end
 
-        it 'render error when response_type is missing' do
+        it "render error when response_type is missing" do
           authorize!(response_type: nil)
 
           expect(response).to have_http_status(:bad_request)
-          expect(response).to render_template('doorkeeper/authorizations/error')
+          expect(response).to render_template("doorkeeper/authorizations/error")
         end
       end
 
-      it 'when openid scope is not present' do
-        authorize!(scope: 'profile')
+      it "when openid scope is not present" do
+        authorize!(scope: "profile")
 
         expect_authorization_form!
       end
     end
   end
 
-  describe '#handle_oidc_prompt_param!' do
-    it 'is ignored when the openid scope is not present' do
-      authorize! scope: 'profile', prompt: 'invalid'
+  describe "#handle_oidc_prompt_param!" do
+    it "is ignored when the openid scope is not present" do
+      authorize! scope: "profile", prompt: "invalid"
 
       expect_authorization_form!
     end
 
-    context 'with a prompt=none parameter' do
-      context 'and a matching token' do
+    context "with a prompt=none parameter" do
+      context "and a matching token" do
         before do
           create :access_token, token_attributes
         end
 
-        it 'redirects to the callback if logged in' do
-          authorize! prompt: 'none'
+        it "redirects to the callback if logged in" do
+          authorize! prompt: "none"
 
           expect_successful_callback!
         end
 
-        context 'when another prompt value is present' do
+        context "when another prompt value is present" do
           let(:error_params) do
             {
-              'error' => 'invalid_request',
-              'error_description' => 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.',
+              "error" => "invalid_request",
+              "error_description" => "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.",
             }
           end
-          let(:request_param) { { prompt: 'none login' } }
+          let(:request_param) { { prompt: "none login" } }
 
-          it 'redirect as the query uri with an invalid_request error' do
+          it "redirect as the query uri with an invalid_request error" do
             authorize! request_param
 
             expect(response).to redirect_to build_redirect_uri(error_params)
           end
 
-          it 'redirect as the fragment style uri when response_type is implicit flow request' do
-            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(['implicit_oidc'])
+          it "redirect as the fragment style uri when response_type is implicit flow request" do
+            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(["implicit_oidc"])
 
-            authorize! request_param.merge(response_type: 'id_token token')
+            authorize! request_param.merge(response_type: "id_token token")
 
-            expect(response).to redirect_to build_redirect_uri(error_params, type: 'fragment')
+            expect(response).to redirect_to build_redirect_uri(error_params, type: "fragment")
           end
 
-          it 'set @authorize_response variable and render form_post template and when the form_post response_mode is specified' do
-            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(['implicit_oidc'])
+          it "set @authorize_response variable and render form_post template and when the form_post response_mode is specified" do
+            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(["implicit_oidc"])
 
-            authorize! request_param.merge(response_type: 'id_token token', response_mode: 'form_post')
+            authorize! request_param.merge(response_type: "id_token token", response_mode: "form_post")
 
             authorize_response = controller.instance_variable_get :@authorize_response
             expect(authorize_response.body.to_json).to eq(error_params.to_json)
@@ -155,34 +155,34 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
           end
         end
 
-        context 'when not logged in' do
+        context "when not logged in" do
           let(:error_params) do
             {
-              'error' => 'login_required',
-              'error_description' => 'The authorization server requires end-user authentication',
-              'state' => 'somestate',
+              "error" => "login_required",
+              "error_description" => "The authorization server requires end-user authentication",
+              "state" => "somestate",
             }
           end
           let(:request_param) { { current_user: nil } }
 
-          it 'returns a login_required error' do
-            authorize! request_param.merge(prompt: 'none', state: 'somestate')
+          it "returns a login_required error" do
+            authorize! request_param.merge(prompt: "none", state: "somestate")
 
             expect(response).to redirect_to build_redirect_uri(error_params)
           end
 
-          it 'redirect as the fragment style uri when response_type is implicit flow request' do
-            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(['implicit_oidc'])
+          it "redirect as the fragment style uri when response_type is implicit flow request" do
+            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(["implicit_oidc"])
 
-            authorize! request_param.merge(response_type: 'id_token token', prompt: 'none', state: 'somestate')
+            authorize! request_param.merge(response_type: "id_token token", prompt: "none", state: "somestate")
 
-            expect(response).to redirect_to build_redirect_uri(error_params, type: 'fragment')
+            expect(response).to redirect_to build_redirect_uri(error_params, type: "fragment")
           end
 
-          it 'set @authorize_response variable and render form_post template and when the form_post response_mode is specified' do
-            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(['implicit_oidc'])
+          it "set @authorize_response variable and render form_post template and when the form_post response_mode is specified" do
+            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(["implicit_oidc"])
 
-            authorize! request_param.merge(response_type: 'id_token token', response_mode: 'form_post', prompt: 'none', state: 'somestate')
+            authorize! request_param.merge(response_type: "id_token token", response_mode: "form_post", prompt: "none", state: "somestate")
 
             authorize_response = controller.instance_variable_get :@authorize_response
             expect(authorize_response.body.to_json).to eq(error_params.to_json)
@@ -191,42 +191,42 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
         end
       end
 
-      context 'and no matching token' do
-        it 'redirects to the callback if skip_authorization is set to true' do
+      context "and no matching token" do
+        it "redirects to the callback if skip_authorization is set to true" do
           allow(controller).to receive(:skip_authorization?).and_return(true)
 
-          authorize! prompt: 'none'
+          authorize! prompt: "none"
           expect_successful_callback!
         end
 
-        context 'when not logged in' do
+        context "when not logged in" do
           let(:error_params) do
             {
-              'error' => 'login_required',
-              'error_description' => 'The authorization server requires end-user authentication',
-              'state' => 'somestate',
+              "error" => "login_required",
+              "error_description" => "The authorization server requires end-user authentication",
+              "state" => "somestate",
             }
           end
           let(:request_param) { { current_user: nil } }
 
-          it 'returns the login_required error when not logged in' do
-            authorize! request_param.merge(prompt: 'none', state: 'somestate')
+          it "returns the login_required error when not logged in" do
+            authorize! request_param.merge(prompt: "none", state: "somestate")
 
             expect(response).to redirect_to build_redirect_uri(error_params)
           end
 
-          it 'uses the fragment style uris when redirecting an error for implicit flow request' do
-            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(['implicit_oidc'])
+          it "uses the fragment style uris when redirecting an error for implicit flow request" do
+            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(["implicit_oidc"])
 
-            authorize! request_param.merge(response_type: 'id_token token', prompt: 'none', state: 'somestate')
+            authorize! request_param.merge(response_type: "id_token token", prompt: "none", state: "somestate")
 
-            expect(response).to redirect_to build_redirect_uri(error_params, type: 'fragment')
+            expect(response).to redirect_to build_redirect_uri(error_params, type: "fragment")
           end
 
-          it 'set @authorize_response variable and render form_post template and when the form_post response_mode is specified' do
-            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(['implicit_oidc'])
+          it "set @authorize_response variable and render form_post template and when the form_post response_mode is specified" do
+            allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(["implicit_oidc"])
 
-            authorize! request_param.merge(response_type: 'id_token token', response_mode: 'form_post', prompt: 'none', state: 'somestate')
+            authorize! request_param.merge(response_type: "id_token token", response_mode: "form_post", prompt: "none", state: "somestate")
 
             authorize_response = controller.instance_variable_get :@authorize_response
             expect(authorize_response.body.to_json).to eq(error_params.to_json)
@@ -234,12 +234,12 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
           end
         end
 
-        it 'returns a consent_required error when logged in' do
-          authorize! prompt: 'none'
+        it "returns a consent_required error when logged in" do
+          authorize! prompt: "none"
 
           error_params = {
-            'error' => 'consent_required',
-            'error_description' => 'The authorization server requires end-user consent',
+            "error" => "consent_required",
+            "error_description" => "The authorization server requires end-user consent",
           }
 
           expect(response).to redirect_to build_redirect_uri(error_params)
@@ -247,101 +247,101 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
 
-    context 'with a prompt=login parameter' do
-      it 'redirects to the sign in form if not logged in' do
-        authorize! prompt: 'login', current_user: nil
+    context "with a prompt=login parameter" do
+      it "redirects to the sign in form if not logged in" do
+        authorize! prompt: "login", current_user: nil
 
-        expect(response).to redirect_to('/login')
+        expect(response).to redirect_to("/login")
       end
 
-      it 'reauthenticates the user if logged in' do
-        authorize! prompt: 'login'
+      it "reauthenticates the user if logged in" do
+        authorize! prompt: "login"
 
-        expect(response).to redirect_to('/reauthenticate')
+        expect(response).to redirect_to("/reauthenticate")
       end
     end
 
-    context 'with a prompt=consent parameter' do
-      it 'redirects to the sign in form if not logged in' do
-        authorize! prompt: 'consent', current_user: nil
+    context "with a prompt=consent parameter" do
+      it "redirects to the sign in form if not logged in" do
+        authorize! prompt: "consent", current_user: nil
 
-        expect(response).to redirect_to('/login')
+        expect(response).to redirect_to("/login")
       end
 
-      it 'renders the authorization form even if a matching token is present' do
+      it "renders the authorization form even if a matching token is present" do
         create :access_token, token_attributes
-        authorize! prompt: 'consent'
+        authorize! prompt: "consent"
 
         expect_authorization_form!
       end
     end
 
-    context 'with a prompt=select_account parameter' do
-      it 'redirects to the select account screen' do
-        authorize! prompt: 'select_account'
+    context "with a prompt=select_account parameter" do
+      it "redirects to the select account screen" do
+        authorize! prompt: "select_account"
 
-        expect(response).to redirect_to('/select_account')
+        expect(response).to redirect_to("/select_account")
       end
     end
 
-    context 'with a prompt=create parameter' do
-      it 'ignore it w/o returinig invalid_request error' do
-        authorize! prompt: 'create'
+    context "with a prompt=create parameter" do
+      it "ignore it w/o returinig invalid_request error" do
+        authorize! prompt: "create"
 
-        expect(response).to render_template('doorkeeper/authorizations/new')
+        expect(response).to render_template("doorkeeper/authorizations/new")
       end
     end
 
-    context 'with multiple prompt values' do
-      it 'when select_account+login' do
-        authorize! prompt: 'select_account login'
-        expect(response).to redirect_to('/select_account')
+    context "with multiple prompt values" do
+      it "when select_account+login" do
+        authorize! prompt: "select_account login"
+        expect(response).to redirect_to("/select_account")
       end
 
-      it 'when login+select_account' do
-        authorize! prompt: 'login select_account'
-        expect(response).to redirect_to('/select_account')
+      it "when login+select_account" do
+        authorize! prompt: "login select_account"
+        expect(response).to redirect_to("/select_account")
       end
 
-      it 'when consent+select_account' do
-        authorize! prompt: 'consent select_account'
-        expect(response).to redirect_to('/select_account')
+      it "when consent+select_account" do
+        authorize! prompt: "consent select_account"
+        expect(response).to redirect_to("/select_account")
       end
 
-      it 'when select_account+consent' do
-        authorize! prompt: 'select_account consent'
-        expect(response).to redirect_to('/select_account')
+      it "when select_account+consent" do
+        authorize! prompt: "select_account consent"
+        expect(response).to redirect_to("/select_account")
       end
 
-      it 'when login+consent' do
-        authorize! prompt: 'login consent'
-        expect(response).to redirect_to('/reauthenticate')
+      it "when login+consent" do
+        authorize! prompt: "login consent"
+        expect(response).to redirect_to("/reauthenticate")
       end
     end
 
-    context 'with an unknown prompt parameter' do
-      it 'returns an invalid_request error' do
-        authorize! prompt: 'maybe'
+    context "with an unknown prompt parameter" do
+      it "returns an invalid_request error" do
+        authorize! prompt: "maybe"
 
         error_params = {
-          'error' => 'invalid_request',
-          'error_description' => 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.',
+          "error" => "invalid_request",
+          "error_description" => "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.",
         }
 
         expect(response).to redirect_to build_redirect_uri(error_params)
       end
 
-      it 'does not redirect to an invalid redirect_uri' do
-        authorize! prompt: 'maybe', redirect_uri: 'https://evilapp.com'
+      it "does not redirect to an invalid redirect_uri" do
+        authorize! prompt: "maybe", redirect_uri: "https://evilapp.com"
 
         expect(response).not_to be_redirect
       end
     end
   end
 
-  describe '#handle_oidc_max_age_param!' do
-    context 'with an invalid max_age parameter' do
-      it 'renders the authorization form' do
+  describe "#handle_oidc_max_age_param!" do
+    context "with an invalid max_age parameter" do
+      it "renders the authorization form" do
         %w[-1 -23 foobar].each do |max_age|
           authorize! max_age: max_age
 
@@ -350,42 +350,42 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
 
-    context 'with a max_age=0 parameter' do
-      it 'renders the authorization form if the users last login was within 10 seconds' do
+    context "with a max_age=0 parameter" do
+      it "renders the authorization form if the users last login was within 10 seconds" do
         user.update! current_sign_in_at: 5.seconds.ago
         authorize! max_age: 0
 
-        expect(response).to redirect_to '/reauthenticate'
+        expect(response).to redirect_to "/reauthenticate"
       end
     end
 
-    context 'with a max_age=10 parameter' do
-      it 'renders the authorization form if the users last login was within 10 seconds' do
+    context "with a max_age=10 parameter" do
+      it "renders the authorization form if the users last login was within 10 seconds" do
         user.update! current_sign_in_at: 5.seconds.ago
         authorize! max_age: 10
 
         expect_authorization_form!
       end
 
-      it 'reauthenticates the user if the last login was longer than 10 seconds ago' do
+      it "reauthenticates the user if the last login was longer than 10 seconds ago" do
         user.update! current_sign_in_at: 5.minutes.ago
         authorize! max_age: 10
 
-        expect(response).to redirect_to '/reauthenticate'
+        expect(response).to redirect_to "/reauthenticate"
       end
 
-      it 'reauthenticates the user if the last login is unknown' do
+      it "reauthenticates the user if the last login is unknown" do
         user.update! current_sign_in_at: nil
         authorize! max_age: 10
 
-        expect(response).to redirect_to '/reauthenticate'
+        expect(response).to redirect_to "/reauthenticate"
       end
     end
 
     {
-      'an Integer (epoch seconds)' => ->(time) { time.to_i },
-      'a Time' => ->(time) { time.getlocal },
-      'an ActiveSupport::TimeWithZone' => ->(time) { time.in_time_zone },
+      "an Integer (epoch seconds)" => ->(time) { time.to_i },
+      "a Time" => ->(time) { time.getlocal },
+      "an ActiveSupport::TimeWithZone" => ->(time) { time.in_time_zone },
     }.each do |type_description, converter|
       context "when auth_time_from_resource_owner returns #{type_description}" do
         before do
@@ -394,59 +394,59 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
             .and_return(->(resource_owner) { converter.call(resource_owner.current_sign_in_at) })
         end
 
-        it 'renders the authorization form if the last login is within max_age' do
+        it "renders the authorization form if the last login is within max_age" do
           user.update! current_sign_in_at: 5.seconds.ago
           authorize! max_age: 10
 
           expect_authorization_form!
         end
 
-        it 'reauthenticates the user if the last login is older than max_age' do
+        it "reauthenticates the user if the last login is older than max_age" do
           user.update! current_sign_in_at: 15.seconds.ago
           authorize! max_age: 10
 
-          expect(response).to redirect_to '/reauthenticate'
+          expect(response).to redirect_to "/reauthenticate"
         end
       end
     end
 
-    context 'when used along with prompt=select_account' do
-      it 'renders the authorization form' do
+    context "when used along with prompt=select_account" do
+      it "renders the authorization form" do
         user.update! current_sign_in_at: 5.seconds.ago
-        authorize! max_age: 1, prompt: 'select_account'
+        authorize! max_age: 1, prompt: "select_account"
 
-        expect(response).to redirect_to '/select_account'
+        expect(response).to redirect_to "/select_account"
       end
     end
 
-    context 'when used along with prompt=login' do
-      it 'redirects to reauthenticate without raising a DoubleRenderError' do
+    context "when used along with prompt=login" do
+      it "redirects to reauthenticate without raising a DoubleRenderError" do
         user.update! current_sign_in_at: 5.minutes.ago
-        authorize! max_age: 10, prompt: 'login'
+        authorize! max_age: 10, prompt: "login"
 
-        expect(response).to redirect_to '/reauthenticate'
+        expect(response).to redirect_to "/reauthenticate"
       end
     end
 
-    context 'when used along with prompt=consent' do
-      it 'redirects to reauthenticate without raising a DoubleRenderError' do
+    context "when used along with prompt=consent" do
+      it "redirects to reauthenticate without raising a DoubleRenderError" do
         user.update! current_sign_in_at: 5.minutes.ago
-        authorize! max_age: 10, prompt: 'consent'
+        authorize! max_age: 10, prompt: "consent"
 
-        expect(response).to redirect_to '/reauthenticate'
+        expect(response).to redirect_to "/reauthenticate"
       end
     end
   end
 
-  describe '#reauthenticate_oidc_resource_owner' do
+  describe "#reauthenticate_oidc_resource_owner" do
     let(:performed) { true }
 
     before do
       allow(subject).to receive(:clear_oidc_response)
       allow(subject).to receive(:performed?) { performed }
-      allow(subject.request).to receive(:path).and_return('/oauth/authorize')
+      allow(subject.request).to receive(:path).and_return("/oauth/authorize")
       allow(subject.request).to receive(:query_parameters) {
-        { client_id: 'foo', prompt: 'login consent select_account' }.with_indifferent_access
+        { client_id: "foo", prompt: "login consent select_account" }.with_indifferent_access
       }
     end
 
@@ -463,24 +463,24 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       passed_args
     end
 
-    it 'calls reauthenticate_resource_owner with the current user and the return path' do
+    it "calls reauthenticate_resource_owner with the current user and the return path" do
       resource_owner, return_to = reauthenticate!
 
       expect(resource_owner).to eq user
-      expect(return_to).to eq '/oauth/authorize?client_id=foo&prompt=consent+select_account'
+      expect(return_to).to eq "/oauth/authorize?client_id=foo&prompt=consent+select_account"
     end
 
-    it 'removes login from the prompt parameter and keeps other values' do
+    it "removes login from the prompt parameter and keeps other values" do
       _, return_to = reauthenticate!
       return_params = Rack::Utils.parse_query(URI.parse(return_to).query)
 
-      expect(return_params['prompt']).to eq 'consent select_account'
+      expect(return_params["prompt"]).to eq "consent select_account"
     end
 
-    context 'with a reauthenticator that does not generate a response' do
+    context "with a reauthenticator that does not generate a response" do
       let(:performed) { false }
 
-      it 'raises a login_required error' do
+      it "raises a login_required error" do
         expect do
           reauthenticate!
         end.to raise_error(Doorkeeper::OpenidConnect::Errors::LoginRequired)
@@ -488,11 +488,11 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
     end
   end
 
-  describe '#clear_oidc_response' do
+  describe "#clear_oidc_response" do
     before { allow(subject).to receive(:response_body=) }
 
-    it 'clears response_body and @_response_body' do
-      subject.instance_variable_set(:@_response_body, 'foo bar')
+    it "clears response_body and @_response_body" do
+      subject.instance_variable_set(:@_response_body, "foo bar")
 
       subject.send :clear_oidc_response
 
@@ -500,17 +500,17 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       expect(subject.instance_variable_get(:@_response_body)).to be_nil
     end
 
-    it 'does not raise when response body is already nil' do
+    it "does not raise when response body is already nil" do
       expect { subject.send :clear_oidc_response }.not_to raise_error
     end
   end
 
-  describe '#select_account_for_resource_owner' do
+  describe "#select_account_for_resource_owner" do
     before do
       allow(subject).to receive(:clear_oidc_response)
-      allow(subject.request).to receive(:path).and_return('/oauth/authorize')
+      allow(subject.request).to receive(:path).and_return("/oauth/authorize")
       allow(subject.request).to receive(:query_parameters) {
-        { client_id: 'foo', prompt: 'login consent select_account' }.with_indifferent_access
+        { client_id: "foo", prompt: "login consent select_account" }.with_indifferent_access
       }
     end
 
@@ -527,25 +527,25 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       passed_args
     end
 
-    it 'calls select_account_for_resource_owner with the current user and the return path' do
+    it "calls select_account_for_resource_owner with the current user and the return path" do
       resource_owner, return_to = select_account!
 
       expect(resource_owner).to eq user
-      expect(return_to).to eq '/oauth/authorize?client_id=foo&prompt=login+consent'
+      expect(return_to).to eq "/oauth/authorize?client_id=foo&prompt=login+consent"
     end
 
-    it 'removes select_account from the prompt parameter and keeps other values' do
+    it "removes select_account from the prompt parameter and keeps other values" do
       _, return_to = select_account!
       return_params = Rack::Utils.parse_query(URI.parse(return_to).query)
 
-      expect(return_params['prompt']).to eq 'login consent'
+      expect(return_params["prompt"]).to eq "login consent"
     end
   end
 
-  describe '#pre_auth' do
-    it 'permits nonce parameter' do
-      authorize! nonce: '123456'
-      expect(assigns(:pre_auth).nonce).to eq '123456'
+  describe "#pre_auth" do
+    it "permits nonce parameter" do
+      authorize! nonce: "123456"
+      expect(assigns(:pre_auth).nonce).to eq "123456"
     end
   end
 end

--- a/spec/controllers/doorkeeper/authorized_applications_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorized_applications_controller_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::AuthorizedApplicationsController, type: :controller do
   let(:access_token) { create :access_token }
 
-  describe '#index' do
-    it 'does not run the extended #authenticate_resource_owner!' do
+  describe "#index" do
+    it "does not run the extended #authenticate_resource_owner!" do
       expect do
         get :index
       end.not_to raise_error

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :controller do
   let(:redirect_uris) do
     [
-      'https://test.host/registration_success',
-      'https://test.host/registration_success_second_location',
+      "https://test.host/registration_success",
+      "https://test.host/registration_success_second_location",
     ]
   end
 
@@ -36,16 +36,16 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
 
         body = JSON.parse(response.body)
         expect(body).to eq({
-          'client_secret' => doorkeeper_application.plaintext_secret || doorkeeper_application.secret,
-          'client_id' => doorkeeper_application.uid,
-          'client_id_issued_at' => doorkeeper_application.created_at.to_i,
-          'redirect_uris' => redirect_uris,
-          'token_endpoint_auth_method' => 'client_secret_basic',
-          'token_endpoint_auth_methods_supported' => %w[client_secret_basic client_secret_post],
-          'response_types' => ['code', 'token', 'id_token', 'id_token token'],
-          'grant_types' => %w[authorization_code client_credentials implicit_oidc],
-          'scope' => "public",
-          'application_type' => "web",
+          "client_secret" => doorkeeper_application.plaintext_secret || doorkeeper_application.secret,
+          "client_id" => doorkeeper_application.uid,
+          "client_id_issued_at" => doorkeeper_application.created_at.to_i,
+          "redirect_uris" => redirect_uris,
+          "token_endpoint_auth_method" => "client_secret_basic",
+          "token_endpoint_auth_methods_supported" => %w[client_secret_basic client_secret_post],
+          "response_types" => ["code", "token", "id_token", "id_token token"],
+          "grant_types" => %w[authorization_code client_credentials implicit_oidc],
+          "scope" => "public",
+          "application_type" => "web",
         })
       end
     end
@@ -65,8 +65,8 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         expect(doorkeeper_application.confidential).to be true
 
         body = JSON.parse(response.body)
-        expect(body['token_endpoint_auth_method']).to eq('client_secret_basic')
-        expect(body['client_secret']).to be_present
+        expect(body["token_endpoint_auth_method"]).to eq("client_secret_basic")
+        expect(body["client_secret"]).to be_present
       end
     end
 
@@ -85,8 +85,8 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         expect(doorkeeper_application.confidential).to be true
 
         body = JSON.parse(response.body)
-        expect(body['token_endpoint_auth_method']).to eq('client_secret_post')
-        expect(body['client_secret']).to be_present
+        expect(body["token_endpoint_auth_method"]).to eq("client_secret_post")
+        expect(body["client_secret"]).to be_present
       end
     end
 
@@ -105,8 +105,8 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         expect(doorkeeper_application.confidential).to be false
 
         body = JSON.parse(response.body)
-        expect(body['token_endpoint_auth_method']).to eq('none')
-        expect(body).not_to have_key('client_secret')
+        expect(body["token_endpoint_auth_method"]).to eq("none")
+        expect(body).not_to have_key("client_secret")
       end
     end
 
@@ -123,8 +123,8 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         expect(Doorkeeper::Application.count).to eq(0)
 
         body = JSON.parse(response.body)
-        expect(body['error']).to eq('invalid_client_metadata')
-        expect(body['error_description']).to include('private_key_jwt')
+        expect(body["error"]).to eq("invalid_client_metadata")
+        expect(body["error_description"]).to include("private_key_jwt")
       end
     end
 
@@ -141,8 +141,8 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         expect(Doorkeeper::Application.count).to eq(0)
 
         body = JSON.parse(response.body)
-        expect(body['error']).to eq('invalid_client_metadata')
-        expect(body['error_description']).to include('unknown_value')
+        expect(body["error"]).to eq("invalid_client_metadata")
+        expect(body["error_description"]).to include("unknown_value")
       end
     end
 
@@ -161,7 +161,7 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
 
         expect(response.status).to eq 201
         body = JSON.parse(response.body)
-        expect(body['token_endpoint_auth_methods_supported']).to eq(%w[client_secret_basic])
+        expect(body["token_endpoint_auth_methods_supported"]).to eq(%w[client_secret_basic])
       end
     end
 
@@ -201,7 +201,7 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         post :register, params: {
           client_name: "dummy_client",
           redirect_uris: [
-            'http://test.host/registration_success',
+            "http://test.host/registration_success",
           ],
           scope: "openid"
         }

--- a/spec/controllers/userinfo_controller_spec.rb
+++ b/spec/controllers/userinfo_controller_spec.rb
@@ -1,62 +1,62 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::UserinfoController, type: :controller do
   let(:client) { create :application }
-  let(:user)   { create :user, name: 'Joe' }
+  let(:user)   { create :user, name: "Joe" }
   let(:token)  { create :access_token, application: client, resource_owner_id: user.id }
 
-  describe '#show' do
-    context 'with a valid access token authorized for the openid scope' do
-      let(:token) { create :access_token, application: client, resource_owner_id: user.id, scopes: 'openid' }
+  describe "#show" do
+    context "with a valid access token authorized for the openid scope" do
+      let(:token) { create :access_token, application: client, resource_owner_id: user.id, scopes: "openid" }
 
-      it 'returns the basic user information as JSON' do
+      it "returns the basic user information as JSON" do
         get :show, params: { access_token: token.token }
 
         expect(response.status).to eq 200
         expect(JSON.parse(response.body)).to eq({
-          'sub'                => user.id.to_s,
-          'variable_name'      => 'openid-name',
-          'created_at'         => user.created_at.to_i,
-          'token_id'           => token.id,
-          'both_responses'     => 'both',
-          'user_info_response' => 'user_info',
+          "sub"                => user.id.to_s,
+          "variable_name"      => "openid-name",
+          "created_at"         => user.created_at.to_i,
+          "token_id"           => token.id,
+          "both_responses"     => "both",
+          "user_info_response" => "user_info",
         })
       end
     end
 
-    context 'with a valid access token authorized for the openid and profile scopes' do
-      let(:token) { create :access_token, application: client, resource_owner_id: user.id, scopes: 'openid profile' }
+    context "with a valid access token authorized for the openid and profile scopes" do
+      let(:token) { create :access_token, application: client, resource_owner_id: user.id, scopes: "openid profile" }
 
-      it 'returns the full user information as JSON' do
+      it "returns the full user information as JSON" do
         get :show, params: { access_token: token.token }
 
         expect(response.status).to eq 200
         expect(JSON.parse(response.body)).to eq({
-          'sub'                => user.id.to_s,
-          'name'               => 'Joe',
-          'variable_name'      => 'profile-name',
-          'created_at'         => user.created_at.to_i,
-          'updated_at'         => user.updated_at.to_i,
-          'token_id'           => token.id,
-          'both_responses'     => 'both',
-          'user_info_response' => 'user_info',
+          "sub"                => user.id.to_s,
+          "name"               => "Joe",
+          "variable_name"      => "profile-name",
+          "created_at"         => user.created_at.to_i,
+          "updated_at"         => user.updated_at.to_i,
+          "token_id"           => token.id,
+          "both_responses"     => "both",
+          "user_info_response" => "user_info",
         })
       end
     end
 
-    context 'with a valid access token not authorized for the openid scope' do
-      it 'returns an error' do
+    context "with a valid access token not authorized for the openid scope" do
+      it "returns an error" do
         get :show, params: { access_token: token.token }
 
         expect(response.status).to eq 403
       end
     end
 
-    context 'without a valid access token' do
-      it 'returns an error' do
-        get :show, params: { access_token: 'foobar' }
+    context "without a valid access token" do
+      it "returns an error" do
+        get :show, params: { access_token: "foobar" }
 
         expect(response.status).to eq 401
       end

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -3,6 +3,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/spec/dummy/app/mailers/application_mailer.rb
+++ b/spec/dummy/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: "from@example.com"
+  layout "mailer"
 end

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -2,6 +2,6 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   # Rails 7.1 deprecated false in favor of :none, but we need to use false for
   # backwards compatibility: https://github.com/rails/rails/pull/45867
   config.action_dispatch.show_exceptions =
-    Rails.gem_version >= Gem::Version.new('7.1.0') ? :none : false
+    Rails.gem_version >= Gem::Version.new("7.1.0") ? :none : false
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -7,7 +7,7 @@ Doorkeeper.configure do
     if params[:current_user].present?
       User.find(params[:current_user])
     else
-      redirect_to('/login')
+      redirect_to("/login")
       nil
     end
   end

--- a/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
+++ b/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Doorkeeper::OpenidConnect.configure do
-  issuer 'dummy'
+  issuer "dummy"
 
   signing_key <<~EOL
     -----BEGIN RSA PRIVATE KEY-----
@@ -44,11 +44,11 @@ Doorkeeper::OpenidConnect.configure do
   end
 
   reauthenticate_resource_owner do |_resource_owner, _return_to|
-    redirect_to '/reauthenticate'
+    redirect_to "/reauthenticate"
   end
 
   select_account_for_resource_owner do |_resource_owner, _return_to|
-    redirect_to '/select_account'
+    redirect_to "/select_account"
   end
 
   subject do |resource_owner|
@@ -60,8 +60,8 @@ Doorkeeper::OpenidConnect.configure do
       user.name
     end
 
-    claim :variable_name, scope: :openid do |user, scopes|
-      scopes.exists?(:profile) ? 'profile-name' : 'openid-name'
+    claim :variable_name, scope: :openid do |_user, scopes|
+      scopes.exists?(:profile) ? "profile-name" : "openid-name"
     end
 
     claim :created_at, scope: :openid do |user|
@@ -72,12 +72,12 @@ Doorkeeper::OpenidConnect.configure do
       user.updated_at.to_i
     end
 
-    claim :token_id, scope: :openid do |user, scopes, token|
+    claim :token_id, scope: :openid do |_user, _scopes, token|
       token.id
     end
 
-    claim(:both_responses, scope: :openid, response: [:id_token, :user_info]) { 'both' }
-    claim(:id_token_response, scope: :openid, response: [:id_token]) { 'id_token' }
-    claim(:user_info_response, scope: :openid, response: :user_info) { 'user_info' }
+    claim(:both_responses, scope: :openid, response: [:id_token, :user_info]) { "both" }
+    claim(:id_token_response, scope: :openid, response: [:id_token]) { "id_token" }
+    claim(:user_info_response, scope: :openid, response: :user_info) { "user_info" }
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :access_grant, class: 'Doorkeeper::AccessGrant' do
+  factory :access_grant, class: "Doorkeeper::AccessGrant" do
     resource_owner_id { create(:user).id }
     application
-    redirect_uri { 'https://app.com/callback' }
+    redirect_uri { "https://app.com/callback" }
     expires_in { 100 }
-    scopes { 'public write' }
+    scopes { "public write" }
   end
 
-  factory :access_token, class: 'Doorkeeper::AccessToken' do
+  factory :access_token, class: "Doorkeeper::AccessToken" do
     resource_owner_id { create(:user).id }
     application
     expires_in { 2.hours }
@@ -19,9 +19,9 @@ FactoryBot.define do
     end
   end
 
-  factory :application, class: 'Doorkeeper::Application' do
+  factory :application, class: "Doorkeeper::Application" do
     sequence(:name) { |n| "Application #{n}" }
-    redirect_uri { 'https://app.com/callback' }
+    redirect_uri { "https://app.com/callback" }
   end
 
   factory :user do

--- a/spec/lib/claims/claim_spec.rb
+++ b/spec/lib/claims/claim_spec.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::Claims::Claim do
-  subject { described_class.new name: 'username', scope: 'profile' }
+  subject { described_class.new name: "username", scope: "profile" }
 
-  describe '#initialize' do
-    it 'uses the given name' do
+  describe "#initialize" do
+    it "uses the given name" do
       expect(subject.name).to eq :username
     end
 
-    it 'uses the given scope' do
+    it "uses the given scope" do
       expect(subject.scope).to eq :profile
     end
 
-    it 'falls back to the default scope for standard claims' do
-      expect(described_class.new(name: 'family_name').scope).to eq :profile
+    it "falls back to the default scope for standard claims" do
+      expect(described_class.new(name: "family_name").scope).to eq :profile
       expect(described_class.new(name: :family_name).scope).to eq :profile
-      expect(described_class.new(name: 'email').scope).to eq :email
+      expect(described_class.new(name: "email").scope).to eq :email
       expect(described_class.new(name: :email).scope).to eq :email
-      expect(described_class.new(name: 'address').scope).to eq :address
+      expect(described_class.new(name: "address").scope).to eq :address
       expect(described_class.new(name: :address).scope).to eq :address
-      expect(described_class.new(name: 'phone_number').scope).to eq :phone
+      expect(described_class.new(name: "phone_number").scope).to eq :phone
       expect(described_class.new(name: :phone_number).scope).to eq :phone
     end
 
-    it 'falls back to the profile scope for non-standard claims' do
-      expect(described_class.new(name: 'unknown').scope).to eq :profile
+    it "falls back to the profile scope for non-standard claims" do
+      expect(described_class.new(name: "unknown").scope).to eq :profile
     end
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe Doorkeeper::OpenidConnect, 'configuration' do
+describe Doorkeeper::OpenidConnect, "configuration" do
   subject { described_class.configuration }
 
-  describe '#configure' do
-    it 'fails if not set to :active_record' do
+  describe "#configure" do
+    it "fails if not set to :active_record" do
       # stub ORM setup to avoid Doorkeeper exceptions
       allow(Doorkeeper).to receive(:setup_orm_adapter)
       allow(Doorkeeper).to receive(:setup_orm_models)
@@ -22,9 +22,9 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'jws_private_key' do
-    it 'delegates to signing_key' do
-      value = 'private_key'
+  describe "jws_private_key" do
+    it "delegates to signing_key" do
+      value = "private_key"
       described_class.configure do
         jws_private_key value
       end
@@ -32,9 +32,9 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'signing_key' do
-    it 'sets the value that is accessible via signing_key' do
-      value = 'private_key'
+  describe "signing_key" do
+    it "sets the value that is accessible via signing_key" do
+      value = "private_key"
       described_class.configure do
         signing_key value
       end
@@ -42,16 +42,16 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'issuer' do
-    it 'sets the value that is accessible via issuer' do
-      value = 'issuer'
+  describe "issuer" do
+    it "sets the value that is accessible via issuer" do
+      value = "issuer"
       described_class.configure do
         issuer value
       end
       expect(subject.issuer).to eq(value)
     end
 
-    it 'sets the block that is accessible via issuer' do
+    it "sets the block that is accessible via issuer" do
       block = proc {}
       described_class.configure do
         issuer(&block)
@@ -60,8 +60,8 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'resource_owner_from_access_token' do
-    it 'sets the block that is accessible via resource_owner_from_access_token' do
+  describe "resource_owner_from_access_token" do
+    it "sets the block that is accessible via resource_owner_from_access_token" do
       block = proc {}
       described_class.configure do
         resource_owner_from_access_token(&block)
@@ -69,7 +69,7 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       expect(subject.resource_owner_from_access_token).to eq(block)
     end
 
-    it 'fails if unset' do
+    it "fails if unset" do
       described_class.configure {}
 
       expect do
@@ -78,8 +78,8 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'auth_time_from_resource_owner' do
-    it 'sets the block that is accessible via auth_time_from_resource_owner' do
+  describe "auth_time_from_resource_owner" do
+    it "sets the block that is accessible via auth_time_from_resource_owner" do
       block = proc {}
       described_class.configure do
         auth_time_from_resource_owner(&block)
@@ -87,7 +87,7 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       expect(subject.auth_time_from_resource_owner).to eq(block)
     end
 
-    it 'fails if unset' do
+    it "fails if unset" do
       described_class.configure {}
 
       expect do
@@ -96,8 +96,8 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'reauthenticate_resource_owner' do
-    it 'sets the block that is accessible via reauthenticate_resource_owner' do
+  describe "reauthenticate_resource_owner" do
+    it "sets the block that is accessible via reauthenticate_resource_owner" do
       block = proc {}
       described_class.configure do
         reauthenticate_resource_owner(&block)
@@ -105,7 +105,7 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       expect(subject.reauthenticate_resource_owner).to eq(block)
     end
 
-    it 'fails if unset' do
+    it "fails if unset" do
       described_class.configure {}
 
       expect do
@@ -114,8 +114,8 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'select_account_for_resource_owner' do
-    it 'sets the block that is accessible via select_account_for_resource_owner' do
+  describe "select_account_for_resource_owner" do
+    it "sets the block that is accessible via select_account_for_resource_owner" do
       block = proc {}
       described_class.configure do
         select_account_for_resource_owner(&block)
@@ -123,7 +123,7 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       expect(subject.select_account_for_resource_owner).to eq(block)
     end
 
-    it 'fails if unset' do
+    it "fails if unset" do
       described_class.configure {}
 
       expect do
@@ -132,8 +132,8 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'subject' do
-    it 'sets the block that is accessible via subject' do
+  describe "subject" do
+    it "sets the block that is accessible via subject" do
       block = proc {}
       described_class.configure do
         subject(&block)
@@ -141,7 +141,7 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
       expect(subject.subject).to eq(block)
     end
 
-    it 'fails if unset' do
+    it "fails if unset" do
       described_class.configure {}
 
       expect do
@@ -150,9 +150,9 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'expiration' do
-    it 'sets the value that is accessible via expiration' do
-      value = 'expiration'
+  describe "expiration" do
+    it "sets the value that is accessible via expiration" do
+      value = "expiration"
       described_class.configure do
         expiration value
       end
@@ -160,8 +160,8 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'claims' do
-    it 'sets the claims configuration that is accessible via claims' do
+  describe "claims" do
+    it "sets the claims configuration that is accessible via claims" do
       described_class.configure do
         claims do
         end
@@ -170,20 +170,20 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'protocol' do
-    it 'defaults to https in production' do
+  describe "protocol" do
+    it "defaults to https in production" do
       expect(::Rails.env).to receive(:production?).and_return(true)
 
       expect(subject.protocol.call).to eq(:https)
     end
 
-    it 'defaults to http in other environments' do
+    it "defaults to http in other environments" do
       expect(::Rails.env).to receive(:production?).and_return(false)
 
       expect(subject.protocol.call).to eq(:http)
     end
 
-    it 'can be set to other protocols' do
+    it "can be set to other protocols" do
       described_class.configure do
         protocol { :ftp }
       end
@@ -192,41 +192,41 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
-  describe 'end_session_endpoint' do
-    it 'defaults to nil' do
+  describe "end_session_endpoint" do
+    it "defaults to nil" do
       expect(subject.end_session_endpoint.call).to be_nil
     end
 
-    it 'can be set to a custom url' do
+    it "can be set to a custom url" do
       described_class.configure do
-        end_session_endpoint { 'http://test.host/logout' }
+        end_session_endpoint { "http://test.host/logout" }
       end
 
-      expect(subject.end_session_endpoint.call).to eq('http://test.host/logout')
+      expect(subject.end_session_endpoint.call).to eq("http://test.host/logout")
     end
   end
 
-  describe 'discovery_url_options' do
-    it 'defaults to empty hash' do
-      expect(subject.discovery_url_options.call).to be_kind_of(Hash)
+  describe "discovery_url_options" do
+    it "defaults to empty hash" do
+      expect(subject.discovery_url_options.call).to be_a(Hash)
       expect(subject.discovery_url_options.call).to be_empty
     end
 
-    it 'can be set to other hosts' do
+    it "can be set to other hosts" do
       Doorkeeper::OpenidConnect.configure do
-        discovery_url_options do |request|
+        discovery_url_options do |_request|
           {
-            authorization: { host: 'alternate-authorization-host' },
-            token: { host: 'alternate-token-host' },
-            revocation: { host: 'alternate-revocation-host' },
-            introspection: { host: 'alternate-introspection-host' },
-            userinfo: { host: 'alternate-userinfo-host' },
-            jwks: { host: 'alternate-jwks-host' }
+            authorization: { host: "alternate-authorization-host" },
+            token: { host: "alternate-token-host" },
+            revocation: { host: "alternate-revocation-host" },
+            introspection: { host: "alternate-introspection-host" },
+            userinfo: { host: "alternate-userinfo-host" },
+            jwks: { host: "alternate-jwks-host" }
           }
         end
       end
 
-      expect(subject.discovery_url_options.call[:authorization]).to eq(host: 'alternate-authorization-host')
+      expect(subject.discovery_url_options.call[:authorization]).to eq(host: "alternate-authorization-host")
     end
   end
 end

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -1,80 +1,80 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::IdToken do
   subject { described_class.new(access_token, nonce) }
 
-  let(:access_token) { create :access_token, resource_owner_id: user.id, scopes: 'openid' }
+  let(:access_token) { create :access_token, resource_owner_id: user.id, scopes: "openid" }
   let(:user) { create :user }
-  let(:nonce) { '123456' }
+  let(:nonce) { "123456" }
 
   before do
     allow(Time).to receive(:now) { Time.zone.at 60 }
   end
 
-  describe '#nonce' do
-    it 'returns the stored nonce' do
-      expect(subject.nonce).to eq '123456'
+  describe "#nonce" do
+    it "returns the stored nonce" do
+      expect(subject.nonce).to eq "123456"
     end
   end
 
-  describe '#claims' do
-    it 'returns all default claims' do
+  describe "#claims" do
+    it "returns all default claims" do
       expect(subject.claims).to eq(
-        iss: 'dummy',
+        iss: "dummy",
         sub: user.id.to_s,
         aud: access_token.application.uid,
         exp: 180,
         iat: 60,
         nonce: nonce,
         auth_time: 23,
-        both_responses: 'both',
-        id_token_response: 'id_token',
+        both_responses: "both",
+        id_token_response: "id_token",
       )
     end
 
-    context 'when expires_in is specified for the token' do
+    context "when expires_in is specified for the token" do
       subject { described_class.new(access_token, nonce, expires_in) }
 
       let(:expires_in) { 10 }
 
-      it 'returns expiration claim with the specified value' do
+      it "returns expiration claim with the specified value" do
         expect(subject.claims[:exp]).to eq(subject.claims[:iat] + expires_in)
       end
     end
-    
-    context 'when the expiration is a block' do
+
+    context "when the expiration is a block" do
       subject { described_class.new(access_token, nonce, expires_in) }
 
       let(:expires_in) { proc { |_, _| 10 } }
 
-      it 'returns expiration claim with the specified value' do
+      it "returns expiration claim with the specified value" do
         expect(subject.claims[:exp]).to eq(subject.claims[:iat] + expires_in.call(user, access_token.application))
       end
     end
 
-    context 'when application is not set on the access token' do
+    context "when application is not set on the access token" do
       before do
         access_token.application = nil
       end
 
-      it 'returns all default claims except audience' do
+      it "returns all default claims except audience" do
         expect(subject.claims).to eq(
-          iss: 'dummy',
+          iss: "dummy",
           sub: user.id.to_s,
           aud: nil,
           exp: 180,
           iat: 60,
           nonce: nonce,
           auth_time: 23,
-          both_responses: 'both',
-          id_token_response: 'id_token',
+          both_responses: "both",
+          id_token_response: "id_token",
         )
       end
     end
 
-    context 'when issuer block has arity 3' do
+    context "when issuer block has arity 3" do
       before do
         Doorkeeper::OpenidConnect.configure do
           issuer do |resource_owner, application, _request|
@@ -95,16 +95,16 @@ describe Doorkeeper::OpenidConnect::IdToken do
         end
       end
 
-      it 'passes resource_owner and application to the issuer block' do
+      it "passes resource_owner and application to the issuer block" do
         claims = subject.claims
         expect(claims[:iss]).to eq "#{user.id}-#{access_token.application.uid}"
       end
     end
 
-    context 'when auth_time_from_resource_owner is not configured' do
+    context "when auth_time_from_resource_owner is not configured" do
       before do
         Doorkeeper::OpenidConnect.configure do
-          issuer 'dummy'
+          issuer "dummy"
 
           resource_owner_from_access_token do |access_token|
             User.find_by(id: access_token.resource_owner_id)
@@ -116,7 +116,7 @@ describe Doorkeeper::OpenidConnect::IdToken do
         end
       end
 
-      it 'builds claims without raising and omits auth_time' do
+      it "builds claims without raising and omits auth_time" do
         expect { subject.claims }.not_to raise_error
         expect(subject.claims[:auth_time]).to be_nil
         expect(subject.as_json).not_to include(:auth_time)
@@ -124,11 +124,11 @@ describe Doorkeeper::OpenidConnect::IdToken do
     end
   end
 
-  describe '#as_json' do
-    it 'returns claims with nil values and empty strings removed' do
+  describe "#as_json" do
+    it "returns claims with nil values and empty strings removed" do
       allow(subject).to receive(:issuer).and_return(nil)
-      allow(subject).to receive(:subject).and_return('')
-      allow(subject).to receive(:audience).and_return(' ')
+      allow(subject).to receive(:subject).and_return("")
+      allow(subject).to receive(:audience).and_return(" ")
 
       json = subject.as_json
 
@@ -138,9 +138,9 @@ describe Doorkeeper::OpenidConnect::IdToken do
     end
   end
 
-  describe '#as_jws_token' do
-    shared_examples 'a jws token' do
-      it 'returns claims encoded as JWT' do
+  describe "#as_jws_token" do
+    shared_examples "a jws token" do
+      it "returns claims encoded as JWT" do
         algorithms = [Doorkeeper::OpenidConnect.signing_algorithm.to_s]
 
         data, headers = ::JWT.decode subject.as_jws_token, Doorkeeper::OpenidConnect.signing_key.keypair, true, { algorithms: algorithms }
@@ -151,18 +151,18 @@ describe Doorkeeper::OpenidConnect::IdToken do
       end
     end
 
-    it_behaves_like 'a jws token'
+    it_behaves_like "a jws token"
 
-    context 'when signing_algorithm is EC' do
+    context "when signing_algorithm is EC" do
       before { configure_ec }
 
-      it_behaves_like 'a jws token'
+      it_behaves_like "a jws token"
     end
 
-    context 'when signing_algorithm is HMAC' do
+    context "when signing_algorithm is HMAC" do
       before { configure_hmac }
 
-      it_behaves_like 'a jws token'
+      it_behaves_like "a jws token"
     end
   end
 end

--- a/spec/lib/id_token_token_spec.rb
+++ b/spec/lib/id_token_token_spec.rb
@@ -1,67 +1,67 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::IdTokenToken do
   subject { described_class.new(access_token, nonce) }
 
-  let(:access_token) { create :access_token, resource_owner_id: user.id, scopes: 'openid' }
+  let(:access_token) { create :access_token, resource_owner_id: user.id, scopes: "openid" }
   let(:user) { create :user }
-  let(:nonce) { '123456' }
+  let(:nonce) { "123456" }
 
   before do
     allow(Time).to receive(:now) { Time.zone.at 60 }
   end
 
-  describe '#claims' do
-    it 'returns all default claims' do
+  describe "#claims" do
+    it "returns all default claims" do
       # access token is from http://openid.net/specs/openid-connect-core-1_0.html
       # so we can test `at_hash` value
-      access_token.update(token: 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y')
+      access_token.update(token: "jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y")
 
       expect(subject.claims).to eq({
-        iss: 'dummy',
+        iss: "dummy",
         sub: user.id.to_s,
         aud: access_token.application.uid,
         exp: 180,
         iat: 60,
         nonce: nonce,
         auth_time: 23,
-        at_hash: '77QmUPtjPfzWtF2AnpK9RQ',
-        both_responses: 'both',
-        id_token_response: 'id_token',
+        at_hash: "77QmUPtjPfzWtF2AnpK9RQ",
+        both_responses: "both",
+        id_token_response: "id_token",
       })
     end
   end
 
-  describe '#at_hash' do
+  describe "#at_hash" do
     # Per OIDC Core 1.0 §3.1.3.6 / §3.2.2.9, at_hash must use the hash algorithm
     # that matches the alg of the ID Token's JOSE header (e.g. HS512 -> SHA-512).
-    let(:token_value) { 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y' }
+    let(:token_value) { "jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y" }
 
     before { access_token.update(token: token_value) }
 
     def expected_at_hash(token, hasher)
       digest = hasher.digest(token)
-      Base64.urlsafe_encode64(digest[0, digest.length / 2]).tr('=', '')
+      Base64.urlsafe_encode64(digest[0, digest.length / 2]).tr("=", "")
     end
 
-    it 'uses SHA-256 for the default RS256 signing algorithm' do
+    it "uses SHA-256 for the default RS256 signing algorithm" do
       expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA256))
     end
 
-    context 'when signing_algorithm is HS512' do
+    context "when signing_algorithm is HS512" do
       before { configure_hmac }
 
-      it 'uses SHA-512' do
+      it "uses SHA-512" do
         expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA512))
       end
     end
 
-    context 'when signing_algorithm is ES512' do
+    context "when signing_algorithm is ES512" do
       before { configure_ec }
 
-      it 'uses SHA-512' do
+      it "uses SHA-512" do
         expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA512))
       end
     end

--- a/spec/lib/oauth/authorization/code_spec.rb
+++ b/spec/lib/oauth/authorization/code_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::OAuth::Authorization::Code do
   subject { Doorkeeper::OAuth::Authorization::Code.new pre_auth, resource_owner }
@@ -11,45 +11,45 @@ describe Doorkeeper::OpenidConnect::OAuth::Authorization::Code do
   let(:client) { double }
   let(:openid_request_class) { Doorkeeper::OpenidConnect.configuration.open_id_request_model }
 
-  describe '#issue_token' do
+  describe "#issue_token" do
     before do
       allow(pre_auth).to receive(:client) { client }
-      allow(pre_auth).to receive(:redirect_uri).and_return('redirect_uri')
-      allow(pre_auth).to receive(:scopes).and_return('scopes')
-      allow(pre_auth).to receive(:nonce).and_return('123456')
-      allow(pre_auth).to receive(:code_challenge).and_return('987654')
-      allow(pre_auth).to receive(:code_challenge_method).and_return('plain')
+      allow(pre_auth).to receive(:redirect_uri).and_return("redirect_uri")
+      allow(pre_auth).to receive(:scopes).and_return("scopes")
+      allow(pre_auth).to receive(:nonce).and_return("123456")
+      allow(pre_auth).to receive(:code_challenge).and_return("987654")
+      allow(pre_auth).to receive(:code_challenge_method).and_return("plain")
       allow(pre_auth).to receive(:custom_access_token_attributes).and_return({})
-      allow(client).to receive(:id).and_return('client_id')
+      allow(client).to receive(:id).and_return("client_id")
 
       allow(Doorkeeper::AccessGrant).to receive(:create!) { access_grant }
       allow(openid_request_class).to receive(:create!)
     end
 
-    it 'stores the nonce' do
+    it "stores the nonce" do
       subject.issue_token
 
       expect(openid_request_class).to have_received(:create!).with({
         access_grant: access_grant,
-        nonce: '123456'
+        nonce: "123456"
       })
     end
 
-    it 'does not store the nonce if not present' do
+    it "does not store the nonce if not present" do
       allow(pre_auth).to receive(:nonce).and_return(nil)
       subject.issue_token
 
       expect(openid_request_class).not_to have_received(:create!)
     end
 
-    it 'does not store the nonce if blank' do
-      allow(pre_auth).to receive(:nonce).and_return(' ')
+    it "does not store the nonce if blank" do
+      allow(pre_auth).to receive(:nonce).and_return(" ")
       subject.issue_token
 
       expect(openid_request_class).not_to have_received(:create!)
     end
 
-    it 'returns the created grant' do
+    it "returns the created grant" do
       expect(subject.issue_token).to be_a Doorkeeper::AccessGrant
     end
   end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
   subject do
     Doorkeeper::OAuth::AuthorizationCodeRequest.new(server, grant, client).tap do |request|
-      request.instance_variable_set '@response', response
-      request.instance_variable_set('@access_token', token)
+      request.instance_variable_set "@response", response
+      request.instance_variable_set("@access_token", token)
     end
   end
 
   let(:server) { double }
   let(:client) { double }
   let(:grant) { create :access_grant, openid_request: openid_request }
-  let(:openid_request) { create :openid_request, nonce: '123456' }
-  let(:token) { create :access_token, scopes: 'openid' }
+  let(:openid_request) { create :openid_request, nonce: "123456" }
+  let(:token) { create :access_token, scopes: "openid" }
   let(:response) { Doorkeeper::OAuth::TokenResponse.new token }
   let(:openid_request_class) { Doorkeeper::OpenidConnect.configuration.open_id_request_model }
 
-  describe '#after_successful_response' do
-    it 'adds the ID token to the response when the openid scope is granted' do
+  describe "#after_successful_response" do
+    it "adds the ID token to the response when the openid scope is granted" do
       subject.send :after_successful_response
 
       expect(response.id_token).to be_a Doorkeeper::OpenidConnect::IdToken
-      expect(response.id_token.nonce).to eq '123456'
+      expect(response.id_token.nonce).to eq "123456"
     end
 
-    it 'destroys the OpenID request record' do
+    it "destroys the OpenID request record" do
       grant.save!
 
       expect do
@@ -34,18 +34,18 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
       end.to change { openid_request_class.count }.by(-1)
     end
 
-    it 'skips the nonce if not present' do
+    it "skips the nonce if not present" do
       grant.openid_request.nonce = nil
       subject.send :after_successful_response
 
       expect(response.id_token.nonce).to be_nil
     end
 
-    context 'when the access token does not include the openid scope' do
-      let(:token) { create :access_token, scopes: 'public' }
+    context "when the access token does not include the openid scope" do
+      let(:token) { create :access_token, scopes: "public" }
       let(:grant) { create :access_grant, openid_request: nil }
 
-      it 'does not build an ID token' do
+      it "does not build an ID token" do
         expect(Doorkeeper::OpenidConnect::IdToken).not_to receive(:new)
 
         subject.send :after_successful_response
@@ -54,10 +54,10 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
       end
     end
 
-    context 'when the grant has an OpenID request but the token lacks the openid scope' do
-      let(:token) { create :access_token, scopes: 'public' }
+    context "when the grant has an OpenID request but the token lacks the openid scope" do
+      let(:token) { create :access_token, scopes: "public" }
 
-      it 'destroys the OpenID request record' do
+      it "destroys the OpenID request record" do
         grant.save!
 
         expect do
@@ -65,7 +65,7 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
         end.to change { openid_request_class.count }.by(-1)
       end
 
-      it 'does not build an ID token' do
+      it "does not build an ID token" do
         expect(Doorkeeper::OpenidConnect::IdToken).not_to receive(:new)
 
         subject.send :after_successful_response

--- a/spec/lib/oauth/id_token_request_spec.rb
+++ b/spec/lib/oauth/id_token_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OAuth::IdTokenRequest do
   subject do
@@ -8,21 +8,21 @@ describe Doorkeeper::OAuth::IdTokenRequest do
   end
 
   let :application do
-    FactoryBot.create(:application, scopes: 'public')
+    FactoryBot.create(:application, scopes: "public")
   end
 
   let :pre_auth do
     server = Doorkeeper.configuration
-    allow(server).to receive(:grant_flows).and_return(['implicit_oidc'])
+    allow(server).to receive(:grant_flows).and_return(["implicit_oidc"])
 
     client = Doorkeeper::OAuth::Client.new(application)
 
     attributes = {
       client_id: client.uid,
-      response_type: 'id_token',
-      redirect_uri: 'https://app.com/callback',
-      scope: 'public',
-      nonce: '12345',
+      response_type: "id_token",
+      redirect_uri: "https://app.com/callback",
+      scope: "public",
+      nonce: "12345",
     }
 
     pre_auth = Doorkeeper::OAuth::PreAuthorization.new(server, attributes)
@@ -33,44 +33,44 @@ describe Doorkeeper::OAuth::IdTokenRequest do
   let(:owner) { build_stubbed(:user) }
 
   # just to make sure self created pre_auth is authorizable
-  it 'pre_auth should be valid' do
+  it "pre_auth should be valid" do
     expect(pre_auth).to be_authorizable
   end
 
-  it 'creates an access token' do
+  it "creates an access token" do
     expect do
       subject.authorize
     end.to change { Doorkeeper::AccessToken.count }.by(1)
   end
 
-  it 'returns id_token response' do
+  it "returns id_token response" do
     expect(subject.authorize).to be_a(Doorkeeper::OAuth::IdTokenResponse)
   end
 
-  context 'token reuse' do
-    it 'creates a new token if there are no matching tokens' do
+  context "token reuse" do
+    it "creates a new token if there are no matching tokens" do
       allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
       expect do
         subject.authorize
       end.to change { Doorkeeper::AccessToken.count }.by(1)
     end
 
-    it 'creates a new token if scopes do not match' do
+    it "creates a new token if scopes do not match" do
       allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
       create(:access_token, application_id: pre_auth.client.id,
-             resource_owner_id: owner.id, scopes: '')
+             resource_owner_id: owner.id, scopes: "")
       expect do
         subject.authorize
       end.to change { Doorkeeper::AccessToken.count }.by(1)
     end
 
-    it 'skips token creation if there is a matching one' do
+    it "skips token creation if there is a matching one" do
       allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
       allow(application.scopes).to receive(:has_scopes?).and_return(true)
       allow(application.scopes).to receive(:all?).and_return(true)
 
       create(:access_token, application_id: pre_auth.client.id,
-             resource_owner_id: owner.id, scopes: 'public')
+             resource_owner_id: owner.id, scopes: "public")
 
       expect { subject.authorize }.not_to(change { Doorkeeper::AccessToken.count })
     end

--- a/spec/lib/oauth/id_token_response_spec.rb
+++ b/spec/lib/oauth/id_token_response_spec.rb
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OAuth::IdTokenResponse do
   subject { described_class.new(pre_auth, auth, id_token) }
 
   let(:token) { create :access_token }
   let(:application) do
-    create(:application, scopes: 'public')
+    create(:application, scopes: "public")
   end
 
   let(:pre_auth) do
     double(
       :pre_auth,
       client: application,
-      redirect_uri: 'http://tst.com/cb',
-      state: 'state',
-      scopes: Doorkeeper::OAuth::Scopes.from_string('public'),
+      redirect_uri: "http://tst.com/cb",
+      state: "state",
+      scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
       error: nil,
       authorizable?: true,
-      nonce: '12345'
+      nonce: "12345"
     )
   end
 
@@ -36,31 +36,31 @@ describe Doorkeeper::OAuth::IdTokenResponse do
   end
   let(:id_token) { Doorkeeper::OpenidConnect::IdToken.new(token, pre_auth) }
 
-  describe '#body' do
-    it 'returns the id_token and state only (no expires_in per OIDC Core §3.2.2.5)' do
+  describe "#body" do
+    it "returns the id_token and state only (no expires_in per OIDC Core §3.2.2.5)" do
       expect(subject.body).to eq({
         state: pre_auth.state,
         id_token: id_token.as_jws_token
       })
     end
 
-    it 'does not include expires_in' do
+    it "does not include expires_in" do
       expect(subject.body).not_to have_key(:expires_in)
     end
   end
 
-  describe '#redirect_uri' do
-    it 'includes id_token and state' do
+  describe "#redirect_uri" do
+    it "includes id_token and state" do
       expect(subject.redirect_uri).to include("#{pre_auth.redirect_uri}#state=#{pre_auth.state}&" \
         "id_token=#{id_token.as_jws_token}")
     end
 
-    it 'does not include access_token' do
-      expect(subject.redirect_uri).not_to include('access_token')
+    it "does not include access_token" do
+      expect(subject.redirect_uri).not_to include("access_token")
     end
 
-    it 'does not include expires_in' do
-      expect(subject.redirect_uri).not_to include('expires_in')
+    it "does not include expires_in" do
+      expect(subject.redirect_uri).not_to include("expires_in")
     end
   end
 end

--- a/spec/lib/oauth/id_token_token_request_spec.rb
+++ b/spec/lib/oauth/id_token_token_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OAuth::IdTokenTokenRequest do
   subject do
@@ -8,21 +8,21 @@ describe Doorkeeper::OAuth::IdTokenTokenRequest do
   end
 
   let :application do
-    FactoryBot.create(:application, scopes: 'public')
+    FactoryBot.create(:application, scopes: "public")
   end
 
   let :pre_auth do
     server = Doorkeeper.configuration
-    allow(server).to receive(:grant_flows).and_return(['implicit_oidc'])
+    allow(server).to receive(:grant_flows).and_return(["implicit_oidc"])
 
     client = Doorkeeper::OAuth::Client.new(application)
 
     attributes = {
       client_id: client.uid,
-      response_type: 'id_token token',
-      redirect_uri: 'https://app.com/callback',
-      scope: 'public',
-      nonce: '12345',
+      response_type: "id_token token",
+      redirect_uri: "https://app.com/callback",
+      scope: "public",
+      nonce: "12345",
     }
 
     pre_auth = Doorkeeper::OAuth::PreAuthorization.new(server, attributes)
@@ -33,17 +33,17 @@ describe Doorkeeper::OAuth::IdTokenTokenRequest do
   let(:owner) { build_stubbed(:user) }
 
   # just to make sure self created pre_auth is authorizable
-  it 'pre_auth should be valid' do
+  it "pre_auth should be valid" do
     expect(pre_auth).to be_authorizable
   end
 
-  it 'creates an access token' do
+  it "creates an access token" do
     expect do
       subject.authorize
     end.to change { Doorkeeper::AccessToken.count }.by(1)
   end
 
-  it 'returns id_token token response' do
+  it "returns id_token token response" do
     expect(subject.authorize).to be_a(Doorkeeper::OAuth::IdTokenTokenResponse)
   end
 end

--- a/spec/lib/oauth/id_token_token_response_spec.rb
+++ b/spec/lib/oauth/id_token_token_response_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OAuth::IdTokenTokenResponse do
   subject { described_class.new(pre_auth, auth, id_token) }
 
   let(:token) { create :access_token }
   let(:application) do
-    create(:application, scopes: 'public')
+    create(:application, scopes: "public")
   end
   let(:pre_auth) do
     double(
       :pre_auth,
       client: application,
-      redirect_uri: 'http://tst.com/cb',
-      state: 'state',
-      scopes: Doorkeeper::OAuth::Scopes.from_string('public'),
+      redirect_uri: "http://tst.com/cb",
+      state: "state",
+      scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
       error: nil,
       authorizable?: true,
-      nonce: '12345'
+      nonce: "12345"
     )
   end
   let(:owner) { build_stubbed(:user) }
@@ -33,8 +33,8 @@ describe Doorkeeper::OAuth::IdTokenTokenResponse do
   end
   let(:id_token) { Doorkeeper::OpenidConnect::IdToken.new(token, pre_auth) }
 
-  describe '#body' do
-    it 'return body response for id_token and access_token' do
+  describe "#body" do
+    it "return body response for id_token and access_token" do
       expect(subject.body).to eq({
         state: pre_auth.state,
         id_token: id_token.as_jws_token,
@@ -45,8 +45,8 @@ describe Doorkeeper::OAuth::IdTokenTokenResponse do
     end
   end
 
-  describe '#redirect_uri' do
-    it 'includes id_token, info of access_token and state' do
+  describe "#redirect_uri" do
+    it "includes id_token, info of access_token and state" do
       expect(subject.redirect_uri).to include("#{pre_auth.redirect_uri}#state=#{pre_auth.state}&" \
         "id_token=#{id_token.as_jws_token}&" \
         "access_token=#{auth.token.token}&" \

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -1,43 +1,42 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::OAuth::PasswordAccessTokenRequest do
-  if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.1')
-    subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, credentials, resource_owner, { nonce: '123456' } }
-  else
-    subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, resource_owner, { nonce: '123456' } }
+  if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.1")
   end
+
+  subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, credentials, resource_owner, { nonce: "123456" } }
 
   let(:server) { double }
   let(:client) { double }
-  let(:credentials) { }
+  let(:credentials) {}
   let(:resource_owner) { create :user }
-  let(:token) { create :access_token, scopes: 'openid' }
+  let(:token) { create :access_token, scopes: "openid" }
   let(:response) { Doorkeeper::OAuth::TokenResponse.new token }
 
-  describe '#initialize' do
-    it 'stores the nonce attribute' do
-      expect(subject.nonce).to eq '123456'
+  describe "#initialize" do
+    it "stores the nonce attribute" do
+      expect(subject.nonce).to eq "123456"
     end
   end
 
-  describe '#after_successful_response' do
-    it 'adds the ID token to the response when the openid scope is granted' do
-      subject.instance_variable_set '@response', response
-      subject.instance_variable_set '@access_token', token
+  describe "#after_successful_response" do
+    it "adds the ID token to the response when the openid scope is granted" do
+      subject.instance_variable_set "@response", response
+      subject.instance_variable_set "@access_token", token
       subject.send :after_successful_response
 
       expect(response.id_token).to be_a Doorkeeper::OpenidConnect::IdToken
-      expect(response.id_token.nonce).to eq '123456'
+      expect(response.id_token.nonce).to eq "123456"
     end
 
-    context 'when the access token does not include the openid scope' do
-      let(:token) { create :access_token, scopes: 'public' }
+    context "when the access token does not include the openid scope" do
+      let(:token) { create :access_token, scopes: "public" }
 
-      it 'does not build an ID token' do
-        subject.instance_variable_set '@response', response
-        subject.instance_variable_set '@access_token', token
+      it "does not build an ID token" do
+        subject.instance_variable_set "@response", response
+        subject.instance_variable_set "@access_token", token
 
         expect(Doorkeeper::OpenidConnect::IdToken).not_to receive(:new)
 

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -3,10 +3,14 @@
 require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::OAuth::PasswordAccessTokenRequest do
+  # TODO: Remove conditional when minimum doorkeeper version is >= 5.5.1
+  # rubocop:disable RSpec/MultipleSubjects
   if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.1")
+    subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, credentials, resource_owner, { nonce: "123456" } }
+  else
+    subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, resource_owner, { nonce: "123456" } }
   end
-
-  subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, credentials, resource_owner, { nonce: "123456" } }
+  # rubocop:enable RSpec/MultipleSubjects
 
   let(:server) { double }
   let(:client) { double }

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::OAuth::PreAuthorization do
   subject { Doorkeeper::OAuth::PreAuthorization.new server, attrs }
@@ -8,45 +8,45 @@ describe Doorkeeper::OpenidConnect::OAuth::PreAuthorization do
   let(:server) { Doorkeeper.configuration }
   let(:attrs) {}
 
-  describe '#initialize' do
-    context 'with nonce parameter' do
-      let(:attrs) { { nonce: '123456' } }
+  describe "#initialize" do
+    context "with nonce parameter" do
+      let(:attrs) { { nonce: "123456" } }
 
-      it 'stores the nonce attribute' do
-        expect(subject.nonce).to eq '123456'
+      it "stores the nonce attribute" do
+        expect(subject.nonce).to eq "123456"
       end
     end
   end
 
-  describe '#error_response' do
-    context 'with response_type = code' do
-      let(:attrs) { { response_type: 'code', redirect_uri: 'client.com/callback' } }
+  describe "#error_response" do
+    context "with response_type = code" do
+      let(:attrs) { { response_type: "code", redirect_uri: "client.com/callback" } }
 
-      it 'redirects to redirect_uri with query parameter' do
+      it "redirects to redirect_uri with query parameter" do
         expect(subject.error_response.redirect_uri).to match(/#{attrs[:redirect_uri]}\?/)
       end
     end
 
-    context 'with response_type = token' do
-      let(:attrs) { { response_type: 'token', redirect_uri: 'client.com/callback' } }
+    context "with response_type = token" do
+      let(:attrs) { { response_type: "token", redirect_uri: "client.com/callback" } }
 
-      it 'redirects to redirect_uri with fragment' do
+      it "redirects to redirect_uri with fragment" do
         expect(subject.error_response.redirect_uri).to match(/#{attrs[:redirect_uri]}#/)
       end
     end
 
-    context 'with response_type = id_token' do
-      let(:attrs) { { response_type: 'id_token', redirect_uri: 'client.com/callback' } }
+    context "with response_type = id_token" do
+      let(:attrs) { { response_type: "id_token", redirect_uri: "client.com/callback" } }
 
-      it 'redirects to redirect_uri with fragment' do
+      it "redirects to redirect_uri with fragment" do
         expect(subject.error_response.redirect_uri).to match(/#{attrs[:redirect_uri]}#/)
       end
     end
 
-    context 'with response_type = id_token token' do
-      let(:attrs) { { response_type: 'id_token token', redirect_uri: 'client.com/callback' } }
+    context "with response_type = id_token token" do
+      let(:attrs) { { response_type: "id_token token", redirect_uri: "client.com/callback" } }
 
-      it 'redirects to redirect_uri with fragment' do
+      it "redirects to redirect_uri with fragment" do
         expect(subject.error_response.redirect_uri).to match(/#{attrs[:redirect_uri]}#/)
       end
     end

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -1,51 +1,51 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::OAuth::TokenResponse do
   subject { Doorkeeper::OAuth::TokenResponse.new token }
 
   let(:token) { create :access_token }
   let(:client) { Doorkeeper::OAuth::Client.new create(:application) }
-  let(:pre_auth) { Doorkeeper::OAuth::PreAuthorization.new(Doorkeeper.configuration, client_id: client.uid, nonce: '123456') }
+  let(:pre_auth) { Doorkeeper::OAuth::PreAuthorization.new(Doorkeeper.configuration, client_id: client.uid, nonce: "123456") }
   let(:id_token) { Doorkeeper::OpenidConnect::IdToken.new token, pre_auth }
 
   before do
     pre_auth.valid? # triggers loading of pre_auth.client
   end
 
-  describe '#body' do
+  describe "#body" do
     before do
       subject.id_token = id_token
     end
 
-    context 'with the openid scope present' do
+    context "with the openid scope present" do
       before do
-        token.scopes = 'openid email'
+        token.scopes = "openid email"
       end
 
-      it 'adds the ID token to the response' do
+      it "adds the ID token to the response" do
         expect(subject.body[:id_token]).to eq id_token.as_jws_token
       end
     end
 
-    context 'with the openid scope present but no id_token' do
+    context "with the openid scope present but no id_token" do
       before do
-        token.scopes = 'openid email'
+        token.scopes = "openid email"
         subject.id_token = nil
       end
 
-      it 'adds the ID token to the response' do
+      it "adds the ID token to the response" do
         expect(subject.body[:id_token]).to be_truthy
       end
     end
 
-    context 'with the openid scope not present' do
+    context "with the openid scope not present" do
       before do
-        token.scopes = 'email'
+        token.scopes = "email"
       end
 
-      it 'does not add the ID token to the response' do
+      it "does not add the ID token to the response" do
         expect(subject.body).not_to include :id_token
       end
     end

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect do
-  describe '.signing_algorithm' do
-    it 'returns the signing_algorithm as an uppercase symbol' do
+  describe ".signing_algorithm" do
+    it "returns the signing_algorithm as an uppercase symbol" do
       expect(subject.signing_algorithm).to eq :RS256
     end
   end
 
-  describe '.signing_key' do
-    it 'returns the private key as JWK instance' do
+  describe ".signing_key" do
+    it "returns the private key as JWK instance" do
       expect(subject.signing_key).to be_a ::JWT::JWK::KeyBase
-      expect(subject.signing_key.kid).to eq 'IqYwZo2cE6hsyhs48cU8QHH4GanKIx0S4Dc99kgTIMA'
+      expect(subject.signing_key.kid).to eq "IqYwZo2cE6hsyhs48cU8QHH4GanKIx0S4Dc99kgTIMA"
     end
 
-    context 'when signing_key is callable with RSA key' do
+    context "when signing_key is callable with RSA key" do
       let(:rsa_key_1) { OpenSSL::PKey::RSA.generate(2048) }
       let(:rsa_key_2) { OpenSSL::PKey::RSA.generate(2048) }
       let(:rsa_key_1_pem) { rsa_key_1.to_pem }
@@ -28,21 +28,21 @@ describe Doorkeeper::OpenidConnect do
         end
       end
 
-      it 'returns a JWK instance' do
+      it "returns a JWK instance" do
         expect(subject.signing_key).to be_a ::JWT::JWK::KeyBase
       end
 
-      it 'generates correct key type' do
-        expect(subject.signing_key_normalized[:kty]).to eq 'RSA'
+      it "generates correct key type" do
+        expect(subject.signing_key_normalized[:kty]).to eq "RSA"
       end
 
-      it 'generates valid kid' do
+      it "generates valid kid" do
         expect(subject.signing_key.kid).not_to be_nil
         expect(subject.signing_key.kid).to be_a String
         expect(subject.signing_key.kid.length).to be > 0
       end
 
-      it 'generates different kids for different keys' do
+      it "generates different kids for different keys" do
         kid_1 = subject.signing_key.kid
 
         key_pem = rsa_key_2_pem
@@ -55,27 +55,27 @@ describe Doorkeeper::OpenidConnect do
         expect(kid_1).not_to eq kid_2
       end
 
-      it 'returns same kid for same key across multiple calls' do
+      it "returns same kid for same key across multiple calls" do
         kid_1 = subject.signing_key.kid
         kid_2 = subject.signing_key.kid
 
         expect(kid_1).to eq kid_2
       end
 
-      it 'can be used for JWT signing' do
+      it "can be used for JWT signing" do
         jwk = subject.signing_key
-        payload = { sub: '123', iat: Time.now.to_i }
+        payload = { sub: "123", iat: Time.now.to_i }
 
-        token = JWT.encode(payload, jwk.keypair, 'RS256', kid: jwk.kid)
+        token = JWT.encode(payload, jwk.keypair, "RS256", kid: jwk.kid)
 
         expect(token).not_to be_nil
         expect(token).to be_a String
       end
     end
 
-    context 'when signing_key is callable with EC key' do
+    context "when signing_key is callable with EC key" do
       let(:ec_key) do
-        OpenSSL::PKey::EC.generate('prime256v1')
+        OpenSSL::PKey::EC.generate("prime256v1")
       end
       let(:ec_key_pem) { ec_key.to_pem }
 
@@ -87,22 +87,22 @@ describe Doorkeeper::OpenidConnect do
         end
       end
 
-      it 'returns a JWK instance' do
+      it "returns a JWK instance" do
         expect(subject.signing_key).to be_a ::JWT::JWK::KeyBase
       end
 
-      it 'generates correct key type' do
-        expect(subject.signing_key_normalized[:kty]).to eq 'EC'
+      it "generates correct key type" do
+        expect(subject.signing_key_normalized[:kty]).to eq "EC"
       end
 
-      it 'generates valid kid' do
+      it "generates valid kid" do
         expect(subject.signing_key.kid).not_to be_nil
         expect(subject.signing_key.kid).to be_a String
       end
     end
 
-    context 'when signing_key is callable with HMAC key' do
-      let(:hmac_secret) { 'dynamic_hmac_secret_key_for_testing' }
+    context "when signing_key is callable with HMAC key" do
+      let(:hmac_secret) { "dynamic_hmac_secret_key_for_testing" }
 
       before do
         secret = hmac_secret
@@ -112,136 +112,136 @@ describe Doorkeeper::OpenidConnect do
         end
       end
 
-      it 'returns a JWK instance' do
+      it "returns a JWK instance" do
         expect(subject.signing_key).to be_a ::JWT::JWK::KeyBase
       end
 
-      it 'generates correct key type' do
-        expect(subject.signing_key_normalized[:kty]).to eq 'oct'
+      it "generates correct key type" do
+        expect(subject.signing_key_normalized[:kty]).to eq "oct"
       end
 
-      it 'generates valid kid' do
+      it "generates valid kid" do
         expect(subject.signing_key.kid).not_to be_nil
         expect(subject.signing_key.kid).to be_a String
       end
     end
   end
 
-  describe '.signing_key_normalized' do
-    context 'when signing key is RSA' do
-      it 'returns the RSA public key parameters' do
+  describe ".signing_key_normalized" do
+    context "when signing key is RSA" do
+      it "returns the RSA public key parameters" do
         expect(subject.signing_key_normalized).to eq(
-          :kty => 'RSA',
-          :kid => 'IqYwZo2cE6hsyhs48cU8QHH4GanKIx0S4Dc99kgTIMA',
-          :e => 'AQAB',
-          :n => 'sjdnSA6UWUQQHf6BLIkIEUhMRNBJC1NN_pFt1EJmEiI88GS0ceROO5B5Ooo9Y3QOWJ_n-u1uwTHBz0HCTN4wgArWd1TcqB5GQzQRP4eYnWyPfi4CfeqAHzQp-v4VwbcK0LW4FqtW5D0dtrFtI281FDxLhARzkhU2y7fuYhL8fVw5rUhE8uwvHRZ5CEZyxf7BSHxIvOZAAymhuzNLATt2DGkDInU1BmF75tEtBJAVLzWG_j4LPZh1EpSdfezqaXQlcy9PJi916UzTl0P7Yy-ulOdUsMlB6yo8qKTY1-AbZ5jzneHbGDU_O8QjYvii1WDmJ60t0jXicmOkGrOhruOptw'
+          kty: "RSA",
+          kid: "IqYwZo2cE6hsyhs48cU8QHH4GanKIx0S4Dc99kgTIMA",
+          e: "AQAB",
+          n: "sjdnSA6UWUQQHf6BLIkIEUhMRNBJC1NN_pFt1EJmEiI88GS0ceROO5B5Ooo9Y3QOWJ_n-u1uwTHBz0HCTN4wgArWd1TcqB5GQzQRP4eYnWyPfi4CfeqAHzQp-v4VwbcK0LW4FqtW5D0dtrFtI281FDxLhARzkhU2y7fuYhL8fVw5rUhE8uwvHRZ5CEZyxf7BSHxIvOZAAymhuzNLATt2DGkDInU1BmF75tEtBJAVLzWG_j4LPZh1EpSdfezqaXQlcy9PJi916UzTl0P7Yy-ulOdUsMlB6yo8qKTY1-AbZ5jzneHbGDU_O8QjYvii1WDmJ60t0jXicmOkGrOhruOptw"
         )
       end
     end
 
-    context 'when signing key is EC' do
+    context "when signing key is EC" do
       before { configure_ec }
 
-      it 'returns the EC public key parameters' do
+      it "returns the EC public key parameters" do
         expect(subject.signing_key_normalized).to eq(
-          :kty => 'EC',
-          :kid => 'dOx_AhaepicN2r2M-sxZhgkYZMCX7dYhPsNOw1ZiFnI',
-          :crv => 'P-521',
-          :x => 'AeYVvbl3zZcFCdE-0msqOowYODjzeXAhjsZKhdNjGlDREvko3UFOw6S43g-s8bvVBmBz3fCodEzFRYQqJVI4UFvF',
-          :y => 'AYJ7GYeBm_Fb6liN53xGASdbRSzF34h4BDSVYzjtQc7I-1LK17fwwS3VfQCJwaT6zX33HTrhR4VoUEUJHKwR3dNs'
+          kty: "EC",
+          kid: "dOx_AhaepicN2r2M-sxZhgkYZMCX7dYhPsNOw1ZiFnI",
+          crv: "P-521",
+          x: "AeYVvbl3zZcFCdE-0msqOowYODjzeXAhjsZKhdNjGlDREvko3UFOw6S43g-s8bvVBmBz3fCodEzFRYQqJVI4UFvF",
+          y: "AYJ7GYeBm_Fb6liN53xGASdbRSzF34h4BDSVYzjtQc7I-1LK17fwwS3VfQCJwaT6zX33HTrhR4VoUEUJHKwR3dNs"
         )
       end
     end
 
-    context 'when signing key is HMAC' do
+    context "when signing key is HMAC" do
       before { configure_hmac }
 
-      it 'returns the HMAC public key parameters' do
+      it "returns the HMAC public key parameters" do
         expect(subject.signing_key_normalized).to eq(
-          :kty => 'oct',
-          :kid => 'UGyfZX0uOWB46idsQ0QxdFISdaoGilib_t-ZUw8V0Qc'
+          kty: "oct",
+          kid: "UGyfZX0uOWB46idsQ0QxdFISdaoGilib_t-ZUw8V0Qc"
         )
       end
     end
   end
 
-  describe 'registering grant flows' do
+  describe "registering grant flows" do
     describe Doorkeeper::Request do
       it 'uses the correct strategy for "id_token" response types' do
-        expect(described_class.authorization_strategy('id_token')).to eq(Doorkeeper::Request::IdToken)
+        expect(described_class.authorization_strategy("id_token")).to eq(Doorkeeper::Request::IdToken)
       end
 
       it 'uses the correct strategy for "id_token token" response types' do
-        expect(described_class.authorization_strategy('id_token token')).to eq(Doorkeeper::Request::IdTokenToken)
+        expect(described_class.authorization_strategy("id_token token")).to eq(Doorkeeper::Request::IdTokenToken)
       end
     end
   end
 
-  describe '.resolve_issuer' do
-    let(:resource_owner) { double('ResourceOwner') }
-    let(:application) { double('Application') }
-    let(:request) { double('Request', base_url: 'https://example.com') }
+  describe ".resolve_issuer" do
+    let(:resource_owner) { double("ResourceOwner") }
+    let(:application) { double("Application") }
+    let(:request) { double("Request", base_url: "https://example.com") }
 
-    context 'when issuer is a static string' do
+    context "when issuer is a static string" do
       before do
         Doorkeeper::OpenidConnect.configure do
-          issuer 'https://static-issuer.example.com'
+          issuer "https://static-issuer.example.com"
         end
       end
 
-      it 'returns the static string' do
-        expect(subject.resolve_issuer).to eq 'https://static-issuer.example.com'
+      it "returns the static string" do
+        expect(subject.resolve_issuer).to eq "https://static-issuer.example.com"
       end
     end
 
-    context 'when issuer block has arity 0' do
+    context "when issuer block has arity 0" do
       before do
         Doorkeeper::OpenidConnect.configure do
           issuer do
-            'https://zero-arity.example.com'
+            "https://zero-arity.example.com"
           end
         end
       end
 
-      it 'calls the block without arguments' do
-        expect(subject.resolve_issuer).to eq 'https://zero-arity.example.com'
+      it "calls the block without arguments" do
+        expect(subject.resolve_issuer).to eq "https://zero-arity.example.com"
       end
     end
 
-    context 'when issuer block has arity 1' do
+    context "when issuer block has arity 1" do
       before do
         req = request
         owner = resource_owner
         Doorkeeper::OpenidConnect.configure do
           issuer do |request_or_owner|
             if request_or_owner.equal?(req)
-              'issuer-request'
+              "issuer-request"
             elsif request_or_owner.equal?(owner)
-              'issuer-resource-owner'
+              "issuer-resource-owner"
             else
-              'issuer-unknown'
+              "issuer-unknown"
             end
           end
         end
       end
 
-      it 'passes request when called from discovery context' do
+      it "passes request when called from discovery context" do
         result = subject.resolve_issuer(request: request)
-        expect(result).to eq 'issuer-request'
+        expect(result).to eq "issuer-request"
       end
 
-      it 'passes resource_owner when called from token context' do
+      it "passes resource_owner when called from token context" do
         result = subject.resolve_issuer(resource_owner: resource_owner)
-        expect(result).to eq 'issuer-resource-owner'
+        expect(result).to eq "issuer-resource-owner"
       end
 
-      it 'prefers request over resource_owner when both are present' do
+      it "prefers request over resource_owner when both are present" do
         result = subject.resolve_issuer(resource_owner: resource_owner, request: request)
-        expect(result).to eq 'issuer-request'
+        expect(result).to eq "issuer-request"
       end
     end
 
-    context 'when issuer block has arity 2' do
+    context "when issuer block has arity 2" do
       before do
         Doorkeeper::OpenidConnect.configure do
           issuer do |resource_owner, application|
@@ -250,21 +250,21 @@ describe Doorkeeper::OpenidConnect do
         end
       end
 
-      it 'passes resource_owner and application' do
+      it "passes resource_owner and application" do
         result = subject.resolve_issuer(resource_owner: resource_owner, application: application)
-        expect(result.scan('RSpec::Mocks::Double').size).to eq 2
+        expect(result.scan("RSpec::Mocks::Double").size).to eq 2
       end
 
-      it 'passes nils from discovery context' do
+      it "passes nils from discovery context" do
         result = subject.resolve_issuer(request: request)
-        expect(result).to eq 'owner--app-'
+        expect(result).to eq "owner--app-"
       end
     end
 
-    context 'when issuer block has arity 3' do
+    context "when issuer block has arity 3" do
       before do
         Doorkeeper::OpenidConnect.configure do
-          issuer do |resource_owner, application, request|
+          issuer do |resource_owner, _application, request|
             if request
               request.base_url
             else
@@ -274,19 +274,19 @@ describe Doorkeeper::OpenidConnect do
         end
       end
 
-      it 'passes all three arguments from discovery context' do
+      it "passes all three arguments from discovery context" do
         result = subject.resolve_issuer(request: request)
-        expect(result).to eq 'https://example.com'
+        expect(result).to eq "https://example.com"
       end
 
-      it 'passes all three arguments from token context' do
+      it "passes all three arguments from token context" do
         result = subject.resolve_issuer(resource_owner: resource_owner, application: application)
-        expect(result).to include 'RSpec::Mocks::Double'
+        expect(result).to include "RSpec::Mocks::Double"
       end
 
-      it 'passes all three arguments when all are present' do
+      it "passes all three arguments when all are present" do
         result = subject.resolve_issuer(resource_owner: resource_owner, application: application, request: request)
-        expect(result).to eq 'https://example.com'
+        expect(result).to eq "https://example.com"
       end
     end
   end

--- a/spec/lib/routes_spec.rb
+++ b/spec/lib/routes_spec.rb
@@ -1,64 +1,64 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::Rails::Routes, type: :routing do
-  describe 'userinfo' do
-    it 'maps GET #show' do
-      expect(get: 'oauth/userinfo').to route_to(
-        controller: 'doorkeeper/openid_connect/userinfo',
-        action: 'show'
+  describe "userinfo" do
+    it "maps GET #show" do
+      expect(get: "oauth/userinfo").to route_to(
+        controller: "doorkeeper/openid_connect/userinfo",
+        action: "show"
       )
     end
 
-    it 'maps POST #show' do
-      expect(post: 'oauth/userinfo').to route_to(
-        controller: 'doorkeeper/openid_connect/userinfo',
-        action: 'show'
-      )
-    end
-  end
-
-  describe 'discovery' do
-    it 'maps GET #provider' do
-      expect(get: '.well-known/openid-configuration').to route_to(
-        controller: 'doorkeeper/openid_connect/discovery',
-        action: 'provider'
-      )
-    end
-
-    it 'maps GET #webfinger' do
-      expect(get: '.well-known/webfinger').to route_to(
-        controller: 'doorkeeper/openid_connect/discovery',
-        action: 'webfinger'
-      )
-    end
-
-    it 'maps GET #keys' do
-      expect(get: 'oauth/discovery/keys').to route_to(
-        controller: 'doorkeeper/openid_connect/discovery',
-        action: 'keys'
+    it "maps POST #show" do
+      expect(post: "oauth/userinfo").to route_to(
+        controller: "doorkeeper/openid_connect/userinfo",
+        action: "show"
       )
     end
   end
 
-  describe 'dynamic_client_registration' do
-    it 'doesn\'t map by default' do
+  describe "discovery" do
+    it "maps GET #provider" do
+      expect(get: ".well-known/openid-configuration").to route_to(
+        controller: "doorkeeper/openid_connect/discovery",
+        action: "provider"
+      )
+    end
+
+    it "maps GET #webfinger" do
+      expect(get: ".well-known/webfinger").to route_to(
+        controller: "doorkeeper/openid_connect/discovery",
+        action: "webfinger"
+      )
+    end
+
+    it "maps GET #keys" do
+      expect(get: "oauth/discovery/keys").to route_to(
+        controller: "doorkeeper/openid_connect/discovery",
+        action: "keys"
+      )
+    end
+  end
+
+  describe "dynamic_client_registration" do
+    it "doesn't map by default" do
       Rails.application.reload_routes!
 
-      expect(post: 'oauth/registration').not_to be_routable
+      expect(post: "oauth/registration").not_to be_routable
     end
 
-    it 'maps POST #register' do
+    it "maps POST #register" do
       Doorkeeper::OpenidConnect.configure do
         dynamic_client_registration true
       end
 
       Rails.application.reload_routes!
 
-      expect(post: 'oauth/registration').to route_to(
-        controller: 'doorkeeper/openid_connect/dynamic_client_registration',
-        action: 'register'
+      expect(post: "oauth/registration").to route_to(
+        controller: "doorkeeper/openid_connect/dynamic_client_registration",
+        action: "register"
       )
     end
   end

--- a/spec/lib/user_info_spec.rb
+++ b/spec/lib/user_info_spec.rb
@@ -1,54 +1,54 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::UserInfo do
   subject { described_class.new token }
 
-  let(:user) { create :user, name: 'Joe' }
+  let(:user) { create :user, name: "Joe" }
   let(:token) { create :access_token, resource_owner_id: user.id, scopes: scopes }
-  let(:scopes) { 'openid' }
+  let(:scopes) { "openid" }
 
-  describe '#claims' do
-    it 'returns all accessible claims' do
+  describe "#claims" do
+    it "returns all accessible claims" do
       expect(subject.claims).to eq({
         sub: user.id.to_s,
         created_at: user.created_at.to_i,
-        variable_name: 'openid-name',
+        variable_name: "openid-name",
         token_id: token.id,
-        both_responses: 'both',
-        user_info_response: 'user_info',
+        both_responses: "both",
+        user_info_response: "user_info",
       })
     end
 
-    context 'with a grant for the profile scopes' do
-      let(:scopes) { 'openid profile' }
+    context "with a grant for the profile scopes" do
+      let(:scopes) { "openid profile" }
 
-      it 'returns additional profile claims' do
+      it "returns additional profile claims" do
         expect(subject.claims).to eq({
           sub: user.id.to_s,
-          name: 'Joe',
+          name: "Joe",
           created_at: user.created_at.to_i,
           updated_at: user.updated_at.to_i,
-          variable_name: 'profile-name',
+          variable_name: "profile-name",
           token_id: token.id,
-          both_responses: 'both',
-          user_info_response: 'user_info',
+          both_responses: "both",
+          user_info_response: "user_info",
         })
       end
     end
   end
 
-  describe '#as_json' do
-    it 'returns claims with nil values and empty strings removed' do
+  describe "#as_json" do
+    it "returns claims with nil values and empty strings removed" do
       allow(subject).to receive(:claims).and_return({
         nil: nil,
-        empty: '',
-        blank: ' ',
+        empty: "",
+        blank: " ",
       })
 
       expect(subject.as_json).to eq({
-        blank: ' '
+        blank: " "
       })
     end
   end

--- a/spec/models/access_grant_spec.rb
+++ b/spec/models/access_grant_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::AccessGrant do
   subject { Doorkeeper.config.access_grant_model.new }
+
   let(:openid_request_class_name) { Doorkeeper::OpenidConnect.configuration.open_id_request_class }
   let(:openid_request_class) { Doorkeeper::OpenidConnect.configuration.open_id_request_model }
 
-  it 'has one openid_request' do
+  it "has one openid_request" do
     association = subject.class.reflect_on_association :openid_request
 
     expect(association.options).to eq({
@@ -18,12 +19,12 @@ describe Doorkeeper::OpenidConnect::AccessGrant do
     })
   end
 
-  it 'extends the base doorkeeper AccessGrant' do
+  it "extends the base doorkeeper AccessGrant" do
     expect(subject).to respond_to(:"openid_request=")
   end
 
-  describe '#delete' do
-    it 'cascades to oauth_openid_requests' do
+  describe "#delete" do
+    it "cascades to oauth_openid_requests" do
       if Rails::VERSION::MAJOR >= 6
         access_grant = create(:access_grant, application: create(:application))
         create(:openid_request, access_grant: access_grant)

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -1,24 +1,25 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::Request do
   let(:expected_access_grant_class_name) do
-    if Gem.loaded_specs['doorkeeper'].version >= Gem::Version.create('5.5.0')
+    if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.0")
       Doorkeeper.config.access_grant_class.to_s
     else
-      'Doorkeeper::AccessGrant'
+      "Doorkeeper::AccessGrant"
     end
   end
-  describe 'validations' do
-    it 'requires an access grant' do
+
+  describe "validations" do
+    it "requires an access grant" do
       subject.access_grant_id = nil
 
       expect(subject).not_to be_valid
       expect(subject.errors).to include :access_grant_id
     end
 
-    it 'requires a nonce' do
+    it "requires a nonce" do
       subject.nonce = nil
 
       expect(subject).not_to be_valid
@@ -26,8 +27,8 @@ describe Doorkeeper::OpenidConnect::Request do
     end
   end
 
-  describe 'associations' do
-    it 'belongs to an access_grant' do
+  describe "associations" do
+    it "belongs to an access_grant" do
       association = subject.class.reflect_on_association :access_grant
 
       expect(association.options).to eq({

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV['RAILS_ENV'] ||= 'test'
-require 'dummy/config/environment'
+ENV["RAILS_ENV"] ||= "test"
+require "dummy/config/environment"
 # Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?
-require 'spec_helper'
-require 'rspec/rails'
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require "spec_helper"
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -26,20 +26,18 @@ require 'rspec/rails'
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
-Dir.chdir('spec/dummy') do
+Dir.chdir("spec/dummy") do
   ActiveRecord::Migration.maintain_test_schema!
 end
 
-require_relative 'support/doorkeeper_configuration.rb'
+require_relative "support/doorkeeper_configuration"
 
-require 'factory_bot'
+require "factory_bot"
 FactoryBot.find_definitions
 
 RSpec.configure do |config|
   # Backward compatibility: fixture_path was removed in RSpec-Rails 8.x
-  if config.respond_to?(:fixture_path=)
-    config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  end
+  config.fixture_path = "#{Rails.root.join("spec/fixtures")}" if config.respond_to?(:fixture_path=)
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
@@ -55,7 +53,7 @@ RSpec.configure do |config|
 
   # Reinitialize configuration after each example
   config.after do
-    load Rails.root.join('config/initializers/doorkeeper.rb')
-    load Rails.root.join('config/initializers/doorkeeper_openid_connect.rb')
+    load Rails.root.join("config/initializers/doorkeeper.rb")
+    load Rails.root.join("config/initializers/doorkeeper_openid_connect.rb")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pry-byebug' unless ENV['CI']
+require "pry-byebug" unless ENV["CI"]
 
 puts "====> Doorkeeper version: #{Doorkeeper::VERSION::STRING}"
 
@@ -47,7 +47,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = 'spec/examples.txt'
+  config.example_status_persistence_file_path = "spec/examples.txt"
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
@@ -63,7 +63,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
+    config.default_formatter = "doc"
   end
 
   # Print the 10 slowest examples and example groups at the

--- a/spec/support/doorkeeper_configuration.rb
+++ b/spec/support/doorkeeper_configuration.rb
@@ -35,7 +35,7 @@ module DoorkeeperConfiguration
   end
 
   def configure_hmac
-    configure_doorkeeper('the_greatest_secret_key', :HS512)
+    configure_doorkeeper("the_greatest_secret_key", :HS512)
   end
 end
 


### PR DESCRIPTION
Follow-up to #261 — step 1 of the cleanup plan.

**Commit 1:** Add `Style/StringLiterals` and `Style/StringLiteralsInInterpolation` (`double_quotes`) to `.rubocop.yml`, aligning with [doorkeeper core](https://github.com/doorkeeper-gem/doorkeeper/blob/5cf486ed720860f3869c46504565487015a09e84/.rubocop.yml#L37-L40).

**Commit 2:** `bundle exec rubocop -a` (safe autocorrections only, no manual edits)

After this PR, offenses drop from 272 → 178 (remaining are manual-fix items like `Style/Documentation`, `Metrics/*`, etc.)
