### PR TITLE
Raise on blank issuer in `resolve_issuer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#291] Document multi-namespace mount pattern for multiple resource owner models ([#192](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/192))
 - [#292] Drop formatting cops from `.rubocop_todo.yml` and align trailing-comma style with upstream doorkeeper
 - [#296] Fix the `prompt` parameter being rejected with `invalid_request` when it contains leading or duplicate spaces (e.g. `prompt=%20none`) — blank entries in the space-delimited value are now ignored
+- [#299] Raise `InvalidConfiguration` when the `issuer` config resolves to a blank value instead of silently advertising an empty `issuer` in the discovery document. Since v1.10.0 an arity-2 `issuer` block receives `(resource_owner, application)` — both `nil` in the discovery context — so a block relying on the old v1.9.0 request argument could return `nil` and produce a discovery `issuer` that mismatched the ID token `iss` ([#298](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/298))
 
 ## v1.10.0 (2026-06-01)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,4 +22,5 @@ en:
           select_account_for_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.select_account_for_resource_owner missing configuration.'
           subject_not_configured: 'ID Token generation failed due to Doorkeeper::OpenidConnect.configure.subject missing configuration.'
           signing_key_not_configured: 'Doorkeeper::OpenidConnect.configure.signing_key must resolve to at least one key.'
+          issuer_not_configured: 'Doorkeeper::OpenidConnect.configure.issuer must resolve to a non-blank value.'
           dynamic_client_registration_unauthorized: 'Authorization required for client registration'

--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -132,18 +132,29 @@ module Doorkeeper
     # @return [String] the issuer string
     def self.resolve_issuer(resource_owner: nil, application: nil, request: nil)
       issuer = configuration.issuer
-      return issuer.to_s unless issuer.respond_to?(:call)
 
-      case issuer.arity
-      when 0
-        issuer.call
-      when 1
-        issuer.call(request || resource_owner)
-      when 2
-        issuer.call(resource_owner, application)
-      else
-        issuer.call(resource_owner, application, request)
-      end.to_s
+      value =
+        if issuer.respond_to?(:call)
+          case issuer.arity
+          when 0
+            issuer.call
+          when 1
+            issuer.call(request || resource_owner)
+          when 2
+            issuer.call(resource_owner, application)
+          else
+            issuer.call(resource_owner, application, request)
+          end
+        else
+          issuer
+        end.to_s
+
+      if value.blank?
+        raise Errors::InvalidConfiguration,
+              I18n.translate("doorkeeper.openid_connect.errors.messages.issuer_not_configured")
+      end
+
+      value
     end
 
     Doorkeeper::GrantFlow.register(

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -261,6 +261,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
 
     it "uses the protocol option for generating URLs" do
       Doorkeeper::OpenidConnect.configure do
+        issuer "dummy"
         protocol { :testing }
       end
 
@@ -273,6 +274,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
     context "when the protocol option is configured with a non-callable value" do
       it "accepts a symbol" do
         Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
           protocol :testing
         end
 
@@ -285,6 +287,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
 
       it "accepts a string" do
         Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
           protocol "testing"
         end
 
@@ -299,6 +302,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
     context "when the discovery_url_options option is set for all endpoints" do
       before do
         Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
           discovery_url_options do |_request|
             {
               authorization: { host: "alternate-authorization.host" },
@@ -328,6 +332,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
     context "when the discovery_url_options option is only set for some endpoints" do
       before do
         Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
           discovery_url_options do |_request|
             { authorization: { host: "alternate-authorization.host" } }
           end
@@ -359,6 +364,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
 
     it "uses the configured end session endpoint with self as context" do
       Doorkeeper::OpenidConnect.configure do
+        issuer "dummy"
         end_session_endpoint -> { logout_url }
       end
 
@@ -420,6 +426,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
     context "when the discovery_url_options option uses the request for an endpoint" do
       before do
         Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
           discovery_url_options do |request|
             {
               authorization: { host: "alternate-authorization.host",

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -413,5 +413,30 @@ describe Doorkeeper::OpenidConnect do
         expect(result).to eq "https://example.com"
       end
     end
+
+    context "when issuer resolves to a blank value" do
+      it "raises InvalidConfiguration for a block returning nil in the discovery context" do
+        described_class.configure do
+          issuer do |resource_owner, application|
+            resource_owner && application && "https://example.com"
+          end
+        end
+
+        expect { subject.resolve_issuer(request: request) }
+          .to raise_error(
+            Doorkeeper::OpenidConnect::Errors::InvalidConfiguration,
+            /issuer must resolve to a non-blank value/,
+          )
+      end
+
+      it "raises InvalidConfiguration for a blank static value" do
+        described_class.configure do
+          issuer "  "
+        end
+
+        expect { subject.resolve_issuer }
+          .to raise_error(Doorkeeper::OpenidConnect::Errors::InvalidConfiguration)
+      end
+    end
   end
 end

--- a/spec/support/doorkeeper_configuration.rb
+++ b/spec/support/doorkeeper_configuration.rb
@@ -3,6 +3,8 @@
 module DoorkeeperConfiguration
   def configure_doorkeeper(signing_key, signing_algorithm)
     Doorkeeper::OpenidConnect.configure do
+      issuer "dummy"
+
       signing_key signing_key
 
       signing_algorithm signing_algorithm


### PR DESCRIPTION
Fixes #298

## Problem

Since v1.10.0, `Doorkeeper::OpenidConnect.resolve_issuer` unified issuer dispatch and calls **arity-2** issuer blocks with `(resource_owner, application)`.

In the **discovery** context both arguments are `nil`. An existing arity-2 block that relied on the v1.9.0 behavior — where `DiscoveryController` called `issuer.call(request)` and the block received the **request** as its first argument — now receives `nil` and can return `nil`.

`resolve_issuer` then silently coerced that `nil` to `""` via `to_s`. The result was a discovery document advertising an **empty `issuer`**, while the ID token `iss` claim still carried the configured value. OIDC clients reject this mismatch, so the failure surfaced far from its cause (a broken callback) instead of at the misconfiguration.

This is the scenario reported in #298.

## Change

`resolve_issuer` now raises `Errors::InvalidConfiguration` when the resolved issuer is **blank**, mirroring the existing `signing_key` handling (`signing_key must resolve to at least one key`). The guard covers **both** the static-value and callable paths, so any misconfigured issuer (a `nil` block result, an empty string, or whitespace) now fails loudly instead of shipping a broken discovery document.

The issuer argument unification itself is intentional and unchanged — this PR only adds a fail-fast guard on the resolved value.

### Migration

For blocks that previously relied on the discovery-context request:

```ruby
# arity-3 block — works in both discovery and token contexts
issuer do |resource_owner, application, request|
  request&.base_url || "https://default.example.com"
