### PR TITLE
Document `acr` / `amr` claims in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#277] Fix README inaccuracies (`signing_algorithm` description and link, `discovery_url_options` endpoint list, `oauth-authorization-server` route) and use constant-time comparison in the DCR authorization example to prevent timing attacks on the Initial Access Token
 - [#279] Return `account_selection_required` when a `prompt=select_account` handler does not generate a response, per [OIDC Core 1.0 §3.1.2.6](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) — previously the authorization silently continued without account selection. Adds the missing `Errors::AccountSelectionRequired` class, mirroring the existing `login_required` backstop for `reauthenticate_resource_owner`
 - [#275] Return `login_required` for `max_age` reauthentication when `prompt=none`, instead of triggering the interactive `reauthenticate_resource_owner` flow (OIDC Core §3.1.2.1)
+- [#284] Document `acr` / `amr` claims in README — show how to expose Authentication Context Class Reference and Authentication Methods References via the `claim` DSL, with callouts for the `response:` and `scope:` defaults that silently bite
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,35 @@ By default all custom claims are only returned from the `UserInfo` endpoint and 
 
 You can also pass a `scope:` keyword argument on each claim to specify which OAuth scope should be required to access the claim. If you define any of the defined [Standard Claims](http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) they will by default use their [corresponding scopes](http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims) (`profile`, `email`, `address` and `phone`), and any other claims will by default use the `profile` scope. Again, to use any of these scopes you need to enable them as described above.
 
+#### Authentication Context (`acr`) and Methods (`amr`)
+
+The `claim` DSL also handles standard top-level ID Token claims such as [`acr`](http://openid.net/specs/openid-connect-core-1_0.html#IDToken) (Authentication Context Class Reference) and [`amr`](https://www.rfc-editor.org/rfc/rfc8176) (Authentication Methods References) — commonly used to expose MFA status to clients:
+
+```ruby
+claims do
+  claim :acr, response: [:id_token, :user_info], scope: :openid do |resource_owner|
+    # Single string — e.g. a URI like "urn:mace:incommon:iap:silver",
+    # or a numeric Level of Assurance "1".."4" per ISO/IEC 29115.
+    resource_owner.mfa_enabled? ? "2" : "1"
+  end
+
+  claim :amr, response: [:id_token, :user_info], scope: :openid do |resource_owner|
+    # Array of strings, per RFC 8176.
+    methods = ["pwd"]
+    methods << "mfa" if resource_owner.mfa_enabled?
+    methods << "otp" if resource_owner.last_login_used_totp?
+    methods
+  end
+end
+```
+
+Two defaults are worth calling out because they bite silently:
+
+- **`response: [:id_token, :user_info]`** — custom claims default to UserInfo only, but relying parties usually expect `acr` / `amr` on the ID Token.
+- **`scope: :openid`** — without it, non-standard claims fall back to the `profile` scope and disappear for clients that only requested `openid`.
+
+Claim names you declare here are automatically advertised under `claims_supported` in the discovery document. The list of advertised `acr` values (`acr_values_supported`) is not currently generated.
+
 ### Routes
 
 The installation generator will update your `config/routes.rb` to define all required routes:


### PR DESCRIPTION
Add a section showing how to expose ACR (Authentication Context Class Reference) and AMR (Authentication Methods References) via the existing `claim` DSL.

Two defaults silently bite when adding standard top-level ID Token claims that aren't in the `STANDARD_CLAIMS` list:

- `response:` defaults to `[:user_info]` only — relying parties usually expect `acr` / `amr` on the ID Token
- `scope:` falls back to `:profile` — clients requesting only `openid` won't see the claim

The example includes both callouts and a note on `claims_supported` vs `acr_values_supported` in the discovery document.

Refs #163.