### PR TITLE
execute account selection even without owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Please add here
+- [#303] execute account selection even without owner
 
 ## v1.10.1 (2026-06-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Please add here
-- [#303] execute account selection even without owner
+- [#303] execute account selection even without owner, and `select_account_for_resource_owner` can now receive `nil` as the first argument.
 - [#304] allow handle auth_time per grant
 
 ## v1.10.1 (2026-06-03)

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -125,7 +125,7 @@ module Doorkeeper
                 render :new
               end
             when "select_account"
-              select_account_for_oidc_resource_owner(owner) if owner
+              select_account_for_oidc_resource_owner(owner)
             when "create"
               # NOTE: not supported, but not raise error.
             else

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -76,9 +76,11 @@ Doorkeeper::OpenidConnect.configure do
     # redirect_to new_user_session_url
   end
 
-  select_account_for_resource_owner do |resource_owner, return_to|
+  select_account_for_resource_owner do |resource_owner_or_nil, return_to|
     # Example implementation:
-    # store_location_for resource_owner, return_to
+    # if resource_owner_or_nil
+    #   store_location_for resource_owner_or_nil, return_to
+    # end
     # redirect_to account_select_url
   end
 

--- a/spec/controllers/doorkeeper/redirecting_resource_owner_authenticator_spec.rb
+++ b/spec/controllers/doorkeeper/redirecting_resource_owner_authenticator_spec.rb
@@ -61,13 +61,13 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
     # like the other unauthenticated prompts.
     it "prompt=select_account: falls through to the login redirect without raising" do
       Doorkeeper::OpenidConnect.configure do
-        select_account_for_resource_owner do |resource_owner, _return_to|
-          redirect_to "/accounts?uid=#{resource_owner.id}"
+        select_account_for_resource_owner do |_resource_owner, _return_to|
+          redirect_to "/accounts"
         end
       end
 
       expect { authorize!(prompt: "select_account") }.not_to raise_error
-      expect(response).to redirect_to("/login")
+      expect(response).to redirect_to("/accounts")
     end
 
     # OpenID Connect Core 1.0 §3.1.2.1: with prompt=none and no authenticated

--- a/spec/controllers/doorkeeper/redirecting_resource_owner_authenticator_spec.rb
+++ b/spec/controllers/doorkeeper/redirecting_resource_owner_authenticator_spec.rb
@@ -61,6 +61,7 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       Doorkeeper::OpenidConnect.configure do
         select_account_for_resource_owner do |resource_owner_or_nil, _return_to|
           raise unless resource_owner_or_nil.nil?
+
           redirect_to "/accounts"
         end
       end

--- a/spec/controllers/doorkeeper/redirecting_resource_owner_authenticator_spec.rb
+++ b/spec/controllers/doorkeeper/redirecting_resource_owner_authenticator_spec.rb
@@ -54,14 +54,13 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       expect(response).to redirect_to("/login")
     end
 
-    # prompt=select_account had no `if owner` guard (unlike prompt=login /
-    # prompt=consent), so the leaked owner reached the host
-    # select_account_for_resource_owner block and a block that touches the
-    # owner blew up. With the guard it falls through to the login redirect
-    # like the other unauthenticated prompts.
+    # prompt=select_account has no `if owner` guard (unlike prompt=login /
+    # prompt=consent), so select_account_for_resource_owner can navigate users to
+    # account selector screen even if they are not authenticated upto your configuration.
     it "prompt=select_account: executes the select_account handler without raising" do
       Doorkeeper::OpenidConnect.configure do
-        select_account_for_resource_owner do |_resource_owner, _return_to|
+        select_account_for_resource_owner do |resource_owner_or_nil, _return_to|
+          raise unless resource_owner_or_nil.nil?
           redirect_to "/accounts"
         end
       end

--- a/spec/controllers/doorkeeper/redirecting_resource_owner_authenticator_spec.rb
+++ b/spec/controllers/doorkeeper/redirecting_resource_owner_authenticator_spec.rb
@@ -59,7 +59,7 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
     # select_account_for_resource_owner block and a block that touches the
     # owner blew up. With the guard it falls through to the login redirect
     # like the other unauthenticated prompts.
-    it "prompt=select_account: falls through to the login redirect without raising" do
+    it "prompt=select_account: executes the select_account handler without raising" do
       Doorkeeper::OpenidConnect.configure do
         select_account_for_resource_owner do |_resource_owner, _return_to|
           redirect_to "/accounts"


### PR DESCRIPTION
fixes https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/302