### PR TITLE
Skip OIDC prompt/max_age handling when response is already committed

### DIFF
--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -15,6 +15,7 @@ module Doorkeeper
 
         def authenticate_resource_owner!
           super.tap do |owner|
+            next if performed?
             next unless oidc_authorization_request?
 
             handle_oidc_max_age_param!(owner)


### PR DESCRIPTION
  ## problem

  if a user hits an openid authorize request with `prompt=login` while not authenticated, the `reauthenticate_resource_owner` callback receives a non-model value and blows up. same issue applies to `prompt=none` and `max_age` -- anything  where `handle_oidc_prompt_param!` or `handle_oidc_max_age_param!` acts on the `owner` value.

  `authenticate_resource_owner!` uses `.tap` on the return value of `super`, but doesn't check whether a response was already committed. when the `resource_owner_authenticator` block redirects (the standard pattern for unauthenticated users), the `.tap` block still runs with whatever `redirect_to` returned — which is always truthy (`self.status` on rails 8, the response body string on rails 7). this passes the `if owner` guards in `handle_oidc_prompt_param!` and the configured callback tries to call model methods on a non-model value:

  `NoMethodError: undefined method 'sessions' for an instance of Integer`

  followed by a `DoubleRenderError` since the response was already committed by the authenticator's redirect.

  ## fix

  add a `performed?` guard at the top of the `.tap` block. if a redirect already happened, there's no authenticated owner to process OIDC params against.

  ## versions affected

  confirmed on doorkeeper-openid_connect 1.8.11 & 1.9.0, rails 8.0.4, doorkeeper 5.8.2. the underlying issue (no `performed?` check) affects all rails versions.