### PR TITLE
Normalize leaked resource owner when authenticator redirects + guard select_account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#275] Return `login_required` for `max_age` reauthentication when `prompt=none`, instead of triggering the interactive `reauthenticate_resource_owner` flow (OIDC Core §3.1.2.1)
 - [#284] Document `acr` / `amr` claims in README — show how to expose Authentication Context Class Reference and Authentication Methods References via the `claim` DSL, with callouts for the `response:` and `scope:` defaults that silently bite
 - [#288] Document `offline_access` scope recipe in README — show how to wire `use_refresh_token` with scope-based filtering for OIDC offline access
+- [#281] Fix `NoMethodError` / `DoubleRenderError` when `resource_owner_authenticator` redirects with a truthy non-model value (e.g. `current_user || redirect_to(login_url)`). Normalize the leaked value to `nil` when `performed?` and add missing `if owner` guard on `select_account`.
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -40,6 +40,14 @@ module Doorkeeper
           super.tap do |owner|
             next unless oidc_authorization_request?
 
+            # When the configured resource_owner_authenticator redirects an
+            # unauthenticated user, +super+ returns whatever +redirect_to+
+            # returned (a truthy Integer/String), not a resource owner. Treat
+            # that as "no owner" so the OIDC param handling below still runs
+            # (e.g. prompt=none must yield login_required per OIDC Core
+            # §3.1.2.1) without calling model methods on a non-model value.
+            owner = nil if performed?
+
             handle_oidc_max_age_param!(owner)
             handle_oidc_prompt_param!(owner)
           end
@@ -107,7 +115,7 @@ module Doorkeeper
                 render :new
               end
             when "select_account"
-              select_account_for_oidc_resource_owner(owner)
+              select_account_for_oidc_resource_owner(owner) if owner
             when "create"
               # NOTE: not supported, but not raise error.
             else

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -104,9 +104,7 @@ module Doorkeeper
           prompt_values.each do |prompt|
             case prompt
             when "none"
-              raise Errors::InvalidRequest if (prompt_values - ["none"]).any?
-              raise Errors::LoginRequired unless owner
-              raise Errors::ConsentRequired if oidc_consent_required?
+              handle_oidc_prompt_none!(prompt_values, owner)
             when "login"
               reauthenticate_oidc_resource_owner(owner) if owner
             when "consent"
@@ -122,6 +120,12 @@ module Doorkeeper
               raise Errors::InvalidRequest
             end
           end
+        end
+
+        def handle_oidc_prompt_none!(prompt_values, owner)
+          raise Errors::InvalidRequest if (prompt_values - ["none"]).any?
+          raise Errors::LoginRequired unless owner
+          raise Errors::ConsentRequired if oidc_consent_required?
         end
 
         def handle_oidc_max_age_param!(owner)

--- a/spec/controllers/doorkeeper/redirecting_resource_owner_authenticator_spec.rb
+++ b/spec/controllers/doorkeeper/redirecting_resource_owner_authenticator_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression coverage for the case where
+# `Doorkeeper.config.authenticate_resource_owner` redirects an unauthenticated
+# user instead of returning an explicit `nil`.
+#
+# The most common host-app pattern is:
+#
+#   resource_owner_authenticator do
+#     current_user || redirect_to(new_user_session_url)
+#   end
+#
+# When the user is not signed in, the block's value is whatever `redirect_to`
+# returns -- an Integer status on Rails >= 8, the body String on Rails 7 --
+# i.e. a *truthy non-model* value, not `nil`. doorkeeper-openid_connect's
+# `authenticate_resource_owner!` does `super.tap { |owner| ... }`, so `owner`
+# becomes that leaked value and the OIDC param handlers invoke model methods
+# on it (`NoMethodError`), followed by a `DoubleRenderError`.
+#
+# The dummy app's authenticator returns an explicit `nil` after redirecting,
+# which is why the rest of the suite never exercises this path.
+describe Doorkeeper::AuthorizationsController, type: :controller do
+  let(:application) { create :application, scopes: "openid profile" }
+
+  before do
+    # Faithfully model the `current_user || redirect_to(...)` pattern for the
+    # unauthenticated branch: `redirect_to` is the last expression, so its
+    # truthy return value leaks out as the "resource owner".
+    leaky_authenticator = proc { redirect_to("/login") }
+    allow(Doorkeeper.config)
+      .to receive(:authenticate_resource_owner)
+      .and_return(leaky_authenticator)
+  end
+
+  def authorize!(extra = {})
+    get :new, params: {
+      response_type: "code",
+      client_id: application.uid,
+      scope: "openid profile",
+      redirect_uri: application.redirect_uri,
+    }.merge(extra)
+  end
+
+  context "when the resource_owner_authenticator redirects an unauthenticated user" do
+    it "prompt=login: falls through to the authenticator's login redirect without raising" do
+      expect { authorize!(prompt: "login") }.not_to raise_error
+      expect(response).to redirect_to("/login")
+    end
+
+    it "max_age: falls through to the authenticator's login redirect without raising" do
+      expect { authorize!(max_age: "10") }.not_to raise_error
+      expect(response).to redirect_to("/login")
+    end
+
+    # prompt=select_account had no `if owner` guard (unlike prompt=login /
+    # prompt=consent), so the leaked owner reached the host
+    # select_account_for_resource_owner block and a block that touches the
+    # owner blew up. With the guard it falls through to the login redirect
+    # like the other unauthenticated prompts.
+    it "prompt=select_account: falls through to the login redirect without raising" do
+      Doorkeeper::OpenidConnect.configure do
+        select_account_for_resource_owner do |resource_owner, _return_to|
+          redirect_to "/accounts?uid=#{resource_owner.id}"
+        end
+      end
+
+      expect { authorize!(prompt: "select_account") }.not_to raise_error
+      expect(response).to redirect_to("/login")
+    end
+
+    # OpenID Connect Core 1.0 §3.1.2.1: with prompt=none and no authenticated
+    # End-User the server MUST return a login_required error and MUST NOT show
+    # any UI -- so it must NOT bounce to the host app's /login page.
+    it "prompt=none: returns the login_required error to the client redirect_uri" do
+      expect { authorize!(prompt: "none", state: "somestate") }.not_to raise_error
+
+      expect(response).not_to redirect_to("/login")
+      expect(response).to redirect_to(
+        build_redirect_uri(
+          "error" => "login_required",
+          "error_description" => "The authorization server requires end-user authentication",
+          "state" => "somestate",
+        ),
+      )
+    end
+  end
+
+  def build_redirect_uri(params)
+    Doorkeeper::OAuth::Authorization::URIBuilder.uri_with_query(application.redirect_uri, params)
+  end
+end


### PR DESCRIPTION
### Problem

When the host app uses the common authenticator pattern:

```ruby
resource_owner_authenticator do
  current_user || redirect_to(new_user_session_url)
end
```

`super` in `authenticate_resource_owner!` returns whatever `redirect_to` returned — a truthy non-model value (`self.status` Integer on Rails 8, body String on Rails 7). The `.tap` block then passes this value into `handle_oidc_prompt_param!` / `handle_oidc_max_age_param!`, which call model methods on it → `NoMethodError` + `DoubleRenderError`.

The gem's dummy app masks this by returning an explicit `nil` after redirecting, so the existing suite never exercised the real-world code path.

>[!NOTE]
>Originally reported in #280 by @24c02 — thank you for the detailed bug report and analysis 😊

### Why not `next if performed?`

The approach proposed in #280 (`next if performed?` at the top of the `.tap` block) fixes the crash but skips **all** OIDC handling when the authenticator has redirected. Since the authenticator *always* redirects for unauthenticated users, this also skips `prompt=none` — which OIDC Core §3.1.2.1 requires to return `login_required` without showing any UI. This regresses 6 existing specs.

### Fix

**1. Normalize the leaked owner to `nil` when `performed?`** (instead of bailing out)

The OIDC param handlers continue to run with a falsy `owner`, so:
- `prompt=none` → `LoginRequired` as required by §3.1.2.1 ✅
- `prompt=login` / `max_age` → `if owner` guards skip correctly ✅

**2. Add the missing `if owner` guard on `select_account`**

`select_account` was the only prompt branch without an `if owner` guard (unlike `login` and `consent`). With the normalization alone, `select_account_for_oidc_resource_owner(nil)` still runs unguarded and the host block hits `nil.id`. Adding `if owner` makes it consistent with the other branches.

### Tests

Adds regression specs for the leaky-authenticator pattern covering:
- `prompt=login` — no longer raises `NoMethodError` / `DoubleRenderError`
- `prompt=select_account` — no longer raises (previously unguarded)
- `max_age` — no longer raises
- `prompt=none` — correctly returns `login_required` to the client redirect URI (§3.1.2.1)

Full suite: **236 examples, 0 failures**.

Closes #280.