### PR TITLE
Add `auth_time_from_session` for per-session `max_age` enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#269] Document `authorize_dynamic_client_registration` in README
 - [#270] Document the unified issuer block signature in README
 - [#278] Test against Ruby 4.0.
+- [#271] **Security:** Add `auth_time_from_session` config for per-session `max_age` enforcement. The legacy `auth_time_from_resource_owner` cannot distinguish between concurrent sessions and is now deprecated for `max_age` use (see [#150](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/150))
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -53,6 +53,8 @@ module Doorkeeper
         raise Errors::InvalidConfiguration, I18n.translate("doorkeeper.openid_connect.errors.messages.auth_time_from_resource_owner_not_configured")
       }
 
+      option :auth_time_from_session, default: nil
+
       option :reauthenticate_resource_owner, default: lambda { |*_|
         raise Errors::InvalidConfiguration, I18n.translate("doorkeeper.openid_connect.errors.messages.reauthenticate_resource_owner_not_configured")
       }

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -4,6 +4,29 @@ module Doorkeeper
   module OpenidConnect
     module Helpers
       module Controller
+        # Emit `auth_time_from_resource_owner` deprecation at most once per process
+        # to avoid spamming logs on every authorize request with `max_age`.
+        @auth_time_from_resource_owner_deprecation_warned = false
+
+        def self.warn_auth_time_from_resource_owner_deprecation
+          return if @auth_time_from_resource_owner_deprecation_warned
+
+          @auth_time_from_resource_owner_deprecation_warned = true
+          warn "DEPRECATION WARNING: `auth_time_from_resource_owner` is deprecated for " \
+               "`max_age` enforcement because it cannot distinguish between concurrent " \
+               "sessions of the same user, which is a security issue (see " \
+               "https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/150). " \
+               "Please configure `auth_time_from_session` to derive auth_time from the " \
+               "current session instead. The `auth_time_from_resource_owner` callback " \
+               "continues to be used as a fallback and for the `auth_time` claim on the " \
+               "ID Token."
+        end
+
+        # Reset the deprecation flag (test helper).
+        def self.reset_auth_time_deprecation_warning!
+          @auth_time_from_resource_owner_deprecation_warned = false
+        end
+
         private
 
         # FIXME: remove after Doorkeeper will merge it
@@ -99,10 +122,7 @@ module Doorkeeper
           max_age = params[:max_age].to_i
           return unless (params[:max_age].to_s == "0" || max_age > 0) && owner
 
-          auth_time = instance_exec(
-            owner,
-            &Doorkeeper::OpenidConnect.configuration.auth_time_from_resource_owner
-          )
+          auth_time = resolve_oidc_auth_time(owner)
 
           # Normalize non-Time values (e.g. an Integer epoch) so that the
           # subtraction below yields a Float of elapsed seconds rather than a
@@ -117,6 +137,23 @@ module Doorkeeper
           return unless !auth_time || (Time.zone.now - auth_time) > max_age
 
           reauthenticate_oidc_resource_owner(owner)
+        end
+
+        # Resolve auth_time for max_age enforcement.
+        #
+        # Prefers `auth_time_from_session` so that multi-session deployments can
+        # return the auth_time of the *current* session rather than the user's
+        # most recent login on any device (issue #150). Falls back to the legacy
+        # `auth_time_from_resource_owner` with a one-time deprecation warning.
+        def resolve_oidc_auth_time(owner)
+          config = Doorkeeper::OpenidConnect.configuration
+
+          if config.auth_time_from_session
+            return instance_exec(session, request, &config.auth_time_from_session)
+          end
+
+          Doorkeeper::OpenidConnect::Helpers::Controller.warn_auth_time_from_resource_owner_deprecation
+          instance_exec(owner, &config.auth_time_from_resource_owner)
         end
 
         def return_without_oidc_prompt_param(prompt_value)

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -21,9 +21,30 @@ Doorkeeper::OpenidConnect.configure do
   end
 
   auth_time_from_resource_owner do |resource_owner|
+    # Used to populate the `auth_time` claim on the ID Token, and as a
+    # fallback for `max_age` enforcement when `auth_time_from_session` is
+    # not configured.
+    #
     # Example implementation:
     # resource_owner.current_sign_in_at
   end
+
+  # Recommended: derive `auth_time` from the current session for `max_age`
+  # enforcement. `auth_time_from_resource_owner` returns the same value for
+  # every concurrent session of the same user (e.g. PC + smartphone), which
+  # can let a stale session satisfy an RP's `max_age` requirement by
+  # piggy-backing on a fresh login from another device.
+  #
+  # The block is executed in the controller's scope and receives the
+  # current `session` and `request`. Return value can be a `Time`,
+  # `DateTime`, or anything responding to `to_i`. Return `nil` to force
+  # reauthentication.
+  #
+  # auth_time_from_session do |session, _request|
+  #   # Example implementation: capture auth_time on the session at login,
+  #   # and surface it here.
+  #   session[:auth_time]
+  # end
 
   reauthenticate_resource_owner do |resource_owner, return_to|
     # Example implementation:

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -410,6 +410,101 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
 
+    context "when auth_time_from_session is configured" do
+      def authorize_with_session!(session_attrs, params = {})
+        get :new, params: {
+          response_type: "code",
+          response_mode: "",
+          current_user: user.id,
+          client_id: application.uid,
+          scope: default_scopes,
+          redirect_uri: application.redirect_uri,
+        }.merge(params), session: session_attrs
+      end
+
+      before do
+        Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
+          resource_owner_from_access_token do |access_token|
+            User.find_by(id: access_token.resource_owner_id)
+          end
+          auth_time_from_resource_owner do |resource_owner|
+            resource_owner.current_sign_in_at
+          end
+          auth_time_from_session do |session, _request|
+            session[:current_session_auth_time]
+          end
+          reauthenticate_resource_owner do |_resource_owner, _return_to|
+            redirect_to "/reauthenticate"
+          end
+          subject do |resource_owner|
+            resource_owner.id
+          end
+        end
+      end
+
+      it "uses the session-derived auth_time and renders the form when within max_age" do
+        authorize_with_session!(
+          { current_session_auth_time: 5.seconds.ago },
+          max_age: 10,
+        )
+
+        expect_authorization_form!
+      end
+
+      it "uses the session-derived auth_time and reauthenticates when older than max_age" do
+        authorize_with_session!(
+          { current_session_auth_time: 5.minutes.ago },
+          max_age: 10,
+        )
+
+        expect(response).to redirect_to "/reauthenticate"
+      end
+
+      it "reauthenticates when the session has no auth_time" do
+        authorize_with_session!({}, max_age: 10)
+
+        expect(response).to redirect_to "/reauthenticate"
+      end
+
+      it "respects per-session auth_time even when the resource owner was logged in on another device more recently" do
+        # The resource owner's last sign-in (e.g. on another device) is recent,
+        # but the *current* session is stale: max_age should still trigger
+        # reauthentication. This is the security scenario from issue #150.
+        user.update! current_sign_in_at: 5.seconds.ago
+
+        authorize_with_session!(
+          { current_session_auth_time: 1.hour.ago },
+          max_age: 60,
+        )
+
+        expect(response).to redirect_to "/reauthenticate"
+      end
+
+      it "does not emit the auth_time_from_resource_owner deprecation warning" do
+        expect(Doorkeeper::OpenidConnect::Helpers::Controller)
+          .not_to receive(:warn_auth_time_from_resource_owner_deprecation)
+
+        authorize_with_session!(
+          { current_session_auth_time: 5.seconds.ago },
+          max_age: 10,
+        )
+      end
+    end
+
+    context "when only auth_time_from_resource_owner is configured" do
+      before { Doorkeeper::OpenidConnect::Helpers::Controller.reset_auth_time_deprecation_warning! }
+
+      it "emits a deprecation warning once per process" do
+        user.update! current_sign_in_at: 5.seconds.ago
+
+        expect { authorize! max_age: 10 }.to output(/auth_time_from_resource_owner.*deprecated/).to_stderr
+
+        # Subsequent calls do not re-emit the warning.
+        expect { authorize! max_age: 10 }.not_to output.to_stderr
+      end
+    end
+
     context "when used along with prompt=select_account" do
       it "renders the authorization form" do
         user.update! current_sign_in_at: 5.seconds.ago

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -96,6 +96,22 @@ describe Doorkeeper::OpenidConnect, "configuration" do
     end
   end
 
+  describe "auth_time_from_session" do
+    it "defaults to nil" do
+      described_class.configure {}
+
+      expect(subject.auth_time_from_session).to be_nil
+    end
+
+    it "sets the block that is accessible via auth_time_from_session" do
+      block = proc {}
+      described_class.configure do
+        auth_time_from_session(&block)
+      end
+      expect(subject.auth_time_from_session).to eq(block)
+    end
+  end
+
   describe "reauthenticate_resource_owner" do
     it "sets the block that is accessible via reauthenticate_resource_owner" do
       block = proc {}


### PR DESCRIPTION
### Problem

`auth_time_from_resource_owner` derives `auth_time` from the resource owner object — in practice, the user's most recent login stored in the database. When a user holds multiple concurrent sessions (e.g. PC + smartphone), every session shares the same `auth_time`. This means a stale session can satisfy an RP's `max_age` requirement by piggy-backing on a fresh login from another device, which is a violation of OIDC Core §3.1.2.1.

See #150 for the original report.

### Solution

Add a new `auth_time_from_session` config option that receives `(session, request)` in the controller scope, allowing deployments to return the auth time of the *current* session.

The core change is two points:

1. **`config.rb`**: Add `option :auth_time_from_session, default: nil`
2. **`controller.rb`**: Extract `resolve_oidc_auth_time` — prefers `auth_time_from_session` when configured, falls back to `auth_time_from_resource_owner` with a one-time deprecation warning

### Backward compatibility

Existing users who only configure `auth_time_from_resource_owner` are **not affected** — the only change they will see is a one-time deprecation warning on stderr (once per process).

### What's NOT in scope

- The `auth_time` claim on the ID Token still uses `auth_time_from_resource_owner`, because `IdToken` is constructed from an access token and has no access to the session/request.
- README update is intentionally deferred to a follow-up PR to keep this diff focused.

Closes #150