### PR TITLE
Allow claims to be assigned to multiple scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - [#281] Fix `NoMethodError` / `DoubleRenderError` when `resource_owner_authenticator` redirects with a truthy non-model value (e.g. `current_user || redirect_to(login_url)`). Normalize the leaked value to `nil` when `performed?` and add missing `if owner` guard on `select_account`.
 - [#285] Document custom `jwks_uri` path pattern in README — show how to advertise a non-default path in the discovery document using Rails' `direct` URL helper
 - [#283] Support multiple signing keys in the JWKS response — `signing_key` now also accepts an array (and callables returning an array). The first entry is the active key used to sign new ID tokens; the remaining entries are published in the JWKS so clients can still validate tokens signed with a retired key during a rotation window. Single-value and callable forms continue to work unchanged
-- [#286] Allow claims to be assigned to multiple scopes via `scope: [:profile, :all_data]` — the claim is returned whenever the access token grants any of the listed scopes
+- [#286] Allow claims to be assigned to multiple scopes via `scope: [:profile, :all_data]` — the claim is returned whenever the access token grants any of the listed scopes. **Note:** the previously implicit `Claim#scope=` writer (from `attr_accessor :scope`) is no longer provided; rebuild the claim instead of mutating it
 
 ## v1.9.0 (2026-03-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [#281] Fix `NoMethodError` / `DoubleRenderError` when `resource_owner_authenticator` redirects with a truthy non-model value (e.g. `current_user || redirect_to(login_url)`). Normalize the leaked value to `nil` when `performed?` and add missing `if owner` guard on `select_account`.
 - [#285] Document custom `jwks_uri` path pattern in README — show how to advertise a non-default path in the discovery document using Rails' `direct` URL helper
 - [#283] Support multiple signing keys in the JWKS response — `signing_key` now also accepts an array (and callables returning an array). The first entry is the active key used to sign new ID tokens; the remaining entries are published in the JWKS so clients can still validate tokens signed with a retired key during a rotation window. Single-value and callable forms continue to work unchanged
+- [#286] Allow claims to be assigned to multiple scopes via `scope: [:profile, :all_data]` — the claim is returned whenever the access token grants any of the listed scopes
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,18 @@ By default all custom claims are only returned from the `UserInfo` endpoint and 
 
 You can also pass a `scope:` keyword argument on each claim to specify which OAuth scope should be required to access the claim. If you define any of the defined [Standard Claims](http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) they will by default use their [corresponding scopes](http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims) (`profile`, `email`, `address` and `phone`), and any other claims will by default use the `profile` scope. Again, to use any of these scopes you need to enable them as described above.
 
+You can also pass an array of scopes, in which case the claim is returned whenever the access token grants any of the listed scopes. This is useful when you want to expose the same claim under both a standard scope and an aggregate scope:
+
+``` ruby
+claim :given_name, scope: [:profile, :all_data] do |user|
+  user.first_name
+end
+
+claim :email, scope: [:email, :all_data] do |user|
+  user.email
+end
+```
+
 #### Authentication Context (`acr`) and Methods (`amr`)
 
 The `claim` DSL also handles standard top-level ID Token claims such as [`acr`](http://openid.net/specs/openid-connect-core-1_0.html#IDToken) (Authentication Context Class Reference) and [`amr`](https://www.rfc-editor.org/rfc/rfc8176) (Authentication Methods References) — commonly used to expose MFA status to clients:
@@ -338,6 +350,7 @@ Two defaults are worth calling out because they bite silently:
 - **`scope: :openid`** — without it, non-standard claims fall back to the `profile` scope and disappear for clients that only requested `openid`.
 
 Claim names you declare here are automatically advertised under `claims_supported` in the discovery document. The list of advertised `acr` values (`acr_values_supported`) is not currently generated.
+
 
 ### Routes
 

--- a/lib/doorkeeper/openid_connect/claims/claim.rb
+++ b/lib/doorkeeper/openid_connect/claims/claim.rb
@@ -4,7 +4,8 @@ module Doorkeeper
   module OpenidConnect
     module Claims
       class Claim
-        attr_accessor :name, :response, :scope
+        attr_accessor :name, :response
+        attr_reader :scopes
 
         # http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
         # http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
@@ -21,15 +22,29 @@ module Doorkeeper
         def initialize(options = {})
           @name = options[:name].to_sym
           @response = Array.wrap(options[:response])
-          @scope = options[:scope].to_sym if options[:scope]
+          @scopes = normalize_scopes(options[:scope])
 
-          # use default scope for Standard Claims
-          @scope ||= STANDARD_CLAIMS.find do |_scope, claims|
+          # use default scope for Standard Claims, fallback to profile
+          @scopes = [default_scope] if @scopes.empty?
+        end
+
+        def scope
+          @scopes.first
+        end
+
+        private
+
+        def normalize_scopes(value)
+          return [] if value.nil?
+
+          scopes = value.is_a?(Array) ? value : [value]
+          scopes.compact.map(&:to_sym)
+        end
+
+        def default_scope
+          STANDARD_CLAIMS.find do |_scope, claims|
             claims.include? @name
-          end.try(:first)
-
-          # use profile scope as default fallback
-          @scope ||= :profile
+          end.try(:first) || :profile
         end
       end
     end

--- a/lib/doorkeeper/openid_connect/claims/claim.rb
+++ b/lib/doorkeeper/openid_connect/claims/claim.rb
@@ -35,10 +35,7 @@ module Doorkeeper
         private
 
         def normalize_scopes(value)
-          return [] if value.nil?
-
-          scopes = value.is_a?(Array) ? value : [value]
-          scopes.compact.map(&:to_sym)
+          Array.wrap(value).compact.map(&:to_sym)
         end
 
         def default_scope

--- a/lib/doorkeeper/openid_connect/claims_builder.rb
+++ b/lib/doorkeeper/openid_connect/claims_builder.rb
@@ -9,7 +9,8 @@ module Doorkeeper
         resource_owner = Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(access_token)
 
         Doorkeeper::OpenidConnect.configuration.claims.to_h.map do |name, claim|
-          if access_token.scopes.exists?(claim.scope) && claim.response.include?(response)
+          if claim.scopes.any? { |scope| access_token.scopes.exists?(scope) } &&
+             claim.response.include?(response)
             [name, claim.generator.call(resource_owner, access_token.scopes, access_token)]
           end
         end.compact.to_h

--- a/spec/lib/claims/claim_spec.rb
+++ b/spec/lib/claims/claim_spec.rb
@@ -25,7 +25,7 @@ describe Doorkeeper::OpenidConnect::Claims::Claim do
       expect(claim.scope).to eq :profile
     end
 
-    it "stringifies array entries into symbols" do
+    it "symbolizes string entries in an array scope" do
       claim = described_class.new(name: "given_name", scope: ["profile", "all_data"])
       expect(claim.scopes).to eq %i[profile all_data]
     end

--- a/spec/lib/claims/claim_spec.rb
+++ b/spec/lib/claims/claim_spec.rb
@@ -12,6 +12,32 @@ describe Doorkeeper::OpenidConnect::Claims::Claim do
 
     it "uses the given scope" do
       expect(subject.scope).to eq :profile
+      expect(subject.scopes).to eq [:profile]
+    end
+
+    it "accepts an array of scopes" do
+      claim = described_class.new(name: "given_name", scope: [:profile, :all_data])
+      expect(claim.scopes).to eq %i[profile all_data]
+    end
+
+    it "exposes the first scope via #scope for backward compatibility" do
+      claim = described_class.new(name: "given_name", scope: [:profile, :all_data])
+      expect(claim.scope).to eq :profile
+    end
+
+    it "stringifies array entries into symbols" do
+      claim = described_class.new(name: "given_name", scope: ["profile", "all_data"])
+      expect(claim.scopes).to eq %i[profile all_data]
+    end
+
+    it "drops nil entries in an array scope" do
+      claim = described_class.new(name: "given_name", scope: [:profile, nil])
+      expect(claim.scopes).to eq [:profile]
+    end
+
+    it "falls back to the default scope when an empty array is given" do
+      expect(described_class.new(name: "email", scope: []).scopes).to eq [:email]
+      expect(described_class.new(name: "unknown", scope: []).scopes).to eq [:profile]
     end
 
     it "falls back to the default scope for standard claims" do

--- a/spec/lib/user_info_spec.rb
+++ b/spec/lib/user_info_spec.rb
@@ -38,6 +38,48 @@ describe Doorkeeper::OpenidConnect::UserInfo do
       end
     end
 
+    context "with a claim assigned to multiple scopes" do
+      before do
+        Doorkeeper::OpenidConnect.configure do
+          resource_owner_from_access_token do |access_token|
+            User.find_by(id: access_token.resource_owner_id)
+          end
+
+          subject do |resource_owner|
+            resource_owner.id
+          end
+
+          claims do
+            claim(:nickname, scope: [:profile, :all_data], response: [:user_info]) { |user| user.name }
+          end
+        end
+      end
+
+      context "when the token grants the first scope" do
+        let(:scopes) { "openid profile" }
+
+        it "returns the claim" do
+          expect(subject.claims[:nickname]).to eq user.name
+        end
+      end
+
+      context "when the token grants the second scope" do
+        let(:scopes) { "openid all_data" }
+
+        it "returns the claim" do
+          expect(subject.claims[:nickname]).to eq user.name
+        end
+      end
+
+      context "when the token grants none of the listed scopes" do
+        let(:scopes) { "openid email" }
+
+        it "omits the claim" do
+          expect(subject.claims).not_to have_key(:nickname)
+        end
+      end
+    end
+
     context "when a custom claim collides with the protected sub claim" do
       before do
         Doorkeeper::OpenidConnect.configure do


### PR DESCRIPTION
## Summary

Lets `claim` accept an Array of scopes so the same claim can be exposed under more than one OAuth scope. The original report on #125 was that defining the same claim twice with different `scope:` arguments breaks because `ClaimsBuilder` keys claims by name in an `OpenStruct` (later definitions silently overwrite earlier ones). Following the maintainer's suggestion on the issue, this PR takes the array-form approach instead.

```ruby
claims do
  claim :given_name, scope: [:profile, :all_data] do |user|
    user.first_name
  end

  claim :email, scope: [:email, :all_data] do |user|
    user.email
  end
end
```

A token with `profile` returns `given_name`; a token with `all_data` returns both `given_name` and `email`.

## Changes

- `Claims::Claim#initialize` normalizes `scope:` into a frozen-style `@scopes` array, accepting either a Symbol or an Array. The Standard Claims default-scope fallback (`profile` / `email` / `address` / `phone`) is preserved and now produces a single-element array.
- `Claims::Claim#scope` is kept as a reader returning `@scopes.first` for backward compatibility; `Claims::Claim#scopes` exposes the full Array.
- `ClaimsBuilder.generate` matches a claim when **any** of its scopes is granted by the access token (`claim.scopes.any? { |s| access_token.scopes.exists?(s) }`).
- README gains an array-scope example next to the existing `scope:` documentation.
- New unit specs cover array input, symbolization of String entries, `nil`/empty-array fallback, and the `#scope` back-compat alias. A new integration context in `user_info_spec` exercises array scopes end-to-end.

## Backward compatibility

- `claim :foo, scope: :bar` still works identically.
- `Claim#scope` still returns a single Symbol (the first element of `@scopes`).
- The `scope=` writer that previously came from `attr_accessor :scope` is removed; if any external code mutated it, switching to `claim.instance_variable_set(:@scopes, [...])` or rebuilding the claim is the migration path. This is an internal accessor and is very unlikely to be used externally.

## Out of scope (deliberately)

- Defining the same claim name twice with different scopes is still **not** supported — the claim store is keyed by name. The array form is the documented way to expose a claim under multiple scopes. README is updated to make that explicit.

## Test plan

- [x] `bundle exec rspec` — 252 examples, 0 failures
- [x] `bundle exec rubocop` on touched files — no offenses
- [x] Manual smoke: configure an aggregate scope on a host app and confirm both focused-scope and aggregate-scope tokens emit the expected claims at `/oauth/userinfo` and in the ID token

Closes #125.