### PR TITLE
Allow `prompt=` handling outside of OIDC requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [#285] Document custom `jwks_uri` path pattern in README — show how to advertise a non-default path in the discovery document using Rails' `direct` URL helper
 - [#283] Support multiple signing keys in the JWKS response — `signing_key` now also accepts an array (and callables returning an array). The first entry is the active key used to sign new ID tokens; the remaining entries are published in the JWKS so clients can still validate tokens signed with a retired key during a rotation window. Single-value and callable forms continue to work unchanged
 - [#286] Allow claims to be assigned to multiple scopes via `scope: [:profile, :all_data]` — the claim is returned whenever the access token grants any of the listed scopes. **Note:** the previously implicit `Claim#scope=` writer (from `attr_accessor :scope`) is no longer provided; rebuild the claim instead of mutating it
+- [#287] Add `apply_prompt_to_non_oidc_requests` option to honor the `prompt` parameter on plain OAuth requests that do not include the `openid` scope
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,20 @@ The following settings are optional:
     end
     ```
 
+- `apply_prompt_to_non_oidc_requests`
+  - Whether to honor the `prompt` authorization parameter (`none`, `login`, `consent`, `select_account`) on plain OAuth requests that do not include the `openid` scope.
+  - Defaults to `false`, which preserves the historical behavior of silently ignoring `prompt` outside of OIDC requests.
+  - `max_age` enforcement remains OIDC-only regardless of this option, since it is defined by OIDC Core.
+
+    ```ruby
+    # config/initializers/doorkeeper_openid_connect.rb
+    Doorkeeper::OpenidConnect.configure do
+      # ...
+      apply_prompt_to_non_oidc_requests true
+      # ...
+    end
+    ```
+
 ### Scopes
 
 To perform authentication over OpenID Connect, an OAuth client needs to request the `openid` scope. This scope needs to be enabled using either `optional_scopes` in the global Doorkeeper configuration in `config/initializers/doorkeeper.rb`, or by adding it to any OAuth application's `scope` attribute.

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -85,6 +85,12 @@ module Doorkeeper
 
       option :dynamic_client_registration, default: false
 
+      # When enabled, the `prompt` authorization parameter (`none`, `login`,
+      # `consent`, `select_account`) is honored even on non-OIDC requests,
+      # i.e. when the `openid` scope is not part of the authorization request.
+      # `max_age` remains OIDC-only because it is defined by OIDC Core.
+      option :apply_prompt_to_non_oidc_requests, default: false
+
       option :authorize_dynamic_client_registration, default: nil
 
       option :open_id_request_class, default: "Doorkeeper::OpenidConnect::Request"

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -38,7 +38,8 @@ module Doorkeeper
 
         def authenticate_resource_owner!
           super.tap do |owner|
-            next unless oidc_authorization_request?
+            next unless oidc_authorization_request? ||
+                        non_oidc_request_with_prompt_handling_enabled?
 
             # When the configured resource_owner_authenticator redirects an
             # unauthenticated user, +super+ returns whatever +redirect_to+
@@ -48,7 +49,9 @@ module Doorkeeper
             # §3.1.2.1) without calling model methods on a non-model value.
             owner = nil if performed?
 
-            handle_oidc_max_age_param!(owner)
+            # `max_age` stays OIDC-only (OIDC Core §3.1.2.1); `prompt` is
+            # also honored on non-OIDC requests when the option is enabled.
+            handle_oidc_max_age_param!(owner) if oidc_authorization_request?
             handle_oidc_prompt_param!(owner)
           end
         rescue Errors::OpenidConnectError => e
@@ -56,10 +59,19 @@ module Doorkeeper
         end
 
         def oidc_authorization_request?
+          authorization_request_on_authorize_endpoint? &&
+            pre_auth.scopes.include?("openid")
+        end
+
+        def non_oidc_request_with_prompt_handling_enabled?
+          Doorkeeper::OpenidConnect.configuration.apply_prompt_to_non_oidc_requests &&
+            authorization_request_on_authorize_endpoint?
+        end
+
+        def authorization_request_on_authorize_endpoint?
           controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] &&
             action_name == "new" &&
-            pre_auth.valid? &&
-            pre_auth.scopes.include?("openid")
+            pre_auth.valid?
         end
 
         def handle_oidc_error!(exception)

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -100,6 +100,25 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
         expect_authorization_form!
       end
     end
+
+    context "with non-OIDC requests and apply_prompt_to_non_oidc_requests enabled" do
+      before do
+        allow(Doorkeeper::OpenidConnect.configuration)
+          .to receive(:apply_prompt_to_non_oidc_requests).and_return(true)
+      end
+
+      it "calls the prompt handler" do
+        expect(controller).to receive(:handle_oidc_prompt_param!)
+
+        authorize!(scope: "profile", prompt: "login")
+      end
+
+      it "does not call the max_age handler" do
+        expect(controller).not_to receive(:handle_oidc_max_age_param!)
+
+        authorize!(scope: "profile", prompt: "login", max_age: 10)
+      end
+    end
   end
 
   describe "#handle_oidc_prompt_param!" do
@@ -107,6 +126,54 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       authorize! scope: "profile", prompt: "invalid"
 
       expect_authorization_form!
+    end
+
+    context "when apply_prompt_to_non_oidc_requests is enabled" do
+      before do
+        allow(Doorkeeper::OpenidConnect.configuration)
+          .to receive(:apply_prompt_to_non_oidc_requests).and_return(true)
+      end
+
+      it "honors prompt=login on a non-OIDC request" do
+        authorize! scope: "profile", prompt: "login"
+
+        expect(response).to redirect_to("/reauthenticate")
+      end
+
+      it "honors prompt=consent on a non-OIDC request" do
+        create :access_token, token_attributes.merge(scopes: "profile")
+        authorize! scope: "profile", prompt: "consent"
+
+        expect_authorization_form!
+      end
+
+      it "honors prompt=select_account on a non-OIDC request" do
+        authorize! scope: "profile", prompt: "select_account"
+
+        expect(response).to redirect_to("/select_account")
+      end
+
+      it "honors prompt=none on a non-OIDC request" do
+        authorize! scope: "profile", prompt: "none", current_user: nil
+
+        error_params = {
+          "error" => "login_required",
+          "error_description" => "The authorization server requires end-user authentication",
+        }
+
+        expect(response).to redirect_to build_redirect_uri(error_params)
+      end
+
+      it "still rejects unknown prompt values on a non-OIDC request" do
+        authorize! scope: "profile", prompt: "maybe"
+
+        error_params = {
+          "error" => "invalid_request",
+          "error_description" => "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.",
+        }
+
+        expect(response).to redirect_to build_redirect_uri(error_params)
+      end
     end
 
     context "with a prompt=none parameter" do

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -222,6 +222,22 @@ describe Doorkeeper::OpenidConnect, "configuration" do
     end
   end
 
+  describe "apply_prompt_to_non_oidc_requests" do
+    it "defaults to false" do
+      described_class.configure {}
+
+      expect(subject.apply_prompt_to_non_oidc_requests).to be(false)
+    end
+
+    it "can be enabled" do
+      described_class.configure do
+        apply_prompt_to_non_oidc_requests true
+      end
+
+      expect(subject.apply_prompt_to_non_oidc_requests).to be(true)
+    end
+  end
+
   describe "discovery_url_options" do
     it "defaults to empty hash" do
       expect(subject.discovery_url_options.call).to be_a(Hash)


### PR DESCRIPTION
## Summary

Adds an opt-in configuration option, `apply_prompt_to_non_oidc_requests` (default `false`), that lets the `prompt` authorization parameter (`none`, `login`, `consent`, `select_account`) take effect on plain OAuth authorization requests that do not include the `openid` scope.

Issue #120 (Jeff Sawatzky, 2021) reported that `prompt=login` and friends are silently ignored outside OIDC requests. Maintainer @toupeira responded that they'd accept a PR adding a single configuration flag because the `prompt` values themselves don't depend on OIDC semantics. This PR implements exactly that.

```ruby
# config/initializers/doorkeeper_openid_connect.rb
Doorkeeper::OpenidConnect.configure do
  # ...
  apply_prompt_to_non_oidc_requests true
end
```

After enabling, a request like `GET /oauth/authorize?response_type=code&scope=profile&prompt=login&...` triggers `reauthenticate_resource_owner` exactly the same way it would with `scope=openid profile`.

## Changes

- `Config` gains the new `apply_prompt_to_non_oidc_requests` option (default `false`).
- `Helpers::Controller#authenticate_resource_owner!` now branches: OIDC requests get both `handle_oidc_max_age_param!` and `handle_oidc_prompt_param!` as before, non-OIDC requests get only `handle_oidc_prompt_param!` when the new option is enabled, and otherwise are left untouched.
- The existing `oidc_authorization_request?` helper is split: a new `authorization_request_on_authorize_endpoint?` captures the "we are on the authorize endpoint with a valid pre-auth" precondition that both OIDC and the new non-OIDC path need; `oidc_authorization_request?` keeps its previous public-looking shape (still requires the `openid` scope).
- Spec coverage: controller-level specs for the flag-on path covering `login`, `none`, `consent`, `select_account`, and an unknown prompt value; plus a guard test confirming `max_age` stays OIDC-only even when the flag is enabled. New `config_spec.rb` cases cover the default and overridden values.
- README documents the new option next to the existing optional settings.

## Design notes

- **`max_age` deliberately stays OIDC-only.** It's defined by OIDC Core §3.1.2.1 and is conceptually a separate parameter from `prompt`; @toupeira's comment on the issue specifically scoped the flag to `prompt`.
- **OIDC error codes (`login_required`, `consent_required`, `account_selection_required`) leak into OAuth flows when the flag is enabled.** This is intentional and is the natural consequence of running `handle_oidc_prompt_param!` on the request. Clients that already integrate with this gem are OIDC-aware, so the leakage is acceptable.
- **Default off** means zero behavior change for existing installations.
- **`prompt=create` continues to be a no-op pass-through** on both OIDC and non-OIDC paths.

## Test plan

- [x] `bundle exec rspec` — 253 examples, 0 failures
- [x] `bundle exec rubocop` on touched files — no offenses
- [x] Manual smoke: with `apply_prompt_to_non_oidc_requests true`, confirm `GET /oauth/authorize?scope=profile&prompt=login&...` redirects through `reauthenticate_resource_owner`, and that `scope=profile&prompt=none` (no current user) returns `login_required` to the registered `redirect_uri`

Closes #120.