### PR TITLE
Return login_required for max_age reauthentication when prompt=none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#276] Get RuboCop to zero offenses: fix `Lint/MissingSuper` in `IdTokenResponse`, replace `puts` with `warn` for deprecation notices, and modernise spec style
 - [#277] Fix README inaccuracies (`signing_algorithm` description and link, `discovery_url_options` endpoint list, `oauth-authorization-server` route) and use constant-time comparison in the DCR authorization example to prevent timing attacks on the Initial Access Token
 - [#279] Return `account_selection_required` when a `prompt=select_account` handler does not generate a response, per [OIDC Core 1.0 §3.1.2.6](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) — previously the authorization silently continued without account selection. Adds the missing `Errors::AccountSelectionRequired` class, mirroring the existing `login_required` backstop for `reauthenticate_resource_owner`
+- [#275] Return `login_required` for `max_age` reauthentication when `prompt=none`, instead of triggering the interactive `reauthenticate_resource_owner` flow (OIDC Core §3.1.2.1)
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -88,10 +88,8 @@ module Doorkeeper
         end
 
         def handle_oidc_prompt_param!(owner)
-          prompt_values ||= params[:prompt].to_s.split(/ +/).uniq
-
           priority = %w[none consent login select_account]
-          prompt_values.sort_by! do |prompt|
+          prompt_values = oidc_prompt_values.sort_by do |prompt|
             priority.find_index(prompt).to_i
           end
 
@@ -136,7 +134,19 @@ module Doorkeeper
 
           return unless !auth_time || (Time.zone.now - auth_time) > max_age
 
+          # OIDC Core 1.0 §3.1.2.1: with `prompt=none` the Authorization Server
+          # MUST NOT display any authentication UI. Reauthentication required by
+          # `max_age` must therefore be reported as `login_required` instead of
+          # triggering the interactive `reauthenticate_resource_owner` flow.
+          # (Conflicting combinations like `prompt=none login` are still left to
+          # `handle_oidc_prompt_param!`, which raises `invalid_request`.)
+          raise Errors::LoginRequired if oidc_prompt_values == ["none"]
+
           reauthenticate_oidc_resource_owner(owner)
+        end
+
+        def oidc_prompt_values
+          @oidc_prompt_values ||= params[:prompt].to_s.split(/ +/).uniq
         end
 
         # Resolve auth_time for max_age enforcement.

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -531,6 +531,24 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
         expect(response).to redirect_to "/reauthenticate"
       end
     end
+
+    context "when used along with prompt=none" do
+      # OIDC Core 1.0 §3.1.2.1: with prompt=none the Authorization Server MUST
+      # NOT display any UI; an exceeded max_age must be reported as
+      # login_required rather than triggering interactive reauthentication.
+      it "returns login_required instead of reauthenticating interactively" do
+        create :access_token, token_attributes
+        user.update! current_sign_in_at: 5.minutes.ago
+
+        authorize! max_age: 10, prompt: "none", state: "somestate"
+
+        expect(response).to redirect_to build_redirect_uri({
+          "error" => "login_required",
+          "error_description" => "The authorization server requires end-user authentication",
+          "state" => "somestate",
+        })
+      end
+    end
   end
 
   describe "#reauthenticate_oidc_resource_owner" do


### PR DESCRIPTION
### Summary
When `max_age` requires reauthentication, raise `LoginRequired` (instead of triggering the interactive `reauthenticate_resource_owner` flow) if `prompt` is exactly `none`:

```ruby
prompt_values = params[:prompt].to_s.split(/ +/).uniq
raise Errors::LoginRequired if prompt_values == ["none"]

reauthenticate_oidc_resource_owner(owner)
```

Conflicting combinations such as `prompt=none login` are intentionally left to `handle_oidc_prompt_param!`, which already raises `invalid_request` for them (so their behavior is unchanged).

### Why
OpenID Connect Core 1.0 §3.1.2.1 — `prompt=none` must not show UI; required reauthentication must be reported as `login_required`.

### Test coverage
- `spec/controllers/doorkeeper/authorizations_controller_spec.rb`: new context under `#handle_oidc_max_age_param!` asserting `login_required` is returned (not a `/reauthenticate` redirect).
- Verified red before the fix (redirected to `/reauthenticate`) / green after; existing `max_age` + `prompt=login/consent/select_account` specs unaffected.

Closes #274.