### PR TITLE
Add authorize_dynamic_client_registration config to gate the registration endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#264] Apply safe RuboCop autocorrections and fix resulting artifacts
 - [#265] Add Dynamic Client Registration section to README
 - [#266] Validate `application_type`, `response_types`, and `grant_types` parameters in dynamic client registration per RFC 7591 — reject unsupported values with `invalid_client_metadata` and echo the requested values back in the registration response, instead of silently ignoring them and returning the server's global configuration
+- [#267] Add `authorize_dynamic_client_registration` config option to gate the dynamic client registration endpoint per RFC 7591 §3.1 — when set to a callable, the block is evaluated in the controller scope (with access to `request`, `params`, `request.headers`, etc.) and falsy return values reject the request with `401 invalid_token`. Default is `nil` so the endpoint remains open for backward compatibility; consumers should configure this to validate an Initial Access Token (or any other authorization scheme) before allowing client registration
 - [#268] Update Dynamic Client Registration README for validated metadata parameters
 
 ## v1.9.0 (2026-03-16)

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -3,6 +3,8 @@
 module Doorkeeper
   module OpenidConnect
     class DynamicClientRegistrationController < ::Doorkeeper::ApplicationMetalController
+      before_action :authorize_dynamic_client_registration!
+
       def register
         registration = OAuth::DynamicRegistrationRequest.new(::Doorkeeper.configuration, params)
 
@@ -20,11 +22,36 @@ module Doorkeeper
 
       private
 
+      def authorize_dynamic_client_registration!
+        authorizer = ::Doorkeeper::OpenidConnect.configuration.authorize_dynamic_client_registration
+        return if authorizer.nil?
+
+        return if authorized?(authorizer)
+
+        response.headers["WWW-Authenticate"] = "Bearer error=\"invalid_token\""
+        render json: {
+          error: "invalid_token",
+          error_description: I18n.t(
+            "doorkeeper.openid_connect.errors.messages.dynamic_client_registration_unauthorized",
+          ),
+        }, status: :unauthorized
+      end
+
+      def authorized?(authorizer)
+        if authorizer.respond_to?(:to_proc)
+          instance_exec(&authorizer.to_proc)
+        elsif authorizer.respond_to?(:call)
+          authorizer.call(self)
+        else
+          authorizer
+        end
+      end
+
       def application_params(registration)
         {
-          name: params.dig(:client_name),
-          redirect_uri: params.dig(:redirect_uris) || [],
-          scopes: params.dig(:scope),
+          name: params[:client_name],
+          redirect_uri: params[:redirect_uris] || [],
+          scopes: params[:scope],
           confidential: registration.confidential_client?,
         }
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,4 @@ en:
           reauthenticate_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.reauthenticate_resource_owner missing configuration.'
           select_account_for_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.select_account_for_resource_owner missing configuration.'
           subject_not_configured: 'ID Token generation failed due to Doorkeeper::OpenidConnect.configure.subject missing configuration.'
+          dynamic_client_registration_unauthorized: 'Authorization required for client registration'

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -83,6 +83,8 @@ module Doorkeeper
 
       option :dynamic_client_registration, default: false
 
+      option :authorize_dynamic_client_registration, default: nil
+
       option :open_id_request_class, default: "Doorkeeper::OpenidConnect::Request"
 
       # Doorkeeper OpenID Request model class.

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -295,6 +295,85 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
       end
     end
 
+    context "when authorize_dynamic_client_registration is configured" do
+      let(:valid_register_params) do
+        {
+          client_name: "auth_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+        }
+      end
+
+      context "when the authorizer returns truthy" do
+        before do
+          Doorkeeper::OpenidConnect.configure do
+            issuer "dummy"
+            dynamic_client_registration true
+            authorize_dynamic_client_registration { true }
+          end
+          Rails.application.reload_routes!
+        end
+
+        it "allows the request" do
+          post :register, params: valid_register_params
+
+          expect(response.status).to eq 201
+          expect(Doorkeeper::Application.count).to eq(1)
+        end
+      end
+
+      context "when the authorizer returns falsy" do
+        before do
+          Doorkeeper::OpenidConnect.configure do
+            issuer "dummy"
+            dynamic_client_registration true
+            authorize_dynamic_client_registration { false }
+          end
+          Rails.application.reload_routes!
+        end
+
+        it "rejects the request with 401 invalid_token" do
+          post :register, params: valid_register_params
+
+          expect(response.status).to eq 401
+          expect(Doorkeeper::Application.count).to eq(0)
+          expect(response.headers["WWW-Authenticate"]).to include("Bearer")
+          expect(response.headers["WWW-Authenticate"]).to include("error=\"invalid_token\"")
+
+          body = JSON.parse(response.body)
+          expect(body["error"]).to eq("invalid_token")
+        end
+      end
+
+      context "when the authorizer reads request context" do
+        before do
+          Doorkeeper::OpenidConnect.configure do
+            issuer "dummy"
+            dynamic_client_registration true
+            authorize_dynamic_client_registration do
+              request.headers["Authorization"] == "Bearer initial-access-token"
+            end
+          end
+          Rails.application.reload_routes!
+        end
+
+        it "allows the request when the header matches" do
+          request.headers["Authorization"] = "Bearer initial-access-token"
+          post :register, params: valid_register_params
+
+          expect(response.status).to eq 201
+        end
+
+        it "rejects the request when the header does not match" do
+          request.headers["Authorization"] = "Bearer wrong"
+          post :register, params: valid_register_params
+
+          expect(response.status).to eq 401
+          expect(Doorkeeper::Application.count).to eq(0)
+        end
+      end
+    end
+
     context "with invalid redirect_uris" do
       it "errors and returns errors" do
         post :register, params: {


### PR DESCRIPTION
### Summary

Add an opt-in `authorize_dynamic_client_registration` config option to authorize dynamic client registration requests, per RFC 7591 §3.1.

### Problem

When `dynamic_client_registration true` is set, `POST /oauth/registration` is fully open — any anonymous request can register a new OAuth client. RFC 7591 §3.1 explicitly allows authorization servers to require an Initial Access Token, but this gem provides no hook to enforce it.

### Changes

- Add `authorize_dynamic_client_registration` config option (default: `nil`)
- When set to a callable (block/proc/lambda), it is evaluated in the controller scope on every registration request, giving access to `request`, `params`, `request.headers`, etc.
- Truthy return → request proceeds; falsy return → `401 invalid_token` with `WWW-Authenticate: Bearer error="invalid_token"` header (RFC 6750 §3)
- Default `nil` preserves the existing open behavior — strictly additive, no breaking changes

### Example

```ruby
Doorkeeper::OpenidConnect.configure do
  dynamic_client_registration true
  authorize_dynamic_client_registration do
    request.headers["Authorization"] == "Bearer #{ENV['DCR_INITIAL_ACCESS_TOKEN']}"
  end
end
```

Refs #249.