### PR TITLE
Document `auth_time_from_session` in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#270] Document the unified issuer block signature in README
 - [#278] Test against Ruby 4.0.
 - [#271] **Security:** Add `auth_time_from_session` config for per-session `max_age` enforcement. The legacy `auth_time_from_resource_owner` cannot distinguish between concurrent sessions and is now deprecated for `max_age` use (see [#150](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/150))
+- [#272] Document `auth_time_from_session` in README (follow-up to [#271](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/271))
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,19 @@ The following settings are optional, but recommended for better client compatibi
 
 - `auth_time_from_resource_owner`
   - Returns the time of the user's last login, this can be a `Time`, `DateTime`, or any other class that responds to `to_i`
-  - Required to support the `max_age` parameter and the `auth_time` claim.
+  - Used to populate the `auth_time` claim on the ID Token.
+  - Used as a fallback for `max_age` enforcement when `auth_time_from_session` is not configured. **Note:** for multi-session deployments this is insecure (it returns the most recent login on _any_ device), and emits a deprecation warning — prefer `auth_time_from_session` below.
+- `auth_time_from_session`
+  - Returns the time the user authenticated for the *current* session. Required for correct `max_age` enforcement when the same user can hold multiple concurrent sessions (e.g. PC + smartphone) — `auth_time_from_resource_owner` cannot distinguish between sessions and would let a stale session inherit a fresh login from another device.
+  - The block is executed in the controller's scope and receives `(session, request)`. Return value can be a `Time`, `DateTime`, or anything responding to `to_i`. Return `nil` to force reauthentication.
+
+    ```ruby
+    # Example: capture auth_time on the session at login,
+    # and surface it here for the OIDC max_age check.
+    auth_time_from_session do |session, _request|
+      session[:auth_time]
+    end
+    ```
 - `reauthenticate_resource_owner`
   - Defines how to trigger reauthentication for the current user (e.g. display a password prompt, or sign-out the user and redirect to the login form).
   - Required to support the `max_age` and `prompt=login` parameters.


### PR DESCRIPTION
Follow-up to #271. Add usage documentation and migration guidance for the new `auth_time_from_session` config option.