### PR TITLE
Add Dynamic Client Registration section to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#261] Fix obsolete RuboCop configuration (`require:` → `plugins:`, `RSpec/FilePath` split, remove `Capybara/FeatureMethods`)
 - [#263] **Security/Breaking:** Determine dynamically registered client's `confidential` flag from `token_endpoint_auth_method` per RFC 7591 — previously every dynamically registered client was created as public (`confidential: false`), which let callers authenticate with only `client_id` (`by_uid_and_secret(uid, nil)` bypass). Default is now `client_secret_basic` (confidential); `none` produces a public client; unsupported values (e.g. `private_key_jwt`) are rejected with `invalid_client_metadata`. Also derive `token_endpoint_auth_methods_supported` in the response from `Doorkeeper.configuration.client_credentials_methods` instead of a hardcoded list, matching #236
 - [#264] Apply safe RuboCop autocorrections and fix resulting artifacts
+- [#265] Add Dynamic Client Registration section to README
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ OpenID Connect is a single-sign-on and identity layer with a [growing list of se
   - [Routes](#routes)
   - [Nonces](#nonces)
   - [Internationalization (I18n)](#internationalization-i18n)
+  - [Dynamic Client Registration](#dynamic-client-registration)
 - [Development](#development)
 - [License](#license)
 - [Sponsors](#sponsors)
@@ -310,6 +311,41 @@ Then tweak the template as follows:
 ### Internationalization (I18n)
 
 We use Rails locale files for error messages and scope descriptions, see [config/locales/en.yml](config/locales/en.yml). You can override these by adding them to your own translations in `config/locale`.
+
+### Dynamic Client Registration
+
+This gem supports [OpenID Connect Dynamic Client Registration 1.0](https://openid.net/specs/openid-connect-registration-1_0.html) based on [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591).
+
+To enable dynamic client registration, add the following to `config/initializers/doorkeeper_openid_connect.rb`:
+
+```ruby
+Doorkeeper::OpenidConnect.configure do
+  # ...
+  dynamic_client_registration true
+  # ...
+end
+```
+
+This exposes a `POST /oauth/registration` endpoint where OAuth clients can register themselves.
+
+#### Supported parameters
+
+The registration endpoint currently accepts the following [RFC 7591 §2](https://www.rfc-editor.org/rfc/rfc7591#section-2) parameters:
+
+| Parameter | Description |
+| --- | --- |
+| `client_name` | Human-readable name of the client |
+| `redirect_uris` | Array of redirection URIs |
+| `scope` | Space-delimited list of requested scopes |
+| `token_endpoint_auth_method` | Requested authentication method. Defaults to `client_secret_basic`. `none` is always allowed (and registers a public client); other allowed values depend on the host application's Doorkeeper `client_credentials_methods` configuration. Unsupported values are rejected with `invalid_client_metadata`. |
+
+When `token_endpoint_auth_method` is set to `none`, the client is registered as **public** (i.e. `confidential: false`). For all other values — or when the parameter is omitted — the client is registered as **confidential**, matching the RFC 7591 default of `client_secret_basic`.
+
+For `application_type`, `response_types`, and `grant_types`, the endpoint returns server-side defaults regardless of what the client requests. Other RFC 7591 parameters (e.g. `client_uri`, `logo_uri`, `contacts`) are silently ignored and not included in the response. See [#249](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/249) for progress on full RFC 7591 compliance.
+
+#### Security note
+
+The registration endpoint does **not** require an Initial Access Token ([RFC 7591 §3.1](https://www.rfc-editor.org/rfc/rfc7591#section-3.1)). Any unauthenticated request can register a new client. If this is a concern for your deployment, consider protecting the endpoint at the network or application level (e.g. rate limiting, IP allowlisting, or a `before_action` in a custom controller).
 
 ## Development
 


### PR DESCRIPTION
## Summary

Add a "Dynamic Client Registration" subsection under Configuration in the README, as discussed in #249 (comment by @nbulaj).

## Changes

- Add DCR subsection to the Configuration section documenting:
  - How to enable `dynamic_client_registration`
  - Supported RFC 7591 §2 parameters (`client_name`, `redirect_uris`, `scope`, `token_endpoint_auth_method`)
  - Client confidentiality behavior based on `token_endpoint_auth_method` (added in #263)
  - A security note about the unauthenticated registration endpoint (no Initial Access Token support yet)
  - Link to #249 for tracking remaining RFC 7591 compliance work
- Add RFC 7591 to the supported features list in the Status section
- Add table of contents entry for the new subsection

## Context

In #249, @nbulaj indicated interest in having a README section about DCR:

> I think we need a section about DCR with some details maybe and a note about current status.

This PR addresses that request. Points 2 and 3 from #249 remain open for future implementation work.

Refs #249 (documentation part).