### PR TITLE
Drop stale Metrics/ClassLength and Metrics/BlockLength from rubocop_todo

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,15 +13,6 @@ Layout/FirstHashElementIndentation:
 Layout/ArgumentAlignment:
   Enabled: false
 
-# Configuration parameters: CountComments, ExcludedMethods.
-# ExcludedMethods: refine
-Metrics/BlockLength:
-  Max: 61
-
-# Configuration parameters: CountComments.
-Metrics/ClassLength:
-  Max: 230
-
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
   Max: 209

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Please add here
+- [#294] Drop stale `Metrics/ClassLength` and `Metrics/BlockLength` overrides from `.rubocop_todo.yml`
 
 ## v1.10.0 (2026-06-01)
 


### PR DESCRIPTION
Remove two stale `Max:` overrides from `.rubocop_todo.yml`. Both cops have zero offenses at RuboCop's default limits — the overrides were leftovers.

- **No code changes:** `.rubocop_todo.yml` only (−9 lines).
- **Independent of #292 and #293.**

rubocop: 92 files, 0 offenses.