### PR TITLE
Document authorize_dynamic_client_registration in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#266] Validate `application_type`, `response_types`, and `grant_types` parameters in dynamic client registration per RFC 7591 — reject unsupported values with `invalid_client_metadata` and echo the requested values back in the registration response, instead of silently ignoring them and returning the server's global configuration
 - [#267] Add `authorize_dynamic_client_registration` config option to gate the dynamic client registration endpoint per RFC 7591 §3.1 — when set to a callable, the block is evaluated in the controller scope (with access to `request`, `params`, `request.headers`, etc.) and falsy return values reject the request with `401 invalid_token`. Default is `nil` so the endpoint remains open for backward compatibility; consumers should configure this to validate an Initial Access Token (or any other authorization scheme) before allowing client registration
 - [#268] Update Dynamic Client Registration README for validated metadata parameters
+- [#269] Document `authorize_dynamic_client_registration` in README
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -344,11 +344,26 @@ The registration endpoint currently accepts the following [RFC 7591 §2](https:/
 
 When `token_endpoint_auth_method` is set to `none`, the client is registered as **public** (i.e. `confidential: false`). For all other values — or when the parameter is omitted — the client is registered as **confidential**, matching the RFC 7591 default of `client_secret_basic`.
 
-Other RFC 7591 parameters (e.g. `client_uri`, `logo_uri`, `contacts`) require schema additions to `oauth_applications` and are not yet supported. See [#249](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/249) for progress on full RFC 7591 compliance.
+Other RFC 7591 parameters (e.g. `client_uri`, `logo_uri`, `contacts`) require schema additions to `oauth_applications` and are not yet supported.
 
-#### Security note
+#### Authorization
 
-The registration endpoint does **not** require an Initial Access Token ([RFC 7591 §3.1](https://www.rfc-editor.org/rfc/rfc7591#section-3.1)). Any unauthenticated request can register a new client. If this is a concern for your deployment, consider protecting the endpoint at the network or application level (e.g. rate limiting, IP allowlisting, or a `before_action` in a custom controller).
+By default, the registration endpoint is open to any request. To require authorization (e.g. an Initial Access Token per [RFC 7591 §3.1](https://www.rfc-editor.org/rfc/rfc7591#section-3.1)), configure `authorize_dynamic_client_registration`:
+
+```ruby
+Doorkeeper::OpenidConnect.configure do
+  # ...
+  dynamic_client_registration true
+  authorize_dynamic_client_registration do
+    request.headers["Authorization"] == "Bearer #{ENV['DCR_INITIAL_ACCESS_TOKEN']}"
+  end
+  # ...
+end
+```
+
+The block is evaluated in the controller scope (with access to `request`, `params`, `request.headers`, etc.). Return a truthy value to allow the request, or a falsy value to reject it with `401 invalid_token`.
+
+When not configured (default), the endpoint remains open for backward compatibility.
 
 ## Development
 


### PR DESCRIPTION
### Summary

Follow-up to #267 — document the `authorize_dynamic_client_registration` config option in the Dynamic Client Registration section of the README.

### Changes

- Replace the "Security note" paragraph (which advised network-level workarounds) with documentation and a configuration example for `authorize_dynamic_client_registration`
- Add CHANGELOG entry

Closes #249.