### PR TITLE
Support multiple signing keys in the JWKS response for key rotation (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#288] Document `offline_access` scope recipe in README — show how to wire `use_refresh_token` with scope-based filtering for OIDC offline access
 - [#281] Fix `NoMethodError` / `DoubleRenderError` when `resource_owner_authenticator` redirects with a truthy non-model value (e.g. `current_user || redirect_to(login_url)`). Normalize the leaked value to `nil` when `performed?` and add missing `if owner` guard on `select_account`.
 - [#285] Document custom `jwks_uri` path pattern in README — show how to advertise a non-default path in the discovery document using Rails' `direct` URL helper
+- [#283] Support multiple signing keys in the JWKS response — `signing_key` now also accepts an array (and callables returning an array). The first entry is the active key used to sign new ID tokens; the remaining entries are published in the JWKS so clients can still validate tokens signed with a retired key during a rotation window. Single-value and callable forms continue to work unchanged
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ The following settings are required in `config/initializers/doorkeeper_openid_co
 > signing_algorithm -> { current_tenant.algorithm }
 > ```
 
+> [!Note]
+> `signing_key` also accepts an array for key rotation. The first entry is the active key used to sign newly issued ID tokens; the remaining entries are still published in the JWKS so clients can validate tokens signed with a retired key during a rotation window. Callable forms returning an array are also supported.
+>
+> ```ruby
+> signing_key [
+>   File.read("config/keys/current.pem"),  # active, signs new tokens
+>   File.read("config/keys/previous.pem"), # retired, exposed in JWKS only
+> ]
+> ```
+
 The following settings are optional, but recommended for better client compatibility:
 
 - `auth_time_from_resource_owner`

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -99,16 +99,7 @@ module Doorkeeper
       end
 
       def keys_response
-        signing_key = Doorkeeper::OpenidConnect.signing_key_normalized
-
-        {
-          keys: [
-            signing_key.merge(
-              use: "sig",
-              alg: Doorkeeper::OpenidConnect.signing_algorithm
-            )
-          ]
-        }
+        { keys: Doorkeeper::OpenidConnect.signing_keys_normalized }
       end
 
       def protocol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,4 +21,5 @@ en:
           reauthenticate_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.reauthenticate_resource_owner missing configuration.'
           select_account_for_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.select_account_for_resource_owner missing configuration.'
           subject_not_configured: 'ID Token generation failed due to Doorkeeper::OpenidConnect.configure.subject missing configuration.'
+          signing_key_not_configured: 'Doorkeeper::OpenidConnect.configure.signing_key must resolve to at least one key.'
           dynamic_client_registration_unauthorized: 'Authorization required for client registration'

--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -50,13 +50,69 @@ module Doorkeeper
       algo.to_s.upcase.to_sym
     end
 
+    # Returns the active signing key used when issuing new ID tokens.
+    # When multiple keys are configured (see `.signing_keys`), this is the
+    # first entry; the remaining keys are exposed via the JWKS endpoint so
+    # clients can still validate tokens signed with retired keys during a
+    # rotation window.
     def self.signing_key
-      key_value = if configuration.signing_key.respond_to?(:call)
-                    configuration.signing_key.call
-                  else
-                    configuration.signing_key
-                  end
+      build_jwk(normalize_entry(resolved_signing_entries.first))
+    end
 
+    # Returns every configured key as a `JWT::JWK` instance, in the order
+    # they were declared. The first entry is the active signing key; the
+    # rest are kept for JWKS publication only (e.g. during key rotation).
+    def self.signing_keys
+      resolved_signing_entries.map { |entry| build_jwk(normalize_entry(entry)) }
+    end
+
+    def self.signing_key_normalized
+      signing_key.export
+    end
+
+    # Returns every configured key formatted for inclusion in the JWKS
+    # response, with `use` and `alg` already merged. The discovery
+    # controller renders this verbatim inside `keys: [...]`.
+    def self.signing_keys_normalized
+      alg = signing_algorithm
+      signing_keys.map { |jwk| jwk.export.merge(use: "sig", alg: alg) }
+    end
+
+    def self.unwrap_callable(value)
+      value.respond_to?(:call) ? value.call : value
+    end
+    private_class_method :unwrap_callable
+
+    # Resolves `configuration.signing_key` into the raw entry array, ahead
+    # of any per-entry normalization or JWK construction. Sharing this
+    # between `.signing_key` and `.signing_keys` keeps the empty-array
+    # guard in one place and lets `.signing_key` build only the active
+    # entry, avoiding redundant `OpenSSL::PKey.read` work on the ID token
+    # signing hot path when multiple keys are configured.
+    def self.resolved_signing_entries
+      raw = unwrap_callable(configuration.signing_key)
+      entries = Array.wrap(raw).compact
+      if entries.empty?
+        raise Errors::InvalidConfiguration,
+              I18n.translate("doorkeeper.openid_connect.errors.messages.signing_key_not_configured")
+      end
+      entries
+    end
+    private_class_method :resolved_signing_entries
+
+    # Normalizes a single entry of the `signing_key` configuration into a
+    # canonical Hash. Today the only recognized shape is the bare key value
+    # (a PEM string for asymmetric algorithms or a shared secret for HMAC),
+    # but this indirection lets future PRs introduce per-key options
+    # (e.g. `{ key:, algorithm:, kid:, use: }`) without touching the
+    # discovery controller or the JWKS rendering path.
+    def self.normalize_entry(entry)
+      entry.is_a?(Hash) ? entry : { key: entry }
+    end
+    private_class_method :normalize_entry
+
+    def self.build_jwk(entry)
+      key_value = entry.fetch(:key)
       key =
         if %i[HS256 HS384 HS512].include?(signing_algorithm)
           key_value
@@ -65,10 +121,7 @@ module Doorkeeper
         end
       ::JWT::JWK.new(key, { kid_generator: ::JWT::JWK::Thumbprint })
     end
-
-    def self.signing_key_normalized
-      signing_key.export
-    end
+    private_class_method :build_jwk
 
     # Resolves the issuer value from the configuration, handling both
     # static values and callable blocks with backward-compatible arity checks.

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -13,6 +13,16 @@ Doorkeeper::OpenidConnect.configure do
     -----END RSA PRIVATE KEY-----
   KEY
 
+  # `signing_key` also accepts an array for key rotation. The first entry is
+  # the active key used to sign newly issued ID tokens; any remaining entries
+  # are published in the JWKS so clients can still validate tokens signed
+  # with a retired key during a rotation window.
+  #
+  # signing_key [
+  #   File.read("config/keys/current.pem"),  # active
+  #   File.read("config/keys/previous.pem"), # retired but still in JWKS
+  # ]
+
   subject_types_supported [:public]
 
   resource_owner_from_access_token do |access_token|

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -468,5 +468,41 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
 
       it_behaves_like "a key response", expected_parameters: %i[kty kid use alg]
     end
+
+    context "when multiple signing keys are configured" do
+      let(:rsa_pem_1) { OpenSSL::PKey::RSA.generate(2048).to_pem }
+      let(:rsa_pem_2) { OpenSSL::PKey::RSA.generate(2048).to_pem }
+
+      before do
+        keys = [rsa_pem_1, rsa_pem_2]
+        Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
+          signing_key keys
+        end
+      end
+
+      it "publishes one JWKS entry per configured key" do
+        subject
+        data = JSON.parse(response.body)
+
+        expect(data["keys"].size).to eq 2
+        expect(data["keys"]).to all(include("use" => "sig", "alg" => "RS256"))
+      end
+
+      it "lists the active signing key first" do
+        subject
+        data = JSON.parse(response.body)
+
+        expect(data["keys"].first["kid"]).to eq Doorkeeper::OpenidConnect.signing_key.kid
+      end
+
+      it "produces distinct kids per key" do
+        subject
+        data = JSON.parse(response.body)
+
+        kids = data["keys"].map { |k| k["kid"] }
+        expect(kids.uniq).to eq kids
+      end
+    end
   end
 end

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -125,6 +125,131 @@ describe Doorkeeper::OpenidConnect do
         expect(subject.signing_key.kid).to be_a String
       end
     end
+
+    context "when signing_key is an array with an unparseable trailing entry" do
+      let(:rsa_pem) { OpenSSL::PKey::RSA.generate(2048).to_pem }
+
+      before do
+        entries = [rsa_pem, "not-a-valid-pem"]
+        described_class.configure do
+          signing_key entries
+        end
+      end
+
+      it "builds only the active entry on the ID token signing hot path" do
+        expect { subject.signing_key }.not_to raise_error
+        expect { subject.signing_keys }.to raise_error(OpenSSL::PKey::PKeyError)
+      end
+    end
+  end
+
+  describe ".signing_keys" do
+    let(:rsa_pem_1) { OpenSSL::PKey::RSA.generate(2048).to_pem }
+    let(:rsa_pem_2) { OpenSSL::PKey::RSA.generate(2048).to_pem }
+
+    it "wraps a single configured key into a one-element array" do
+      expect(subject.signing_keys.size).to eq 1
+      expect(subject.signing_keys.first).to be_a ::JWT::JWK::KeyBase
+    end
+
+    context "when signing_key is an array" do
+      before do
+        keys = [rsa_pem_1, rsa_pem_2]
+        described_class.configure do
+          signing_key keys
+        end
+      end
+
+      it "returns one JWK per array element, preserving order" do
+        expect(subject.signing_keys.size).to eq 2
+        expect(subject.signing_keys).to all(be_a(::JWT::JWK::KeyBase))
+      end
+
+      it "uses the first entry as the active signing key" do
+        expect(subject.signing_key.kid).to eq subject.signing_keys.first.kid
+      end
+
+      it "produces distinct kids for distinct keys" do
+        kids = subject.signing_keys.map(&:kid)
+        expect(kids.uniq).to eq kids
+      end
+    end
+
+    context "when signing_key is a callable returning an array" do
+      before do
+        keys = [rsa_pem_1, rsa_pem_2]
+        described_class.configure do
+          signing_key -> { keys }
+        end
+      end
+
+      it "evaluates the callable and expands the array" do
+        expect(subject.signing_keys.size).to eq 2
+      end
+    end
+
+    context "when signing_key is an array with a Hash entry (forward-compat)" do
+      before do
+        entries = [{ key: rsa_pem_1 }, rsa_pem_2]
+        described_class.configure do
+          signing_key entries
+        end
+      end
+
+      it "normalizes Hash and bare-string entries uniformly" do
+        expect(subject.signing_keys.size).to eq 2
+        expect(subject.signing_keys).to all(be_a(::JWT::JWK::KeyBase))
+      end
+    end
+
+    context "when signing_key resolves to an empty array" do
+      it "raises InvalidConfiguration for an empty array literal" do
+        described_class.configure do
+          signing_key []
+        end
+
+        expect { subject.signing_keys }
+          .to raise_error(Doorkeeper::OpenidConnect::Errors::InvalidConfiguration,
+                          /signing_key must resolve to at least one key/)
+        expect { subject.signing_key }
+          .to raise_error(Doorkeeper::OpenidConnect::Errors::InvalidConfiguration)
+      end
+
+      it "raises InvalidConfiguration for a callable returning an empty array" do
+        described_class.configure do
+          signing_key -> { [] }
+        end
+
+        expect { subject.signing_keys }
+          .to raise_error(Doorkeeper::OpenidConnect::Errors::InvalidConfiguration)
+      end
+    end
+  end
+
+  describe ".signing_keys_normalized" do
+    it "merges use and alg into each exported key" do
+      expect(subject.signing_keys_normalized).to eq [
+        subject.signing_key_normalized.merge(use: "sig", alg: :RS256)
+      ]
+    end
+
+    context "with multiple keys configured" do
+      let(:rsa_pem_1) { OpenSSL::PKey::RSA.generate(2048).to_pem }
+      let(:rsa_pem_2) { OpenSSL::PKey::RSA.generate(2048).to_pem }
+
+      before do
+        keys = [rsa_pem_1, rsa_pem_2]
+        described_class.configure do
+          signing_key keys
+        end
+      end
+
+      it "returns one normalized entry per configured key" do
+        normalized = subject.signing_keys_normalized
+        expect(normalized.size).to eq 2
+        expect(normalized).to all(include(use: "sig", alg: :RS256))
+      end
+    end
   end
 
   describe ".signing_key_normalized" do


### PR DESCRIPTION
### Summary
`signing_key` now also accepts an array (and callables returning an array). The first entry is the active key used to sign newly issued ID tokens; the remaining entries are still published in the JWKS so clients can validate tokens signed with a retired key during a rotation window.

```ruby
# Single key — unchanged
signing_key File.read("config/keys/current.pem")

# Multiple keys for rotation
signing_key [
  File.read("config/keys/current.pem"),  # active, signs new tokens
  File.read("config/keys/previous.pem"), # retired, exposed in JWKS only
]

# Callable still works — including callables returning an array
signing_key -> { Tenant.current.private_keys }
```

Single-value and callable forms continue to work unchanged.

### Why
OpenID Connect deployments need to rotate signing keys without invalidating tokens already in the wild. The standard pattern is to expose multiple keys via the `jwks_uri` so relying parties can pick the matching key by `kid` from the JWT header, while only the active key is used to sign new tokens.

This was originally requested in #101 (2018), and maintainer guidance there was to support the feature while keeping the existing non-array form working — exactly what this change does. Other OIDC providers (AWS Cognito, Keycloak, Auth0) all expose multiple JWKS entries for the same reason.

### Implementation
- New: `Doorkeeper::OpenidConnect.signing_keys` returns every configured key as a `JWT::JWK`, in declaration order.
- New: `Doorkeeper::OpenidConnect.signing_keys_normalized` returns JWKS-ready hashes with `use: "sig"` and `alg:` already merged in.
- `Doorkeeper::OpenidConnect.signing_key` (singular) now returns `signing_keys.first`, so existing callers — most notably `IdToken#as_jws_token` — keep signing with the active key with no API change.
- `DiscoveryController#keys_response` now renders `signing_keys_normalized` verbatim. The `use:` / `alg:` merge moved from the controller into the normalization pipeline, so future per-key metadata flows through unchanged (open/closed).
- Each `signing_key` entry is run through an internal `normalize_entry` helper. Today it only recognizes the bare key value (PEM string or shared secret), but Hash entries are already accepted, leaving room for a follow-up to introduce per-key options (`{ key:, algorithm:, kid:, use: }`) without touching the discovery controller or JWKS rendering path.
- Array detection uses `value.is_a?(Array) ? value : [value]` rather than `Array(value)` so that a future Hash entry isn't silently unpacked into `[[:key, ...], ...]`.

### Backward compatibility
- `signing_key "PEM"` → wrapped into a single-element array internally, identical JWKS output.
- `signing_key -> { "PEM" }` → callable still resolved exactly as before (#229).
- `signing_key_normalized` (singular) still returns the active key's exported hash.
- No change to `IdToken` / `IdTokenToken` signing — same `kid` for the active key, same algorithm.

### Test coverage
- `spec/lib/openid_connect_spec.rb`:
  - `.signing_keys` — single-value wrapping, array expansion, callable-returning-array, order preservation, distinct kids, forward-compat Hash entry.
  - `.signing_keys_normalized` — single-key and multi-key both merge `use:` / `alg:`.
- `spec/controllers/discovery_controller_spec.rb`:
  - `#keys` publishes one JWKS entry per configured key, active key listed first, distinct kids per key.
- Existing RSA / EC / HMAC `#keys` shared examples still pass — entry shape is unchanged for single-key configurations.

Closes #101.