### PR TITLE
Release 1.10.0 🎉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 - Please add here
+
+## v1.10.0 (2026-06-01)
+
 - [#241] Fix NameError on doorkeeper master by deferring AR model loading in run_hooks (see [Doorkeeper PR](https://github.com/doorkeeper-gem/doorkeeper/pull/1804))
 - [#242] Fix `NoMethodError` for openid_request in testing environments.
 - [#246] Fix `at_hash` to use correct hash algorithm based on `signing_algorithm`

--- a/lib/doorkeeper/openid_connect/version.rb
+++ b/lib/doorkeeper/openid_connect/version.rb
@@ -3,7 +3,7 @@
 module Doorkeeper
   module OpenidConnect
     MAJOR = 1
-    MINOR = 9
+    MINOR = 10
     TINY = 0
     PRE = nil
 


### PR DESCRIPTION
Prepares the v1.10.0 release.

- Bump `version.rb` to 1.10.0
- Convert the CHANGELOG `Unreleased` section into the dated `v1.10.0` header

v1.9.0 shipped on 2026-03-16; since then 35 PRs (#241–#288) have accumulated, including several security and breaking changes (#254, #263, #271, #273, #277). Opening this so @nbulaj can review and cut the release (merge → tag → `gem push`) whenever convenient.

**Note:** The currently open PRs (#290–#294) are not blocking this release, but they are lightweight changes (RuboCop cleanup, docs, et al.) that could be included if you'd prefer.