### PR TITLE
Document the unified issuer block signature in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#267] Add `authorize_dynamic_client_registration` config option to gate the dynamic client registration endpoint per RFC 7591 §3.1 — when set to a callable, the block is evaluated in the controller scope (with access to `request`, `params`, `request.headers`, etc.) and falsy return values reject the request with `401 invalid_token`. Default is `nil` so the endpoint remains open for backward compatibility; consumers should configure this to validate an Initial Access Token (or any other authorization scheme) before allowing client registration
 - [#268] Update Dynamic Client Registration README for validated metadata parameters
 - [#269] Document `authorize_dynamic_client_registration` in README
+- [#270] Document the unified issuer block signature in README
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -107,21 +107,19 @@ The following settings are required in `config/initializers/doorkeeper_openid_co
 
 - `issuer`
   - Identifier for the issuer of the response (i.e. your application URL). The value is a case sensitive URL using the `https` scheme that contains scheme, host, and optionally, port number and path components and no query or fragment components.
-  - You can either pass a string value, or a block to generate the issuer dynamically based on the `resource_owner` and `application` or [request](app/controllers/doorkeeper/openid_connect/discovery_controller.rb#L123) passed to the block.
+  - You can either pass a string value, or a block to generate the issuer dynamically. The block receives `resource_owner`, `application`, and `request` so that the same configuration can serve both ID token issuance (where `resource_owner` and `application` are available) and the discovery endpoint (where only `request` is available):
+
     ```ruby
-     # config/initializers/doorkeeper_openid_connect.rb
+    # config/initializers/doorkeeper_openid_connect.rb
     Doorkeeper::OpenidConnect.configure do
       # ...
-      issuer do |request_or_user, application|
-        if application
-          # if application is presence then we have a user
-          "https://#{URI.parse(application.redirect_uri).host}"
-        else # we have the request passed to the block
-          "https://#{request_or_user.host}"
-        end
+      issuer do |resource_owner, application, request|
+        request&.base_url || "https://default.example.com"
       end
     end
     ```
+
+  - For backward compatibility, blocks with arity 0, 1, or 2 are also accepted. An arity-1 block receives `request` from the discovery endpoint and `resource_owner` from the ID token context, while an arity-2 block always receives `resource_owner` and `application`.
 - `subject`
   - Identifier for the resource owner (i.e. the authenticated user). A locally unique and never reassigned identifier within the issuer for the end-user, which is intended to be consumed by the client. The value is a case-sensitive string and must not exceed 255 ASCII characters in length.
   - The database ID of the user is an acceptable choice if you don't mind leaking that information.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ The following settings are required in `config/initializers/doorkeeper_openid_co
 - `issuer`
   - Identifier for the issuer of the response (i.e. your application URL). The value is a case sensitive URL using the `https` scheme that contains scheme, host, and optionally, port number and path components and no query or fragment components.
   - You can either pass a string value, or a block to generate the issuer dynamically based on the `resource_owner` and `application` or [request](app/controllers/doorkeeper/openid_connect/discovery_controller.rb#L123) passed to the block.
+    ```ruby
+     # config/initializers/doorkeeper_openid_connect.rb
+    Doorkeeper::OpenidConnect.configure do
+      # ...
+      issuer do |request_or_user, application|
+        if application
+          # if application is presence then we have a user
+          "https://#{URI.parse(application.redirect_uri).host}"
+        else # we have the request passed to the block
+          "https://#{request_or_user.host}"
+        end
+      end
+    end
+    ```
 - `subject`
   - Identifier for the resource owner (i.e. the authenticated user). A locally unique and never reassigned identifier within the issuer for the end-user, which is intended to be consumed by the client. The value is a case-sensitive string and must not exceed 255 ASCII characters in length.
   - The database ID of the user is an acceptable choice if you don't mind leaking that information.


### PR DESCRIPTION
## Summary

Update the README description of the `issuer` configuration option to reflect the unified block signature introduced in #238 / 2225ce8e (`Doorkeeper::OpenidConnect.resolve_issuer`).

Before that change, the `issuer` block was invoked with different arguments depending on the caller — `(resource_owner, application)` from `IdToken` and `(request)` from `DiscoveryController` — and the README only described that split behavior, pointing to a now-stale line in `discovery_controller.rb`. After the change, a single block can declare `do |resource_owner, application, request|` and work correctly in both contexts, but the README never advertised this form.

This PR:

- Adds a runnable example of the recommended 3-argument form, mirroring the generator template at `lib/generators/doorkeeper/openid_connect/templates/initializer.rb`.
- Explains why a single block can serve both ID token issuance and the discovery endpoint.
- Documents the legacy arity-0/1/2 forms that remain supported for backward compatibility.
- Removes the broken source link (`discovery_controller.rb#L123` no longer points at the `issuer` method).

## Related

- Implements documentation for the change made in #238 (commit 2225ce8e).
- Supersedes #228, which attempted to document the pre-unification behavior with an arity-2 example. The author has not responded to maintainer feedback since, and the example there relied on the pre-unification dispatch quirk (DiscoveryController calling with a single positional arg, leaving `application` nil) — after #238 / 2225ce8e, an arity-2 block always receives `(resource_owner, application)` regardless of context, so that example would `NoMethodError` on the discovery endpoint.