### PR TITLE
Get RuboCop to zero offenses (176 → 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest]
         ruby:
-          - '3.1'
-          - '3.2'
-          - '3.3'
-          - '3.4'
-          - '4.0'
+          - "3.1"
+          - "3.2"
+          - "3.3"
+          - "3.4"
+          - "4.0"
           - head
         gemfile:
           - gemfiles/rails_7.0.gemfile
@@ -54,3 +54,25 @@ jobs:
       - name: Run tests
         timeout-minutes: 10
         run: bundle exec rake spec
+  lint:
+    name: RuboCop
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_PATH: /home/runner/bundle
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]'))
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run RuboCop
+        run: bundle exec rubocop

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,37 @@
+name: rubocop
+on:
+  pull_request:
+    paths:
+      - 'lib/**/*.rb'
+      - 'app/**/*'
+      - 'spec/**/*.rb'
+      - 'bin/*'
+      - '.rubocop.yml'
+      - '.rubocop_todo.yml'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - 'Rakefile'
+      - '*.gemspec'
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  rubocop:
+    name: runner / rubocop
+    runs-on: ubuntu-latest
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]'))
+    env:
+      BUNDLE_ONLY: rubocop
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - uses: reviewdog/action-rubocop@b6d5e953a5fc0bf3ab65254e77730ea2174d6d6d # v2.22.0
+        with:
+          reporter: github-pr-review # Default is github-pr-check
+          skip_install: true
+          use_bundler: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,11 @@ plugins:
 AllCops:
   TargetRubyVersion: 3.1
   Exclude:
+    # CI installs gems into ./vendor/bundle (ruby/setup-ruby bundler-cache),
+    # which RuboCop would otherwise lint. Defining AllCops/Exclude overrides
+    # RuboCop's default vendor exclusion, so list it explicitly here too.
+    - "vendor/**/*"
+    - ".bundle/**/*"
     - "spec/dummy/bin/*"
     - "spec/dummy/db/*"
     - "spec/dummy/db/*/**"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,16 @@ Layout/DotPosition:
 Layout/LineLength:
   Exclude:
     - spec/**/*
+    # Legacy library files with long lines remaining
+    # (mostly multi-line I18n/deprecation message strings).
+    - app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+    - app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+    - lib/doorkeeper/openid_connect/config.rb
+    - lib/doorkeeper/openid_connect/errors.rb
+    - lib/doorkeeper/openid_connect/helpers/controller.rb
+    - lib/doorkeeper/openid_connect/orm/active_record.rb
+    - lib/doorkeeper/openid_connect/orm/active_record/mixins/openid_request.rb
+    - lib/generators/doorkeeper/openid_connect/templates/initializer.rb
   Max: 100
 Metrics/BlockLength:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,7 +27,19 @@ Metrics/ModuleLength:
   Max: 209
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 33
+
+# Configuration parameters: IgnoredMethods.
+Metrics/AbcSize:
+  Max: 35
+
+# Configuration parameters: IgnoredMethods.
+Metrics/CyclomaticComplexity:
+  Max: 13
+
+# Configuration parameters: IgnoredMethods.
+Metrics/PerceivedComplexity:
+  Max: 10
 
 Style/TrailingCommaInArguments:
   Enabled: false
@@ -46,4 +58,45 @@ RSpec/NamedSubject:
 
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:
+  Enabled: false
+
+# This gem does not enforce top-level documentation comments.
+Style/Documentation:
+  Enabled: false
+
+# Configuration parameters: AllowedConstants.
+Naming/VariableNumber:
+  Enabled: false
+
+# The Doorkeeper config DSL (subject, auth_time_from_resource_owner, claim)
+# invokes these blocks with extra arguments, so a strict-arity `&:sym`
+# lambda raises ArgumentError. Keep explicit blocks here.
+Style/SymbolProc:
+  Exclude:
+    - "spec/dummy/config/initializers/doorkeeper_openid_connect.rb"
+    - "spec/lib/id_token_spec.rb"
+    - "spec/support/doorkeeper_configuration.rb"
+
+# Configuration parameters: Max, AllowSubject.
+RSpec/MultipleMemoizedHelpers:
+  Max: 7
+
+RSpec/SubjectStub:
+  Enabled: false
+
+# Configuration parameters: Prefixes, AllowedPatterns.
+# Prefixes: when, with, without
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/ExpectInHook:
+  Enabled: false
+
+RSpec/IndexedLet:
+  Enabled: false
+
+RSpec/StubbedMock:
+  Enabled: false
+
+RSpec/DescribeMethod:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -73,6 +73,7 @@ Naming/VariableNumber:
 # lambda raises ArgumentError. Keep explicit blocks here.
 Style/SymbolProc:
   Exclude:
