### PR TITLE
Ignore blank entries in the `prompt` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#293] Drop `Naming/VariableNumber` from `.rubocop_todo.yml` and normalise test variable names
 - [#291] Document multi-namespace mount pattern for multiple resource owner models ([#192](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/192))
 - [#292] Drop formatting cops from `.rubocop_todo.yml` and align trailing-comma style with upstream doorkeeper
+- [#296] Fix the `prompt` parameter being rejected with `invalid_request` when it contains leading or duplicate spaces (e.g. `prompt=%20none`) — blank entries in the space-delimited value are now ignored
 
 ## v1.10.0 (2026-06-01)
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -176,7 +176,11 @@ module Doorkeeper
         end
 
         def oidc_prompt_values
-          @oidc_prompt_values ||= params[:prompt].to_s.split(/ +/).uniq
+          # Reject blank entries so leading/duplicate spaces in the
+          # space-delimited `prompt` parameter don't surface as an empty
+          # value (which would otherwise be treated as an unknown prompt and
+          # rejected with `invalid_request`).
+          @oidc_prompt_values ||= params[:prompt].to_s.split(/ +/).reject(&:blank?).uniq
         end
 
         # Resolve auth_time for max_age enforcement.

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -188,6 +188,12 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
           expect_successful_callback!
         end
 
+        it "ignores leading/duplicate whitespace in the prompt parameter" do
+          authorize! prompt: "  none"
+
+          expect_successful_callback!
+        end
+
         context "when another prompt value is present" do
           let(:error_params) do
             {


### PR DESCRIPTION
## Summary

`oidc_prompt_values` splits the space-delimited `prompt` parameter with `split(/ +/)`. A value with **leading** (or otherwise stray) whitespace, e.g. `prompt=%20none`, produces an empty-string element:

```ruby
" none".split(/ +/) # => ["", "none"]
```

The empty string then falls through `handle_oidc_prompt_param!`'s `case` to the `else` branch (and trips `handle_oidc_prompt_none!`'s "another value present" guard), so the request is rejected with `invalid_request` instead of being treated as `prompt=none`.

## Fix

Reject blank entries after splitting:

```ruby
params[:prompt].to_s.split(/ +/).reject(&:blank?).uniq
```

Only the empty-string case changes; valid prompts are unaffected.

## Diff

```diff
diff --git a/lib/doorkeeper/openid_connect/helpers/controller.rb b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -176,7 +176,11 @@ module Doorkeeper
         def oidc_prompt_values
-          @oidc_prompt_values ||= params[:prompt].to_s.split(/ +/).uniq
+          # Reject blank entries so leading/duplicate spaces in the
+          # space-delimited `prompt` parameter don't surface as an empty
+          # value (which would otherwise be treated as an unknown prompt and
+          # rejected with `invalid_request`).
+          @oidc_prompt_values ||= params[:prompt].to_s.split(/ +/).reject(&:blank?).uniq
         end
```

A spec was added asserting `prompt: "  none"` (leading whitespace) auto-issues like `prompt: "none"`.

## Verification

- `bundle exec rspec spec/controllers/doorkeeper/authorizations_controller_spec.rb` → 73 examples, 0 failures
- Full suite → 286 examples, 0 failures
- `bundle exec rubocop <changed files>` → no offenses
