### PR TITLE
Document offline_access scope recipe in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [#279] Return `account_selection_required` when a `prompt=select_account` handler does not generate a response, per [OIDC Core 1.0 §3.1.2.6](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) — previously the authorization silently continued without account selection. Adds the missing `Errors::AccountSelectionRequired` class, mirroring the existing `login_required` backstop for `reauthenticate_resource_owner`
 - [#275] Return `login_required` for `max_age` reauthentication when `prompt=none`, instead of triggering the interactive `reauthenticate_resource_owner` flow (OIDC Core §3.1.2.1)
 - [#284] Document `acr` / `amr` claims in README — show how to expose Authentication Context Class Reference and Authentication Methods References via the `claim` DSL, with callouts for the `response:` and `scope:` defaults that silently bite
+- [#288] Document `offline_access` scope recipe in README — show how to wire `use_refresh_token` with scope-based filtering for OIDC offline access
 
 ## v1.9.0 (2026-03-16)
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,24 @@ To perform authentication over OpenID Connect, an OAuth client needs to request 
 >
 > See [Using Scopes](https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes) in the Doorkeeper wiki for more information.
 
+#### `offline_access`
+
+Per [OIDC Core §11](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess), the `offline_access` scope signals that the client wants a refresh token so it can access the user's resources while the user is offline. Doorkeeper's existing `use_refresh_token` block already covers the basic flow — issue a refresh token only when the client actually asked for `offline_access`:
+
+```ruby
+# config/initializers/doorkeeper.rb
+Doorkeeper.configure do
+  optional_scopes :openid, :offline_access
+
+  # Issue a refresh token only when the client requests offline_access
+  use_refresh_token do |context|
+    context.scopes.exists?("offline_access")
+  end
+end
+```
+
+> **Note:** This does not automatically enforce [OIDC Core §11](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess)'s strict requirements — for example, the OP MUST ignore `offline_access` unless `prompt=consent` is present and `response_type` returns an Authorization Code. If you need that level of enforcement, filter the scope in your `use_refresh_token` block or authorization controller override.
+
 ### Claims
 
 Claims can be defined in a `claims` block inside `config/initializers/doorkeeper_openid_connect.rb`:


### PR DESCRIPTION
### Summary

Add a recipe showing how to wire Doorkeeper's `use_refresh_token` block with `offline_access` scope filtering. The basic flow requires no gem changes — just `optional_scopes` + a scope-aware `use_refresh_token` block.

Includes a note that this does not automatically enforce OIDC Core §11's strict requirements (e.g. MUST ignore `offline_access` when `prompt=consent` is absent).

### Context

Issue #133 (open since 2020) asked for `offline_access` support. Triage confirmed the existing Doorkeeper primitives already cover the use case. The original reporter [confirmed](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/133#issuecomment-4525540674) the workaround is sufficient.

Closes #133.