### PR TITLE
Fix README inaccuracies and use constant-time comparison in DCR authorization example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#272] Document `auth_time_from_session` in README (follow-up to [#271](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/271))
 - [#273] **Security/Hardening:** Merge framework-controlled registered claims last — `iss`/`sub`/`aud`/`exp`/`iat`/`nonce`/`auth_time` for the ID Token and `sub` for UserInfo — so a custom claim block can no longer override security-critical values. No legitimate configuration relied on this; custom claims that intentionally shadowed a registered claim name will now be ignored for that key (OIDC Core §2 / §3.1.3.7 / §5.3.2).
 - [#276] Get RuboCop to zero offenses: fix `Lint/MissingSuper` in `IdTokenResponse`, replace `puts` with `warn` for deprecation notices, and modernise spec style
+- [#277] Fix README inaccuracies (`signing_algorithm` description and link, `discovery_url_options` endpoint list, `oauth-authorization-server` route) and use constant-time comparison in the DCR authorization example to prevent timing attacks on the Initial Access Token
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ The following settings are required in `config/initializers/doorkeeper_openid_co
 - `resource_owner_from_access_token`
   - Defines how to translate the Doorkeeper access token to a resource owner model.
 
+> [!Note]
+> Both `signing_key` and `signing_algorithm` also accept callable objects (e.g. a lambda), which are evaluated on each call — useful for multi-tenant setups where the key or algorithm varies per request:
+>
+> ```ruby
+> signing_key -> { current_tenant.private_key }
+> signing_algorithm -> { current_tenant.algorithm }
+> ```
+
 The following settings are optional, but recommended for better client compatibility:
 
 - `auth_time_from_resource_owner`

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The following settings are required in `config/initializers/doorkeeper_openid_co
   - You can generate a private key with the `openssl` command, see e.g. [Generate an RSA keypair using OpenSSL](https://en.wikibooks.org/wiki/Cryptography/Generate_a_keypair_using_OpenSSL).
   - You should not commit the key to your repository, but use an external file (in combination with `File.read`) and/or the [dotenv-rails](https://github.com/bkeepers/dotenv) gem (in combination with `ENV[...]`).
 - `signing_algorithm`
-  - The encryption type of the private key which defaults to `:rs256`. The list of supported algorithms can be found [here](https://github.com/nov/json-jwt/wiki/JWE#supported-algorithms)
+  - The signing algorithm used for the ID token, which defaults to `:rs256`. The list of supported algorithms can be found [here](https://github.com/jwt/ruby-jwt#algorithms-and-usage)
 - `resource_owner_from_access_token`
   - Defines how to translate the Doorkeeper access token to a resource owner model.
 
@@ -204,7 +204,7 @@ The following settings are optional:
 - `discovery_url_options`
   - The URL options for every available endpoint to use when generating the endpoint URL in the
     discovery response. Available endpoints: `authorization`, `token`, `revocation`,
-    `introspection`, `userinfo`, `jwks`.
+    `introspection`, `userinfo`, `jwks`, `dynamic_client_registration`.
   - This option requires option keys with an available endpoint and
     [URL options](https://api.rubyonrails.org/v6.0.3.3/classes/ActionDispatch/Routing/UrlFor.html#method-i-url_for)
     as value.
@@ -294,6 +294,7 @@ GET   /oauth/userinfo
 POST  /oauth/userinfo
 GET   /oauth/discovery/keys
 GET   /.well-known/openid-configuration
+GET   /.well-known/oauth-authorization-server
 GET   /.well-known/webfinger
 ```
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,15 @@ Doorkeeper::OpenidConnect.configure do
   # ...
   dynamic_client_registration true
   authorize_dynamic_client_registration do
-    request.headers["Authorization"] == "Bearer #{ENV['DCR_INITIAL_ACCESS_TOKEN']}"
+    provided = request.headers["Authorization"].to_s
+    expected = "Bearer #{ENV['DCR_INITIAL_ACCESS_TOKEN']}"
+    # Use a constant-time comparison to avoid leaking the token via timing.
+    # Digesting first keeps the comparison fixed-length so the token's length
+    # isn't leaked either.
+    ActiveSupport::SecurityUtils.secure_compare(
+      Digest::SHA256.hexdigest(provided),
+      Digest::SHA256.hexdigest(expected),
+    )
   end
   # ...
 end


### PR DESCRIPTION
Two documentation fixes in a single PR (one commit each):

**1. Fix README inaccuracies**

- `signing_algorithm`: describe it as the ID token **signing** algorithm (RS256 is signing, not encryption) and point to [ruby-jwt's algorithm docs](https://github.com/jwt/ruby-jwt#algorithms-and-usage) instead of the stale nov/json-jwt JWE wiki link.
- `discovery_url_options`: add `dynamic_client_registration` to the list of available endpoints (matches `DiscoveryController`).
- Routes: document the unconditionally-mounted `GET /.well-known/oauth-authorization-server` route.

**2. Use constant-time comparison in DCR authorization example**

The previous example compared the bearer token with `==`, which is vulnerable to a timing attack that could leak the Initial Access Token. Replace with `ActiveSupport::SecurityUtils.secure_compare` over SHA-256 digests so the comparison is both constant-time and fixed-length (avoiding token length leakage).