+    - "spec/controllers/doorkeeper/authorizations_controller_spec.rb"
     - "spec/dummy/config/initializers/doorkeeper_openid_connect.rb"
     - "spec/lib/id_token_spec.rb"
     - "spec/support/doorkeeper_configuration.rb"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -76,6 +76,7 @@ Style/SymbolProc:
     - "spec/controllers/doorkeeper/authorizations_controller_spec.rb"
     - "spec/dummy/config/initializers/doorkeeper_openid_connect.rb"
     - "spec/lib/id_token_spec.rb"
+    - "spec/lib/user_info_spec.rb"
     - "spec/support/doorkeeper_configuration.rb"
 
 # Configuration parameters: Max, AllowSubject.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#271] **Security:** Add `auth_time_from_session` config for per-session `max_age` enforcement. The legacy `auth_time_from_resource_owner` cannot distinguish between concurrent sessions and is now deprecated for `max_age` use (see [#150](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/150))
 - [#272] Document `auth_time_from_session` in README (follow-up to [#271](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/271))
 - [#273] **Security/Hardening:** Merge framework-controlled registered claims last — `iss`/`sub`/`aud`/`exp`/`iat`/`nonce`/`auth_time` for the ID Token and `sub` for UserInfo — so a custom claim block can no longer override security-critical values. No legitimate configuration relied on this; custom claims that intentionally shadowed a registered claim name will now be ignored for that key (OIDC Core §2 / §3.1.3.7 / §5.3.2).
+- [#276] Get RuboCop to zero offenses: fix `Lint/MissingSuper` in `IdTokenResponse`, replace `puts` with `warn` for deprecation notices, and modernise spec style
 
 ## v1.9.0 (2026-03-16)
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,11 @@ ENV["rails"] ||= "8.0.0"
 gem "rails", "~> #{ENV["rails"]}"
 gem "rails-controller-testing"
 
-gem "rubocop", "~> 1.6"
-gem "rubocop-performance", require: false
-gem "rubocop-rails", require: false
-gem "rubocop-rspec", require: false
+group :development, :rubocop do
+  gem "rubocop", "~> 1.6"
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+  gem "rubocop-rspec", require: false
+end
 
 gemspec

--- a/app/controllers/concerns/doorkeeper/openid_connect/authorizations_extension.rb
+++ b/app/controllers/concerns/doorkeeper/openid_connect/authorizations_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Doorkeeper
   module OpenidConnect
     module AuthorizationsExtension

--- a/lib/doorkeeper/oauth/id_token_response.rb
+++ b/lib/doorkeeper/oauth/id_token_response.rb
@@ -8,6 +8,7 @@ module Doorkeeper
       attr_accessor :pre_auth, :auth, :id_token
 
       def initialize(pre_auth, auth, id_token)
+        super()
         @pre_auth = pre_auth
         @auth = auth
         @id_token = id_token

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -27,11 +27,11 @@ module Doorkeeper
         end
 
         def jws_public_key(*_args)
-          puts "DEPRECATION WARNING: `jws_public_key` is not needed anymore and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb"
+          warn "DEPRECATION WARNING: `jws_public_key` is not needed anymore and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb"
         end
 
         def jws_private_key(*args)
-          puts "DEPRECATION WARNING: `jws_private_key` has been replaced by `signing_key` and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb"
+          warn "DEPRECATION WARNING: `jws_private_key` has been replaced by `signing_key` and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb"
           signing_key(*args)
         end
       end

--- a/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
+++ b/spec/dummy/config/initializers/doorkeeper_openid_connect.rb
@@ -3,7 +3,7 @@
 Doorkeeper::OpenidConnect.configure do
   issuer "dummy"
 
-  signing_key <<~EOL
+  signing_key <<~RSA_PRIVATE_KEY
     -----BEGIN RSA PRIVATE KEY-----
     MIIEpgIBAAKCAQEAsjdnSA6UWUQQHf6BLIkIEUhMRNBJC1NN/pFt1EJmEiI88GS0
     ceROO5B5Ooo9Y3QOWJ/n+u1uwTHBz0HCTN4wgArWd1TcqB5GQzQRP4eYnWyPfi4C
@@ -31,7 +31,7 @@ Doorkeeper::OpenidConnect.configure do
     SFR3PjWQyCg7aGGXiooCM38YQruACTj0IFub24MFRA4ZTXvrACvpsVokJlQiG0Z4
     tuQKYki41JvYqPobcq/rLE/AM7PKJftW35nqFuj0MrsUwPacaVwKBf5J
     -----END RSA PRIVATE KEY-----
-  EOL
+  RSA_PRIVATE_KEY
 
   subject_types_supported [:public]
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -229,7 +229,7 @@ describe Doorkeeper::OpenidConnect, "configuration" do
     end
 
     it "can be set to other hosts" do
-      Doorkeeper::OpenidConnect.configure do
+      described_class.configure do
         discovery_url_options do |_request|
           {
             authorization: { host: "alternate-authorization-host" },

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -162,9 +162,7 @@ describe Doorkeeper::OpenidConnect::IdToken do
 
   describe "#as_json" do
     it "returns claims with nil values and empty strings removed" do
-      allow(subject).to receive(:issuer).and_return(nil)
-      allow(subject).to receive(:subject).and_return("")
-      allow(subject).to receive(:audience).and_return(" ")
+      allow(subject).to receive_messages(issuer: nil, subject: "", audience: " ")
 
       json = subject.as_json
 

--- a/spec/lib/oauth/authorization/code_spec.rb
+++ b/spec/lib/oauth/authorization/code_spec.rb
@@ -14,12 +14,7 @@ describe Doorkeeper::OpenidConnect::OAuth::Authorization::Code do
   describe "#issue_token" do
     before do
       allow(pre_auth).to receive(:client) { client }
-      allow(pre_auth).to receive(:redirect_uri).and_return("redirect_uri")
-      allow(pre_auth).to receive(:scopes).and_return("scopes")
-      allow(pre_auth).to receive(:nonce).and_return("123456")
-      allow(pre_auth).to receive(:code_challenge).and_return("987654")
-      allow(pre_auth).to receive(:code_challenge_method).and_return("plain")
-      allow(pre_auth).to receive(:custom_access_token_attributes).and_return({})
+      allow(pre_auth).to receive_messages(redirect_uri: "redirect_uri", scopes: "scopes", nonce: "123456", code_challenge: "987654", code_challenge_method: "plain", custom_access_token_attributes: {})
       allow(client).to receive(:id).and_return("client_id")
 
       allow(Doorkeeper::AccessGrant).to receive(:create!) { access_grant }

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -31,7 +31,7 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
 
       expect do
         subject.send :after_successful_response
-      end.to change { openid_request_class.count }.by(-1)
+      end.to change(openid_request_class, :count).by(-1)
     end
 
     it "skips the nonce if not present" do
@@ -62,7 +62,7 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
 
         expect do
           subject.send :after_successful_response
-        end.to change { openid_request_class.count }.by(-1)
+        end.to change(openid_request_class, :count).by(-1)
       end
 
       it "does not build an ID token" do

--- a/spec/lib/oauth/id_token_request_spec.rb
+++ b/spec/lib/oauth/id_token_request_spec.rb
@@ -40,7 +40,7 @@ describe Doorkeeper::OAuth::IdTokenRequest do
   it "creates an access token" do
     expect do
       subject.authorize
-    end.to change { Doorkeeper::AccessToken.count }.by(1)
+    end.to change(Doorkeeper::AccessToken, :count).by(1)
   end
 
   it "returns id_token response" do
@@ -52,7 +52,7 @@ describe Doorkeeper::OAuth::IdTokenRequest do
       allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
       expect do
         subject.authorize
-      end.to change { Doorkeeper::AccessToken.count }.by(1)
+      end.to change(Doorkeeper::AccessToken, :count).by(1)
     end
 
     it "creates a new token if scopes do not match" do
@@ -61,18 +61,17 @@ describe Doorkeeper::OAuth::IdTokenRequest do
              resource_owner_id: owner.id, scopes: "")
       expect do
         subject.authorize
-      end.to change { Doorkeeper::AccessToken.count }.by(1)
+      end.to change(Doorkeeper::AccessToken, :count).by(1)
     end
 
     it "skips token creation if there is a matching one" do
       allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
-      allow(application.scopes).to receive(:has_scopes?).and_return(true)
-      allow(application.scopes).to receive(:all?).and_return(true)
+      allow(application.scopes).to receive_messages(has_scopes?: true, all?: true)
 
       create(:access_token, application_id: pre_auth.client.id,
              resource_owner_id: owner.id, scopes: "public")
 
-      expect { subject.authorize }.not_to(change { Doorkeeper::AccessToken.count })
+      expect { subject.authorize }.not_to(change(Doorkeeper::AccessToken, :count))
     end
   end
 end

--- a/spec/lib/oauth/id_token_token_request_spec.rb
+++ b/spec/lib/oauth/id_token_token_request_spec.rb
@@ -40,7 +40,7 @@ describe Doorkeeper::OAuth::IdTokenTokenRequest do
   it "creates an access token" do
     expect do
       subject.authorize
-    end.to change { Doorkeeper::AccessToken.count }.by(1)
+    end.to change(Doorkeeper::AccessToken, :count).by(1)
   end
 
   it "returns id_token token response" do

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 describe Doorkeeper::OpenidConnect::OAuth::PasswordAccessTokenRequest do
   # TODO: Remove conditional when minimum doorkeeper version is >= 5.5.1
-  # rubocop:disable RSpec/MultipleSubjects
+  # rubocop:disable RSpec/MultipleSubjects, RSpec/LeadingSubject
   if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.1")
     subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, credentials, resource_owner, { nonce: "123456" } }
   else
     subject { Doorkeeper::OAuth::PasswordAccessTokenRequest.new server, client, resource_owner, { nonce: "123456" } }
   end
-  # rubocop:enable RSpec/MultipleSubjects
+  # rubocop:enable RSpec/MultipleSubjects, RSpec/LeadingSubject
 
   let(:server) { double }
   let(:client) { double }

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -23,7 +23,7 @@ describe Doorkeeper::OpenidConnect do
 
       before do
         key_pem = rsa_key_1_pem
-        Doorkeeper::OpenidConnect.configure do
+        described_class.configure do
           signing_key -> { key_pem }
         end
       end
@@ -46,7 +46,7 @@ describe Doorkeeper::OpenidConnect do
         kid_1 = subject.signing_key.kid
 
         key_pem = rsa_key_2_pem
-        Doorkeeper::OpenidConnect.configure do
+        described_class.configure do
           signing_key -> { key_pem }
         end
 
@@ -81,7 +81,7 @@ describe Doorkeeper::OpenidConnect do
 
       before do
         key_pem = ec_key_pem
-        Doorkeeper::OpenidConnect.configure do
+        described_class.configure do
           signing_algorithm :ES256
           signing_key -> { key_pem }
         end
@@ -106,7 +106,7 @@ describe Doorkeeper::OpenidConnect do
 
       before do
         secret = hmac_secret
-        Doorkeeper::OpenidConnect.configure do
+        described_class.configure do
           signing_algorithm :HS256
           signing_key -> { secret }
         end
@@ -184,7 +184,7 @@ describe Doorkeeper::OpenidConnect do
 
     context "when issuer is a static string" do
       before do
-        Doorkeeper::OpenidConnect.configure do
+        described_class.configure do
           issuer "https://static-issuer.example.com"
         end
       end
@@ -196,7 +196,7 @@ describe Doorkeeper::OpenidConnect do
 
     context "when issuer block has arity 0" do
       before do
-        Doorkeeper::OpenidConnect.configure do
+        described_class.configure do
           issuer do
             "https://zero-arity.example.com"
           end
@@ -212,7 +212,7 @@ describe Doorkeeper::OpenidConnect do
       before do
         req = request
         owner = resource_owner
-        Doorkeeper::OpenidConnect.configure do
+        described_class.configure do
           issuer do |request_or_owner|
             if request_or_owner.equal?(req)
               "issuer-request"
@@ -243,7 +243,7 @@ describe Doorkeeper::OpenidConnect do
 
     context "when issuer block has arity 2" do
       before do
-        Doorkeeper::OpenidConnect.configure do
+        described_class.configure do
           issuer do |resource_owner, application|
             "owner-#{resource_owner&.class&.name}-app-#{application&.class&.name}"
           end
@@ -263,7 +263,7 @@ describe Doorkeeper::OpenidConnect do
 
     context "when issuer block has arity 3" do
       before do
-        Doorkeeper::OpenidConnect.configure do
+        described_class.configure do
           issuer do |resource_owner, _application, request|
             if request
               request.base_url

--- a/spec/models/access_grant_spec.rb
+++ b/spec/models/access_grant_spec.rb
@@ -30,7 +30,7 @@ describe Doorkeeper::OpenidConnect::AccessGrant do
         create(:openid_request, access_grant: access_grant)
 
         expect { access_grant.delete }
-          .to(change { openid_request_class.count }.by(-1))
+          .to(change(openid_request_class, :count).by(-1))
       else
         skip <<-MSG.strip
           Needs Rails 6 for foreign key support with sqlite3:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,7 +37,7 @@ FactoryBot.find_definitions
 
 RSpec.configure do |config|
   # Backward compatibility: fixture_path was removed in RSpec-Rails 8.x
-  config.fixture_path = "#{Rails.root.join("spec/fixtures")}" if config.respond_to?(:fixture_path=)
+  config.fixture_path = Rails.root.join("spec/fixtures").to_s if config.respond_to?(:fixture_path=)
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/support/doorkeeper_configuration.rb
+++ b/spec/support/doorkeeper_configuration.rb
@@ -22,7 +22,7 @@ module DoorkeeperConfiguration
   end
 
   def configure_ec
-    signing_key = <<~EOL
+    signing_key = <<~EC_PRIVATE_KEY
       -----BEGIN EC PRIVATE KEY-----
       MIHbAgEBBEF9VcxGjPKczrJlE1N3oEpZsauQfDXIjLeini7h4/3+DOKw2VWE4lCU
       rNJJL65EHT+2TriRg2xSb0l0rK/MAFAFraAHBgUrgQQAI6GBiQOBhgAEAeYVvbl3
@@ -30,7 +30,7 @@ module DoorkeeperConfiguration
       dEzFRYQqJVI4UFvFAYJ7GYeBm/Fb6liN53xGASdbRSzF34h4BDSVYzjtQc7I+1LK
       17fwwS3VfQCJwaT6zX33HTrhR4VoUEUJHKwR3dNs
       -----END EC PRIVATE KEY-----
-    EOL
+    EC_PRIVATE_KEY
     configure_doorkeeper(signing_key, :ES512)
   end
 


### PR DESCRIPTION
## Summary

Follow-up to #264 — resolves the remaining offenses to reach zero.

Bring RuboCop offenses from **176 → 0** with no test regressions (232 examples, 0 failures — verified on two random seeds from a clean DB).

The second commit adds a dedicated RuboCop job to CI so that the zero-offense baseline is enforced on every push and pull request.

## Motivation

`.rubocop_todo.yml` has not been updated since 2020. Running `rubocop` on the current codebase reports 176 offenses, which makes it easy to miss new violations in PRs. This patch brings the count to zero so CI can enforce a clean baseline going forward.

## What changed

### Real code fixes

| Cop | Fix |
|-----|-----|
| **Lint/MissingSuper** | Call `super()` in `IdTokenResponse#initialize` |
| **Rails/Output** | Replace `puts` → `warn` for deprecation notices (stderr, not stdout) |
| **Naming/HeredocDelimiterNaming** | `EOL` → `RSA_PRIVATE_KEY` / `EC_PRIVATE_KEY` |
| **RSpec/DescribedClass** | `Doorkeeper::OpenidConnect.configure` → `described_class.configure` |
| **RSpec/ExpectChange** | `change { Klass.count }` → `change(Klass, :count)` |
| **RSpec/ReceiveMessages** | Collapse chained `receive` stubs into `receive_messages` |
| **Style/RedundantInterpolation** | `"#{Rails.root.join(...)}"` → `.to_s` |
| **Style/FrozenStringLiteralComment** | Add missing magic comment |

### Safe autocorrects applied

All autocorrects from `rubocop -A` were reviewed; safe cops were applied as-is, and vetted unsafe cops (`RSpec/DescribedClass`, `RSpec/ExpectChange`, `RSpec/ReceiveMessages`) were verified manually.

### Behaviour-breaking autocorrects avoided

Two autocorrects were **reverted** after causing test failures:

1. **RSpec/LeadingSubject** — mangled the version-conditional `subject` in `password_access_token_request_spec.rb` (dropped the `else` branch). Restored the original and added an inline `# rubocop:disable RSpec/LeadingSubject`.

2. **Style/SymbolProc** — rewrote the Doorkeeper config DSL blocks (`subject`, `auth_time_from_resource_owner`, `claim`) to `&:sym`. These DSL methods pass extra arguments, so the strict-arity lambda raises `ArgumentError`. Restored explicit blocks and excluded the files in `.rubocop_todo.yml`.

### Configuration updates (`.rubocop.yml` / `.rubocop_todo.yml`)

- **Disabled:** `Style/Documentation`, `Naming/VariableNumber`, and noisy RSpec structural cops (`ContextWording`, `DescribeMethod`, `ExpectInHook`, `IndexedLet`, `SubjectStub`, `StubbedMock`)
- **Raised Max:** `Metrics/MethodLength` 15 → 33, `Metrics/AbcSize` → 35, `Metrics/CyclomaticComplexity` → 13, `Metrics/PerceivedComplexity` → 10, `RSpec/MultipleMemoizedHelpers` → 7
- **Excluded from Layout/LineLength:** legacy library files with long deprecation / I18n strings

All config changes follow the existing `.rubocop_todo.yml` convention (values derived from `rubocop --auto-gen-config`).

## Behavioural notes for existing users

This patch is mostly spec / config cleanup, but two fixes touch runtime
code:

1. **`puts` → `warn` for deprecation notices** (`config.rb`) — `jws_public_key` and `jws_private_key` deprecation messages now go to **stderr** instead of stdout. This is the standard Ruby / Rails convention for warnings. If you were capturing stdout to detect deprecations, you will need to capture stderr instead.

2. **`super()` added to `IdTokenResponse#initialize`** — `IdTokenResponse` inherits from `BaseResponse`, which does not define its own `initialize`, so `super()` resolves to `Object#initialize` (a no-op). This change silences the `Lint/MissingSuper` cop with **no behavioural effect**. Note that bare `super` (without parens) would forward the three arguments and raise `ArgumentError`; the explicit `super()` avoids this.

Neither change alters the gem's public interface or return values.

## Verification

```
$ bundle exec rubocop
...
91 files inspected, no offenses detected

$ bundle exec rspec --seed 12345
232 examples, 0 failures

$ bundle exec rspec --seed 55728
232 examples, 0 failures
```

>[!TIP]
>As a follow-up I'm planning to open a separate PR to upgrade `actions/checkout` from v3 → v6 and pin it to a commit SHA for supply-chain safety. `ruby/setup-ruby` will stay at `@v1` per their upstream recommendation (the `v1` tag is intentionally a moving target that tracks new Ruby releases).