### PR TITLE
Document `auth_time_from_access_token` config option in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Please add here
 - [#304] allow handle auth_time per grant
+- [#305] Document the `auth_time_from_access_token` config option in the README (per-grant `auth_time`), clarifying that it only affects the ID Token `auth_time` claim and not `max_age` enforcement
 
 ## v1.10.1 (2026-06-03)
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ The following settings are optional, but recommended for better client compatibi
       session[:auth_time]
     end
     ```
+- `auth_time_from_access_token`
+  - Derives the `auth_time` claim from the access token (i.e. per grant) instead of from the resource owner (per user). Useful when you store `auth_time` in a custom authentication-context record linked to the access token.
+  - The block receives the access token and the return value can be a `Time`, `DateTime`, or anything responding to `to_i`. When configured, it takes precedence over `auth_time_from_resource_owner` for populating the `auth_time` claim on the ID Token.
+  - **Note:** this only affects the `auth_time` claim on the ID Token; it is not used for `max_age` enforcement, which still resolves auth_time via `auth_time_from_session` / `auth_time_from_resource_owner`.
+
+    ```ruby
+    auth_time_from_access_token do |access_token|
+      access_token.your_custom_authentication_context_record.auth_time
+    end
+    ```
 - `reauthenticate_resource_owner`
   - Defines how to trigger reauthentication for the current user (e.g. display a password prompt, or sign-out the user and redirect to the login form).
   - Required to support the `max_age` and `prompt=login` parameters.


### PR DESCRIPTION
## Summary

#304 added the `auth_time_from_access_token` config option, allowing `auth_time` to be tracked **per grant** (derived from the access token) instead of **per user** (derived from the resource owner). That PR documented the option in the initializer template and added a CHANGELOG entry, but the **README option list was not updated**.

This PR adds the missing README documentation.

## Changes

- **README.md** — add an `auth_time_from_access_token` entry alongside `auth_time_from_resource_owner` / `auth_time_from_session`, including a usage example.
- **CHANGELOG.md** — add an `## Unreleased` entry for this docs change.

## Documentation notes

The README entry intentionally calls out two points verified against the implementation:

1. **Precedence** — when `auth_time_from_access_token` is configured, it takes precedence over `auth_time_from_resource_owner` for populating the `auth_time` claim on the ID Token (`lib/doorkeeper/openid_connect/id_token.rb`).
2. **Scope limitation** — it **only** affects the ID Token `auth_time` claim. It is **not** used for `max_age` enforcement, which still resolves auth_time via `auth_time_from_session` / `auth_time_from_resource_owner` in the controller helper (`lib/doorkeeper/openid_connect/helpers/controller.rb`). This is highlighted to avoid the misreading that switching to per-grant `auth_time` also makes `max_age` per-grant.

## Related

- Follows up #304 (the feature PR that introduced `auth_time_from_access_token`)