### PR TITLE
Document `jwks_uri` customization via `direct` URL helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [#284] Document `acr` / `amr` claims in README — show how to expose Authentication Context Class Reference and Authentication Methods References via the `claim` DSL, with callouts for the `response:` and `scope:` defaults that silently bite
 - [#288] Document `offline_access` scope recipe in README — show how to wire `use_refresh_token` with scope-based filtering for OIDC offline access
 - [#281] Fix `NoMethodError` / `DoubleRenderError` when `resource_owner_authenticator` redirects with a truthy non-model value (e.g. `current_user || redirect_to(login_url)`). Normalize the leaked value to `nil` when `performed?` and add missing `if owner` guard on `select_account`.
+- [#285] Document custom `jwks_uri` path pattern in README — show how to advertise a non-default path in the discovery document using Rails' `direct` URL helper
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -353,6 +353,30 @@ GET   /.well-known/webfinger
 
 With the exception of the hard-coded `/.well-known` paths (see [RFC 5785](https://tools.ietf.org/html/rfc5785)) you can customize routes in the same way as with Doorkeeper, please refer to [this page on their wiki](https://github.com/doorkeeper-gem/doorkeeper/wiki/Customizing-routes#version--05-1).
 
+#### Customizing the `jwks_uri` path in the discovery document
+
+[`discovery_url_options`](#configuration) lets you tweak the host, protocol, or port of the published `jwks_uri`, but not the path itself. To advertise a custom path — while keeping `/oauth/discovery/keys` working for existing clients during a rollover — mount the discovery controller at the new path and re-point the `oauth_discovery_keys_url` helper at it via [`direct`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/CustomUrlHelpers.html#method-i-direct):
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  use_doorkeeper_openid_connect
+
+  # 1. Mount the custom path under a non-conflicting helper name
+  get "/-/jwks",
+      to: "doorkeeper/openid_connect/discovery#keys",
+      as: :custom_jwks
+
+  # 2. Re-point oauth_discovery_keys_url at the new path
+  direct(:oauth_discovery_keys) { |opts| custom_jwks_url(opts) }
+end
+```
+
+After this, `.well-known/openid-configuration` returns `"jwks_uri": "https://example.com/-/jwks"`, and the original `/oauth/discovery/keys` route still responds (handy during a rollover).
+
+> [!Note]
+> A naive `match "/-/jwks", ..., as: :oauth_discovery_keys` won't work — Rails has refused to reuse a route name [since 4.0](https://github.com/rails/rails/commit/a2b7c0e69d) and raises `ArgumentError: Invalid route name, already in use: 'oauth_discovery_keys'`. The `direct` helper sidesteps this by overriding the URL helper itself rather than re-declaring the route name.
+
 ### Nonces
 
 To support clients who send nonces you have to tweak Doorkeeper's authorization view so the parameter is passed on.


### PR DESCRIPTION
Add a section showing how to point `jwks_uri` in the discovery document at a custom path using Rails' `direct` URL helper.

The previously suggested approach (redefining a route with `as: :oauth_discovery_keys`) has raised `ArgumentError: Invalid route name, already in use` since [Rails 4.0](https://github.com/rails/rails/commit/a2b7c0e69d). The `direct` helper sidesteps this by overriding only the URL helper without conflicting route names:

```ruby
get "/-/jwks",
    to: "doorkeeper/openid_connect/discovery#keys",
    as: :custom_jwks

direct(:oauth_discovery_keys) { |opts| custom_jwks_url(opts) }
```

Verified against `spec/dummy` on Rails 8.0.5.

Refs #159.