### PR TITLE
Release 1.10.1 🎉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 - Please add here
+
+## v1.10.1 (2026-06-03)
+
 - [#294] Drop stale `Metrics/ClassLength` and `Metrics/BlockLength` overrides from `.rubocop_todo.yml`
 - [#293] Drop `Naming/VariableNumber` from `.rubocop_todo.yml` and normalise test variable names
 - [#291] Document multi-namespace mount pattern for multiple resource owner models ([#192](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/192))

--- a/lib/doorkeeper/openid_connect/version.rb
+++ b/lib/doorkeeper/openid_connect/version.rb
@@ -4,7 +4,7 @@ module Doorkeeper
   module OpenidConnect
     MAJOR = 1
     MINOR = 10
-    TINY = 0
+    TINY = 1
     PRE = nil
 
     # Full version number


### PR DESCRIPTION
Prepares the v1.10.1 release.

- Bump `version.rb` to 1.10.1
- Convert the CHANGELOG `Unreleased` section into the dated `v1.10.1` header
