### PR TITLE
Prevent custom claims from overriding protected registered claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#278] Test against Ruby 4.0.
 - [#271] **Security:** Add `auth_time_from_session` config for per-session `max_age` enforcement. The legacy `auth_time_from_resource_owner` cannot distinguish between concurrent sessions and is now deprecated for `max_age` use (see [#150](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/150))
 - [#272] Document `auth_time_from_session` in README (follow-up to [#271](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/271))
+- [#273] **Security/Hardening:** Merge framework-controlled registered claims last — `iss`/`sub`/`aud`/`exp`/`iat`/`nonce`/`auth_time` for the ID Token and `sub` for UserInfo — so a custom claim block can no longer override security-critical values. No legitimate configuration relied on this; custom claims that intentionally shadowed a registered claim name will now be ignored for that key (OIDC Core §2 / §3.1.3.7 / §5.3.2).
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -16,7 +16,10 @@ module Doorkeeper
       end
 
       def claims
-        {
+        # NOTE: framework-controlled claims are merged last so a custom claim
+        # block cannot override security-critical registered claims such as
+        # `sub`, `aud`, `exp`, `iss` or `iat` in the signed ID token.
+        ClaimsBuilder.generate(@access_token, :id_token).merge(
           iss: issuer,
           sub: subject,
           aud: audience,
@@ -24,7 +27,7 @@ module Doorkeeper
           iat: issued_at,
           nonce: nonce,
           auth_time: auth_time
-        }.merge ClaimsBuilder.generate(@access_token, :id_token)
+        )
       end
 
       def as_json(*_)

--- a/lib/doorkeeper/openid_connect/user_info.rb
+++ b/lib/doorkeeper/openid_connect/user_info.rb
@@ -10,9 +10,12 @@ module Doorkeeper
       end
 
       def claims
-        {
+        # NOTE: `sub` is merged last so a custom claim block cannot override
+        # the canonical subject identifier (which would defeat pairwise /
+        # subject-type guarantees).
+        ClaimsBuilder.generate(@access_token, :user_info).merge(
           sub: subject
-        }.merge ClaimsBuilder.generate(@access_token, :user_info)
+        )
       end
 
       def as_json(*_)

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -122,6 +122,42 @@ describe Doorkeeper::OpenidConnect::IdToken do
         expect(subject.as_json).not_to include(:auth_time)
       end
     end
+
+    context "when a custom claim collides with a protected registered claim" do
+      before do
+        Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
+
+          resource_owner_from_access_token do |access_token|
+            User.find_by(id: access_token.resource_owner_id)
+          end
+
+          auth_time_from_resource_owner do |resource_owner|
+            resource_owner.current_sign_in_at
+          end
+
+          subject do |resource_owner|
+            resource_owner.id
+          end
+
+          claims do
+            claim(:sub, scope: :openid, response: [:id_token]) { "SPOOFED-SUB" }
+            claim(:aud, scope: :openid, response: [:id_token]) { "EVIL-CLIENT" }
+            claim(:exp, scope: :openid, response: [:id_token]) { 9_999_999_999 }
+            claim(:iss, scope: :openid, response: [:id_token]) { "https://evil.example.com" }
+          end
+        end
+      end
+
+      it "does not let custom claims override iss/sub/aud/exp in the signed ID token" do
+        claims = subject.claims
+
+        expect(claims[:iss]).to eq "dummy"
+        expect(claims[:sub]).to eq user.id.to_s
+        expect(claims[:aud]).to eq access_token.application.uid
+        expect(claims[:exp]).to eq 180
+      end
+    end
   end
 
   describe "#as_json" do

--- a/spec/lib/user_info_spec.rb
+++ b/spec/lib/user_info_spec.rb
@@ -37,6 +37,28 @@ describe Doorkeeper::OpenidConnect::UserInfo do
         })
       end
     end
+
+    context "when a custom claim collides with the protected sub claim" do
+      before do
+        Doorkeeper::OpenidConnect.configure do
+          resource_owner_from_access_token do |access_token|
+            User.find_by(id: access_token.resource_owner_id)
+          end
+
+          subject do |resource_owner|
+            resource_owner.id
+          end
+
+          claims do
+            claim(:sub, scope: :openid, response: [:user_info]) { "SPOOFED-SUB" }
+          end
+        end
+      end
+
+      it "does not let a custom claim override the canonical subject" do
+        expect(subject.claims[:sub]).to eq user.id.to_s
+      end
+    end
   end
 
   describe "#as_json" do


### PR DESCRIPTION
ID Token and UserInfo merged the framework-controlled registered claims (`iss`/`sub`/`aud`/`exp`/`iat`/`nonce`/`auth_time`, and `sub` for UserInfo) **before** `ClaimsBuilder` output, so a custom claim block whose name collided with a registered claim silently won via `Hash#merge`.

For the signed ID Token this lets a misconfigured **or data/plugin-driven** claim block mint a token with an unintended `sub`/`aud`/`exp`/`iss` under the provider's valid signature; for UserInfo it breaks the OIDC Core §5.3.2 requirement that `sub` exactly match the ID Token `sub` (and defeats pairwise subject identifiers).

>[!NOTE]
> **Scope (honest):** this is not remotely exploitable by an unauthenticated attacker — it requires the provider's own claims configuration to collide with a registered claim name. It is a defense-in-depth + OIDC-conformance hardening: the framework-controlled claims are now merged **last** so they always take precedence. No public API change; no legitimate configuration relies on overriding these claims. Adds regression specs for both ID Token and UserInfo.

Refs: OpenID Connect Core 1.0 [§2](https://openid.net/specs/openid-connect-core-1_0.html#IDToken), [§3.1.3.7](https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation), [§5.3.2](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse).