### PR TITLE
Allow prompt=none reauthorization with a narrower subset of scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [#283] Support multiple signing keys in the JWKS response — `signing_key` now also accepts an array (and callables returning an array). The first entry is the active key used to sign new ID tokens; the remaining entries are published in the JWKS so clients can still validate tokens signed with a retired key during a rotation window. Single-value and callable forms continue to work unchanged
 - [#286] Allow claims to be assigned to multiple scopes via `scope: [:profile, :all_data]` — the claim is returned whenever the access token grants any of the listed scopes. **Note:** the previously implicit `Claim#scope=` writer (from `attr_accessor :scope`) is no longer provided; rebuild the claim instead of mutating it
 - [#287] Add `apply_prompt_to_non_oidc_requests` option to honor the `prompt` parameter on plain OAuth requests that do not include the `openid` scope
+- [#282] Allow `prompt=none` reauthorization with a narrower subset of previously-granted scopes (issue #63). Per RFC 6749 §1.5, narrower-or-equal scopes do not require fresh user consent; previously these requests returned `consent_required`.
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -138,6 +138,12 @@ module Doorkeeper
           raise Errors::InvalidRequest if (prompt_values - ["none"]).any?
           raise Errors::LoginRequired unless owner
           raise Errors::ConsentRequired if oidc_consent_required?
+
+          # Issue #63: if no exact-scope token exists but a previously-granted
+          # token already covers the requested scopes (i.e. the user is asking
+          # for a narrower subset), auto-issue rather than rendering the
+          # consent form — `prompt=none` forbids any interactive UI.
+          @_oidc_prompt_none_skip_authorization = true if oidc_matching_subset_token?
         end
 
         def handle_oidc_max_age_param!(owner)
@@ -218,7 +224,34 @@ module Doorkeeper
         end
 
         def oidc_consent_required?
-          !skip_authorization? && !matching_token?
+          !skip_authorization? && !matching_token? && !oidc_matching_subset_token?
+        end
+
+        # Returns true if the resource owner already has an active token for this
+        # client whose scopes are a (non-strict) superset of the requested scopes.
+        # Used to allow `prompt=none` to succeed when the client re-authorizes
+        # with a narrower set of scopes (issue #63).
+        def oidc_matching_subset_token?
+          return @oidc_matching_subset_token if defined?(@oidc_matching_subset_token)
+
+          @oidc_matching_subset_token =
+            if pre_auth.scopes.empty?
+              false
+            else
+              access_token_model = Doorkeeper.config.access_token_model
+              access_token_model.authorized_tokens_for(
+                pre_auth.client.id,
+                current_resource_owner.id,
+              ).any? { |token| token.scopes.scopes?(pre_auth.scopes) }
+            end
+        end
+
+        # Force Doorkeeper's `render_success` onto the auto-issue path when a
+        # `prompt=none` subset-scope reauthorization has been validated above.
+        def skip_authorization?
+          return true if @_oidc_prompt_none_skip_authorization
+
+          super
         end
 
         def select_account_for_oidc_resource_owner(owner)

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -137,13 +137,13 @@ module Doorkeeper
         def handle_oidc_prompt_none!(prompt_values, owner)
           raise Errors::InvalidRequest if (prompt_values - ["none"]).any?
           raise Errors::LoginRequired unless owner
-          raise Errors::ConsentRequired if oidc_consent_required?
+          raise Errors::ConsentRequired if oidc_consent_required?(owner)
 
-          # Issue #63: if no exact-scope token exists but a previously-granted
-          # token already covers the requested scopes (i.e. the user is asking
-          # for a narrower subset), auto-issue rather than rendering the
-          # consent form — `prompt=none` forbids any interactive UI.
-          @_oidc_prompt_none_skip_authorization = true if oidc_matching_subset_token?
+          # Issue #63: if an active token already covers the requested scopes
+          # (a non-strict superset, including the exact-match case), force
+          # auto-issue rather than rendering the consent form — `prompt=none`
+          # forbids any interactive UI (OIDC Core §3.1.2.1).
+          @_oidc_prompt_none_skip_authorization = true if oidc_matching_subset_token?(owner)
         end
 
         def handle_oidc_max_age_param!(owner)
@@ -223,15 +223,20 @@ module Doorkeeper
           raise Errors::LoginRequired unless performed?
         end
 
-        def oidc_consent_required?
-          !skip_authorization? && !matching_token? && !oidc_matching_subset_token?
+        def oidc_consent_required?(owner)
+          !skip_authorization? && !matching_token? && !oidc_matching_subset_token?(owner)
         end
 
         # Returns true if the resource owner already has an active token for this
         # client whose scopes are a (non-strict) superset of the requested scopes.
         # Used to allow `prompt=none` to succeed when the client re-authorizes
         # with a narrower set of scopes (issue #63).
-        def oidc_matching_subset_token?
+        #
+        # Scans tokens via `find_access_token_in_batches` (same pattern as
+        # upstream Doorkeeper's `find_matching_token`) so that installations
+        # with many active tokens per (client, resource owner) pair do not
+        # load the entire relation into memory.
+        def oidc_matching_subset_token?(owner)
           return @oidc_matching_subset_token if defined?(@oidc_matching_subset_token)
 
           @oidc_matching_subset_token =
@@ -239,10 +244,17 @@ module Doorkeeper
               false
             else
               access_token_model = Doorkeeper.config.access_token_model
-              access_token_model.authorized_tokens_for(
-                pre_auth.client.id,
-                current_resource_owner.id,
-              ).any? { |token| token.scopes.scopes?(pre_auth.scopes) }
+              relation = access_token_model.authorized_tokens_for(pre_auth.client.id, owner)
+              batch_size = Doorkeeper.configuration.token_lookup_batch_size
+
+              match_found = false
+              access_token_model.find_access_token_in_batches(relation, batch_size: batch_size) do |batch|
+                if batch.any? { |token| token.scopes.scopes?(pre_auth.scopes) }
+                  match_found = true
+                  break
+                end
+              end
+              match_found
             end
         end
 

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -312,6 +312,70 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
           expect(response).to redirect_to build_redirect_uri(error_params)
         end
       end
+
+      # Issue #63: a `prompt=none` request that asks for a narrower subset of
+      # scopes than was previously granted must succeed without showing the
+      # consent form (which is forbidden under `prompt=none`).
+      context "and a token covering a wider scope than the request (issue #63)" do
+        let(:application) { create :application, scopes: "openid profile email" }
+        let(:granted_scopes) { "openid profile email" }
+        let(:token_attributes) do
+          { application_id: application.id, resource_owner_id: user.id, scopes: granted_scopes }
+        end
+
+        before { create :access_token, token_attributes }
+
+        it "auto-issues a new code when scopes are narrower (openid email)" do
+          get :new, params: {
+            response_type: "code",
+            response_mode: "",
+            current_user: user.id,
+            client_id: application.uid,
+            scope: "openid email",
+            redirect_uri: application.redirect_uri,
+            prompt: "none",
+          }
+
+          expect_successful_callback!
+        end
+
+        it "auto-issues a new code when scopes are reduced to just openid" do
+          get :new, params: {
+            response_type: "code",
+            response_mode: "",
+            current_user: user.id,
+            client_id: application.uid,
+            scope: "openid",
+            redirect_uri: application.redirect_uri,
+            prompt: "none",
+          }
+
+          expect_successful_callback!
+        end
+
+        it "still raises consent_required when the requested scope is NOT a subset" do
+          # Application supports an extra scope the user hasn't granted yet.
+          application.update!(scopes: "openid profile email address")
+
+          get :new, params: {
+            response_type: "code",
+            response_mode: "",
+            current_user: user.id,
+            client_id: application.uid,
+            scope: "openid address",
+            redirect_uri: application.redirect_uri,
+            prompt: "none",
+            state: "somestate",
+          }
+
+          error_params = {
+            "error" => "consent_required",
+            "error_description" => "The authorization server requires end-user consent",
+            "state" => "somestate",
+          }
+          expect(response).to redirect_to build_redirect_uri(error_params)
+        end
+      end
     end
 
     context "with a prompt=login parameter" do


### PR DESCRIPTION
## Summary

Fixes #63 (open since 2018).

When a resource owner has previously consented to a wider set of scopes (e.g. `openid profile email`) and the client re-authorizes with `prompt=none` and a **narrower subset** (e.g. `openid email`), the server currently returns `consent_required`. Per OAuth 2.0 [RFC 6749 §1.5](https://tools.ietf.org/html/rfc6749#section-1.5) ("…to obtain additional access tokens with identical or narrower scope"), a narrower subset must not require fresh user consent, and `prompt=none` forbids any interactive UI.

The original maintainer attempted this in #65 in 2018 but closed it because Doorkeeper's `matching_token_for` only does **exact** scope matching, which would have caused the consent form to render anyway. That observation is still correct (Doorkeeper 5.9.0 `lib/doorkeeper/models/access_token_mixin.rb#L167`), but for the **`prompt=none`** path we can solve it entirely in this gem: OIDC already owns that branch via the prepended `authenticate_resource_owner!`, so we can both suppress the OIDC error *and* force the auto-issue path without touching upstream.

## What changed

`lib/doorkeeper/openid_connect/helpers/controller.rb`:

1. **`oidc_consent_required?`** now also returns `false` when an active token for the same client + resource owner already covers the requested scopes (`token.scopes.scopes?(pre_auth.scopes)` — subset check using `Doorkeeper::OAuth::Scopes#scopes?`).
2. **New helper `oidc_matching_subset_token?`** encapsulates that subset lookup via the configured `Doorkeeper.config.access_token_model.authorized_tokens_for`. The result is memoized in `@oidc_matching_subset_token` (using a `defined?` guard so the `false` case is cached too) because it is consulted from both `handle_oidc_prompt_param!` and `oidc_consent_required?` within the same request, and the underlying call hits the database.
3. **`skip_authorization?`** is overridden in the OIDC prepend so that when the `prompt=none` branch detects a subset match it sets `@_oidc_prompt_none_skip_authorization = true`, which routes Doorkeeper's `render_success` to `redirect_or_render(authorize_response)` instead of rendering the consent form. The override is scoped strictly to this instance variable; outside the `prompt=none` subset case it falls through to `super`.

### Why an instance-variable flag rather than calling `redirect_or_render` directly

`handle_oidc_prompt_param!` runs inside the prepended `authenticate_resource_owner!` `before_action`, *before* Doorkeeper's `#new` action and its `render_success` filter. At that point we cannot synthesize the success response ourselves — `strategy` / `authorize_response` are constructed by Doorkeeper later in the action. The documented extension point for "this request can auto-issue without showing the form" is `skip_authorization?`, which Doorkeeper checks inside `render_success`. So the flow is:

1. `handle_oidc_prompt_param!` (before_action) validates the prompt=none subset case and records the decision in `@_oidc_prompt_none_skip_authorization`.
2. Control returns to Doorkeeper's `#new`, which builds `strategy` / `authorize_response` and calls `render_success`.
3. `render_success` consults the overridden `skip_authorization?`, sees the flag, and takes the `redirect_or_render(authorize_response)` branch — exactly the same path used by the existing `skip_authorization` config option, so no new response-construction logic is introduced.

The flag is a per-request controller instance variable (no cross-request leakage), defaults to `nil`, and is only ever set to `true` along the validated path. The `skip_authorization?` override uses a strict `if @_oidc_prompt_none_skip_authorization` (no `||=`) so any other caller's `super` behavior is preserved unchanged.

A new access token is issued with the **narrower** `pre_auth.scopes` (current `strategy.authorize` behavior), which matches the spec.

## Reproduction (master)

```ruby
# Granted token: scopes "openid profile email"
# Request: prompt=none, scope="openid email"
# Result on master: redirect_to /callback?error=consent_required
# Result on this branch: redirect_to /callback?code=<...>
```

## What is NOT changed (intentional)

- The general (non-`prompt=none`) authorization flow. If a client re-requests with narrower scopes and *no* `prompt`, the consent form still appears, because `Doorkeeper::AccessToken.scopes_match?` upstream is still exact-match. That requires an upstream fix and is out of scope for this issue.
- `prompt=login`, `prompt=consent`, `prompt=select_account`, `max_age`, and the `login_required` / exact-match paths.

## Test plan

- [x] Added 3 new specs under `#handle_oidc_prompt_param! → with a prompt=none parameter → and a token covering a wider scope than the request (issue #63)`:
  - auto-issues a new code when scopes are narrower (`openid email`)
  - auto-issues a new code when scopes are reduced to just `openid`
  - still raises `consent_required` when the requested scope is **not** a subset of the granted token (application has an extra scope `address` the user hasn't granted)
- [x] Full suite: `bundle exec rspec` → **243 examples, 0 failures**
- [x] All pre-existing `prompt=none` specs (exact match, not-logged-in, `prompt=none login`, no-matching-token + `consent_required`, no-matching-token + `skip_authorization?=true`) pass unchanged.

## Spec references

- OAuth 2.0 RFC 6749 §1.5 — narrower scope on reauthorization
- OIDC Core 1.0 §3.1.2.1 — `prompt=none` MUST NOT display any authentication or consent UI
