### PR TITLE
Update Dynamic Client Registration README for validated metadata parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#264] Apply safe RuboCop autocorrections and fix resulting artifacts
 - [#265] Add Dynamic Client Registration section to README
 - [#266] Validate `application_type`, `response_types`, and `grant_types` parameters in dynamic client registration per RFC 7591 — reject unsupported values with `invalid_client_metadata` and echo the requested values back in the registration response, instead of silently ignoring them and returning the server's global configuration
+- [#268] Update Dynamic Client Registration README for validated metadata parameters
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -338,10 +338,13 @@ The registration endpoint currently accepts the following [RFC 7591 §2](https:/
 | `redirect_uris` | Array of redirection URIs |
 | `scope` | Space-delimited list of requested scopes |
 | `token_endpoint_auth_method` | Requested authentication method. Defaults to `client_secret_basic`. `none` is always allowed (and registers a public client); other allowed values depend on the host application's Doorkeeper `client_credentials_methods` configuration. Unsupported values are rejected with `invalid_client_metadata`. |
+| `application_type` | Client type: `web` (default) or `native`, per [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html). Unsupported values are rejected with `invalid_client_metadata`. |
+| `response_types` | Array of OAuth 2.0 response types the client will use (e.g. `["code"]`). Must be a subset of the server's supported response types. Defaults to the server's full set when omitted. |
+| `grant_types` | Array of OAuth 2.0 grant types the client will use (e.g. `["authorization_code"]`). Must be a subset of the server's supported grant types. Defaults to the server's full set when omitted. |
 
 When `token_endpoint_auth_method` is set to `none`, the client is registered as **public** (i.e. `confidential: false`). For all other values — or when the parameter is omitted — the client is registered as **confidential**, matching the RFC 7591 default of `client_secret_basic`.
 
-For `application_type`, `response_types`, and `grant_types`, the endpoint returns server-side defaults regardless of what the client requests. Other RFC 7591 parameters (e.g. `client_uri`, `logo_uri`, `contacts`) are silently ignored and not included in the response. See [#249](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/249) for progress on full RFC 7591 compliance.
+Other RFC 7591 parameters (e.g. `client_uri`, `logo_uri`, `contacts`) require schema additions to `oauth_applications` and are not yet supported. See [#249](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/249) for progress on full RFC 7591 compliance.
 
 #### Security note
 


### PR DESCRIPTION
Follow-up to #266 — update the Dynamic Client Registration section to reflect that `application_type`, `response_types`, and `grant_types` are now validated and echoed back in the registration response, rather than silently ignored.

### Changes

- Add `application_type`, `response_types`, and `grant_types` to the supported parameters table
- Remove the paragraph stating these parameters return server-side defaults regardless of client input (no longer accurate post-#266)
- Update the #249 reference to note that only `client_uri`, `logo_uri`, `contacts`, etc. remain unsupported

Refs #249.