### PR TITLE
Fix `bundle exec rake server` for the test application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Please add here
 - [#304] allow handle auth_time per grant
 - [#305] Document the `auth_time_from_access_token` config option in the README (per-grant `auth_time`), clarifying that it only affects the ID Token `auth_time` claim and not `max_age` enforcement
+- [#307] Fix `bundle exec rake server` for the test application
 
 ## v1.10.1 (2026-06-03)
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,8 @@ group :development, :rubocop do
   gem "rubocop-rspec", require: false
 end
 
+group :development do
+  gem "puma"
+end
+
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-ENV["RAILS_ENV"] ||= "test"
-
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
@@ -12,6 +10,7 @@ task test: :spec
 
 desc "Generate and run migrations in the test application"
 task :migrate do
+  ENV["RAILS_ENV"] ||= "test"
   Dir.chdir("spec/dummy") do
     system("bin/rails generate doorkeeper:openid_connect:migration")
     system("bin/rake db:migrate")
@@ -20,6 +19,7 @@ end
 
 desc "Run server in the test application"
 task :server do
+  ENV["RAILS_ENV"] ||= "development"
   Dir.chdir("spec/dummy") do
     system("bin/rails server")
   end

--- a/spec/dummy/app/controllers/dummy_controller.rb
+++ b/spec/dummy/app/controllers/dummy_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DummyController < ApplicationController
+  def index
+    redirect_to "/.well-known/openid-configuration", status: :found
+  end
+end


### PR DESCRIPTION
### Problem

The [Development section](https://github.com/doorkeeper-gem/doorkeeper-openid_connect#development) of the README documents `bundle exec rake server` to run the local engine server, but it currently has three issues:

1. It fails with `Could not find a server gem` because no server gem is listed in the Gemfile.
2. After adding a server gem, accessing `http://localhost:3000/` raises `ActionController::RoutingError (uninitialized constant DummyController)` because `routes.rb` references `root 'dummy#index'` but no `DummyController` exists.
3. The `server` Rake task inherits `ENV["RAILS_ENV"] ||= "test"` from the top of the Rakefile, so the test application runs under the `test` environment instead of `development`.

### Changes

- Add `puma` to the `Gemfile` under `group :development`
- Add `DummyController#index` that redirects to `/.well-known/openid-configuration`
- Preserve any user-specified `RAILS_ENV` and default to `development` in the `server` Rake task