### PR TITLE
Freeze Claim#scopes and Claim#response at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [#286] Allow claims to be assigned to multiple scopes via `scope: [:profile, :all_data]` — the claim is returned whenever the access token grants any of the listed scopes. **Note:** the previously implicit `Claim#scope=` writer (from `attr_accessor :scope`) is no longer provided; rebuild the claim instead of mutating it
 - [#287] Add `apply_prompt_to_non_oidc_requests` option to honor the `prompt` parameter on plain OAuth requests that do not include the `openid` scope
 - [#282] Allow `prompt=none` reauthorization with a narrower subset of previously-granted scopes (issue #63). Per RFC 6749 §1.5, narrower-or-equal scopes do not require fresh user consent; previously these requests returned `consent_required`.
+- [#290] Freeze `Claim#scopes` and `Claim#response` arrays at construction so callers can't accidentally mutate the claim's internal state from outside
 
 ## v1.9.0 (2026-03-16)
 

--- a/lib/doorkeeper/openid_connect/claims/claim.rb
+++ b/lib/doorkeeper/openid_connect/claims/claim.rb
@@ -21,11 +21,11 @@ module Doorkeeper
 
         def initialize(options = {})
           @name = options[:name].to_sym
-          @response = Array.wrap(options[:response])
+          @response = Array.wrap(options[:response]).freeze
           @scopes = normalize_scopes(options[:scope])
 
           # use default scope for Standard Claims, fallback to profile
-          @scopes = [default_scope] if @scopes.empty?
+          @scopes = [default_scope].freeze if @scopes.empty?
         end
 
         def scope
@@ -35,7 +35,7 @@ module Doorkeeper
         private
 
         def normalize_scopes(value)
-          Array.wrap(value).compact.map(&:to_sym)
+          Array.wrap(value).compact.map(&:to_sym).freeze
         end
 
         def default_scope

--- a/spec/lib/claims/claim_spec.rb
+++ b/spec/lib/claims/claim_spec.rb
@@ -55,4 +55,24 @@ describe Doorkeeper::OpenidConnect::Claims::Claim do
       expect(described_class.new(name: "unknown").scope).to eq :profile
     end
   end
+
+  describe "immutability" do
+    it "exposes a frozen #scopes array" do
+      claim = described_class.new(name: "given_name", scope: [:profile, :all_data])
+      expect(claim.scopes).to be_frozen
+      expect { claim.scopes << :extra }.to raise_error(FrozenError)
+    end
+
+    it "exposes a frozen #scopes array for the default-scope fallback" do
+      claim = described_class.new(name: "email", scope: [])
+      expect(claim.scopes).to be_frozen
+      expect { claim.scopes << :extra }.to raise_error(FrozenError)
+    end
+
+    it "exposes a frozen #response array" do
+      claim = described_class.new(name: "given_name", response: %i[id_token userinfo])
+      expect(claim.response).to be_frozen
+      expect { claim.response << :extra }.to raise_error(FrozenError)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Freezes the `@scopes` and `@response` arrays at construction time so callers can't accidentally mutate a claim's internal state (e.g. `claim.scopes << :extra`).

Follow-up to [#286 (comment)](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/286#pullrequestreview-4381283265) — @nbulaj and Copilot both flagged the mutable `@scopes` concern. As noted there, I deferred it to a separate PR to freeze both arrays together rather than introducing an inconsistency.

## Changes

- `normalize_scopes` return value: `.freeze`
- `[default_scope]` fallback: `.freeze`
- `Array.wrap(options[:response])`: `.freeze`

## Test plan

- ✅ `bundle exec rspec` — 273 examples, 0 failures
- ✅ `bundle exec rubocop` on touched files — no offenses
- New `"immutability"` context: verifies `FrozenError` is raised on mutation of `#scopes` (array input / default fallback) and `#response`