### PR TITLE
Test against Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
           - head
         gemfile:
           - gemfiles/rails_7.0.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#268] Update Dynamic Client Registration README for validated metadata parameters
 - [#269] Document `authorize_dynamic_client_registration` in README
 - [#270] Document the unified issuer block signature in README
+- [#278] Test against Ruby 4.0.
 
 ## v1.9.0 (2026-03-16)
 


### PR DESCRIPTION
### Summary

Ruby 4.0 has been released (4.0.0, 2025-12-25). Add it to the CI matrix so the gem is exercised against the current major Ruby, following the precedent of #219 ("Test against Ruby 3.4").

### Changes

- Add `'4.0'` to the CI `matrix.ruby` list (quoted so YAML does not parse it as the float `4.0` and stringify it to `"4"`).
- CHANGELOG entry.

No source or gemspec changes are needed: `required_ruby_version` is already `>= 3.1`, and Ruby 4.0 satisfies it.

### Test plan

Verified locally on Ruby 4.0.2 across the full gemfile matrix — 233 examples, 0 failures in every combination:

| gemfile | rails | doorkeeper | result |
| --- | --- | --- | --- |
| rails_7.0 | 7.0.10 | 5.9.0 | 233 / 0 |
| rails_7.1 | 7.1.6 | 5.9.0 | 233 / 0 |
| rails_7.2 | 7.2.3 | 5.9.0 | 233 / 0 |
| rails_8.0 | 8.0.5 | 5.9.0 | 233 / 0 |
| doorkeeper_master | git HEAD | — | 233 / 0 |
