### PR TITLE
allow handle auth_time per grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Please add here
+- [#304] allow handle auth_time per grant
 
 ## v1.10.1 (2026-06-03)
 

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -54,6 +54,7 @@ module Doorkeeper
       }
 
       option :auth_time_from_session, default: nil
+      option :auth_time_from_access_token, default: nil
 
       option :reauthenticate_resource_owner, default: lambda { |*_|
         raise Errors::InvalidConfiguration, I18n.translate("doorkeeper.openid_connect.errors.messages.reauthenticate_resource_owner_not_configured")

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -78,7 +78,13 @@ module Doorkeeper
       end
 
       def auth_time
-        Doorkeeper::OpenidConnect.configuration.auth_time_from_resource_owner.call(@resource_owner).try(:to_i)
+        config = Doorkeeper::OpenidConnect.configuration
+
+        if config.auth_time_from_access_token
+          config.auth_time_from_access_token.call(@access_token).try(:to_i)
+        else
+          config.auth_time_from_resource_owner.call(@resource_owner).try(:to_i)
+        end
       rescue Errors::InvalidConfiguration
         nil
       end

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -57,6 +57,18 @@ Doorkeeper::OpenidConnect.configure do
   #   session[:auth_time]
   # end
 
+  # Advanced:
+  # If you store `auth_time` in a custom authentication context record linked
+  # to the access token, you can configure a block like below to derive it
+  # from the access token instead of `auth_time_from_resource_owner`.
+  #
+  # This allows you to track `auth_time` per grant instead of per user,
+  # but requires more custom implementation on your part.
+  #
+  # auth_time_from_access_token do |access_token|
+  #   access_token.your_custom_authentication_context_record.auth_time
+  # end
+
   reauthenticate_resource_owner do |resource_owner, return_to|
     # Example implementation:
     # store_location_for resource_owner, return_to

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -112,6 +112,22 @@ describe Doorkeeper::OpenidConnect, "configuration" do
     end
   end
 
+  describe "auth_time_from_access_token" do
+    it "defaults to nil" do
+      described_class.configure {}
+
+      expect(subject.auth_time_from_session).to be_nil
+    end
+
+    it "sets the block that is accessible via auth_time_from_access_token" do
+      block = proc {}
+      described_class.configure do
+        auth_time_from_access_token(&block)
+      end
+      expect(subject.auth_time_from_access_token).to eq(block)
+    end
+  end
+
   describe "reauthenticate_resource_owner" do
     it "sets the block that is accessible via reauthenticate_resource_owner" do
       block = proc {}

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -116,7 +116,7 @@ describe Doorkeeper::OpenidConnect, "configuration" do
     it "defaults to nil" do
       described_class.configure {}
 
-      expect(subject.auth_time_from_session).to be_nil
+      expect(subject.auth_time_from_access_token).to be_nil
     end
 
     it "sets the block that is accessible via auth_time_from_access_token" do

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -126,7 +126,7 @@ describe Doorkeeper::OpenidConnect::IdToken do
     context "when auth_time_from_access_token is configured" do
       before do
         access_token.define_singleton_method(:auth_time_from_custom_mechanism) do
-          @auth_time ||= 5.minutes.ago
+          @auth_time_from_custom_mechanism ||= 5.minutes.ago
         end
 
         Doorkeeper::OpenidConnect.configure do

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -123,6 +123,36 @@ describe Doorkeeper::OpenidConnect::IdToken do
       end
     end
 
+    context "when auth_time_from_access_token is configured" do
+      before do
+        access_token.define_singleton_method(:auth_time_from_custom_mechanism) do
+          @auth_time ||= 5.minutes.ago
+        end
+
+        Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
+
+          resource_owner_from_access_token do |access_token|
+            User.find_by(id: access_token.resource_owner_id)
+          end
+
+          auth_time_from_access_token do |access_token|
+            access_token.auth_time_from_custom_mechanism
+          end
+
+          subject do |resource_owner|
+            resource_owner.id
+          end
+        end
+      end
+
+      it "uses auth_time using auth_time_from_access_token" do
+        expect { subject.claims }.not_to raise_error
+        expect(subject.claims[:auth_time]).to eq access_token.auth_time_from_custom_mechanism.to_i
+        expect(subject.as_json).to include(:auth_time)
+      end
+    end
+
     context "when a custom claim collides with a protected registered claim" do
       before do
         Doorkeeper::OpenidConnect.configure do


### PR DESCRIPTION
currently, `auth_time` in ID Token is given via `auth_time_from_resource_owner`.

it's fine in most cases, but theoretically it's not always the same with the time the authorization grant is generated.
(users can switch sessions during authorization code issued and authorization code exchanged)

thus, in my application, I'm storing `auth_time` in a custom record representing authentication context on authorization grant insurance.

the new config `auth_time_from_access_token` allows get `auth_time` from each tokens, not from users.