### PR TITLE
Fix `NameError` in the generated initializer's `issuer` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Please add here
+- [#297] Fix the generated initializer's `issuer` example referencing an undefined `request` local (the block parameter is `_request`), which raised `NameError` when copied verbatim
 
 ## v1.10.0 (2026-06-01)
 

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -2,8 +2,9 @@
 
 Doorkeeper::OpenidConnect.configure do
   issuer do |_resource_owner, _application, _request|
-    # Example implementation:
-    # request&.base_url || 'https://example.com'
+    # Example implementation (the block receives the current request as its
+    # third argument; reference it as `_request` or rename the parameter):
+    # _request&.base_url || 'https://example.com'
     "issuer string"
   end
 


### PR DESCRIPTION
## Summary

The unified issuer block signature (#270) names the third block parameter `_request`, but the commented example still referenced a bare `request`:

```ruby
issuer do |_resource_owner, _application, _request|
  # Example implementation:
  # request&.base_url || 'https://example.com'   # <- `request` is undefined here
  "issuer string"
end
```

`issuer` blocks are invoked as plain procs (`issuer.call(...)`), so a user who uncomments/copies the example gets a `NameError` for the undefined `request` local.

## Fix

Point the example at the actual parameter name (`_request`) and note that it can be renamed. Keeping the parameter underscored avoids a `Lint/UnusedBlockArgument` RuboCop offense (the template file *is* linted).

## Diff

```diff
diff --git a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -2,8 +2,9 @@
 Doorkeeper::OpenidConnect.configure do
   issuer do |_resource_owner, _application, _request|
-    # Example implementation:
-    # request&.base_url || 'https://example.com'
+    # Example implementation (the block receives the current request as its
+    # third argument; reference it as `_request` or rename the parameter):
+    # _request&.base_url || 'https://example.com'
     "issuer string"
   end
```

## Verification

- `bundle exec rubocop lib/generators/doorkeeper/openid_connect/templates/initializer.rb` → no offenses
- Full suite → 285 examples, 0 failures (template change; no runtime/spec impact)
