### PR TITLE
Return account_selection_required when a prompt=select_account handler does not respond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [#273] **Security/Hardening:** Merge framework-controlled registered claims last — `iss`/`sub`/`aud`/`exp`/`iat`/`nonce`/`auth_time` for the ID Token and `sub` for UserInfo — so a custom claim block can no longer override security-critical values. No legitimate configuration relied on this; custom claims that intentionally shadowed a registered claim name will now be ignored for that key (OIDC Core §2 / §3.1.3.7 / §5.3.2).
 - [#276] Get RuboCop to zero offenses: fix `Lint/MissingSuper` in `IdTokenResponse`, replace `puts` with `warn` for deprecation notices, and modernise spec style
 - [#277] Fix README inaccuracies (`signing_algorithm` description and link, `discovery_url_options` endpoint list, `oauth-authorization-server` route) and use constant-time comparison in the DCR authorization example to prevent timing attacks on the Initial Access Token
+- [#279] Return `account_selection_required` when a `prompt=select_account` handler does not generate a response, per [OIDC Core 1.0 §3.1.2.6](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) — previously the authorization silently continued without account selection. Adds the missing `Errors::AccountSelectionRequired` class, mirroring the existing `login_required` backstop for `reauthenticate_resource_owner`
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/errors.rb
+++ b/lib/doorkeeper/openid_connect/errors.rb
@@ -27,6 +27,7 @@ module Doorkeeper
       class LoginRequired < OpenidConnectError; end
       class ConsentRequired < OpenidConnectError; end
       class InteractionRequired < OpenidConnectError; end
+      class AccountSelectionRequired < OpenidConnectError; end
     end
   end
 end

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -196,6 +196,12 @@ module Doorkeeper
             return_to,
             &Doorkeeper::OpenidConnect.configuration.select_account_for_resource_owner
           )
+
+          # OIDC Core 1.0 §3.1.2.6: if the account selection cannot be performed
+          # the request MUST fail with `account_selection_required` rather than
+          # silently continuing the authorization (mirrors the `login_required`
+          # backstop in #reauthenticate_oidc_resource_owner).
+          raise Errors::AccountSelectionRequired unless performed?
         end
       end
     end

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -601,8 +601,11 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
   end
 
   describe "#select_account_for_resource_owner" do
+    let(:performed) { true }
+
     before do
       allow(subject).to receive(:clear_oidc_response)
+      allow(subject).to receive(:performed?) { performed }
       allow(subject.request).to receive(:path).and_return("/oauth/authorize")
       allow(subject.request).to receive(:query_parameters) {
         { client_id: "foo", prompt: "login consent select_account" }.with_indifferent_access
@@ -634,6 +637,16 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       return_params = Rack::Utils.parse_query(URI.parse(return_to).query)
 
       expect(return_params["prompt"]).to eq "login consent"
+    end
+
+    context "with a select account handler that does not generate a response" do
+      let(:performed) { false }
+
+      it "raises an account_selection_required error" do
+        expect do
+          select_account!
+        end.to raise_error(Doorkeeper::OpenidConnect::Errors::AccountSelectionRequired)
+      end
     end
   end
 

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -600,7 +600,7 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
     end
   end
 
-  describe "#select_account_for_resource_owner" do
+  describe "#select_account_for_oidc_resource_owner" do
     let(:performed) { true }
 
     before do


### PR DESCRIPTION
### Summary

Add the missing `account_selection_required` error path for `prompt=select_account`, per [OIDC Core 1.0 §3.1.2.6](https://openid.net/specs/openid-connect-core-1_0.html#AuthError).

### Problem

`handle_oidc_prompt_param!`'s `select_account` branch calls `select_account_for_oidc_resource_owner`, but — unlike `reauthenticate_oidc_resource_owner`, which has a `raise Errors::LoginRequired unless performed?` backstop — it had no equivalent guard.

If a host application's `select_account_for_resource_owner` block does not redirect or render (e.g. a conditional or misconfigured handler), the authorization request silently continues without account selection. OIDC Core 1.0 §3.1.2.6 mandates an `account_selection_required` error in exactly this situation.

The matching I18n message already exists in `config/locales/en.yml` (`account_selection_required`), but no code path raised it and the `Errors::AccountSelectionRequired` class was missing — i.e. the feature was half-wired.

### Changes

- Add `Errors::AccountSelectionRequired < OpenidConnectError`.
- Raise it from `select_account_for_oidc_resource_owner` unless a response was generated, mirroring the existing `login_required` backstop for `reauthenticate_resource_owner`.
- Add a regression spec following the existing `#reauthenticate_oidc_resource_owner` test pattern.
- Add a CHANGELOG entry.

It routes through the same `handle_oidc_error!` → `Doorkeeper::OAuth::ErrorResponse` path as `login_required` / `consent_required`, so the error is returned on the redirect URI with the existing localized description.

### Compatibility

Strictly additive. Well-behaved handlers that perform a response (redirect or render) are unaffected — only the previously-silent no-op case now returns the spec-mandated error. No breaking changes.

### Test plan

- `bundle exec rspec` from a clean DB: 233 examples, 0 failures (+1 = new regression spec).
- New spec: `#select_account_for_resource_owner` → "with a select account handler that does not generate a response → raises an account_selection_required error".
- RuboCop: 0 new offenses in changed `lib/` files (16 before = 16 after); spec additions reuse the existing file's established patterns.