end
```

or, for a constant issuer:

```ruby
issuer "https://example.com"
```

## Files

| File | Change |
| --- | --- |
| `lib/doorkeeper/openid_connect.rb` | `resolve_issuer` computes the value, then raises `InvalidConfiguration` if `blank?`. Covers static + callable paths. |
| `config/locales/en.yml` | New `issuer_not_configured` message, following the `signing_key_not_configured` precedent. |
| `spec/lib/openid_connect_spec.rb` | Specs for the blank guard: an arity-2 block returning `nil` in the discovery context (the reported case), and a blank static value. |
| `spec/controllers/discovery_controller_spec.rb` | Seven partial-config blocks (testing `protocol` / `discovery_url_options` / end-session) now set a valid `issuer`. They previously relied on the silent-`""` behavior. |
| `spec/support/doorkeeper_configuration.rb` | The shared `configure_doorkeeper` helper now sets an issuer (fixes the EC/HMAC `as_jws_token` examples in one place). |

## Notes

- `blank?` (not `empty?`) is used so a whitespace-only issuer is also rejected.
- The pre-existing `IdToken#as_json` test that stubs `issuer: nil` to assert `iss` is omitted is unaffected — it stubs the instance method and never reaches `resolve_issuer`.

## Testing

- Targeted specs (`openid_connect_spec`, `id_token_spec`, `discovery_controller_spec`): **85 examples, 0 failures**
- Full suite: **287 examples, 0 failures**
- RuboCop: **no offenses** on changed files
