### PR TITLE
Wire `openid_request` from the AccessGrant mixin instead of `on_load(:active_record)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Please add here
+- [#308] Fix `NameError: uninitialized constant Auth::ApplicationRecord` on boot when using a namespaced custom access grant model (e.g. `Auth::OAuthAccessGrant < ApplicationRecord`). Since v1.10.0 ([#241]) the `openid_request` association was wired inside an `ActiveSupport.on_load(:active_record)` block, which fires while `ActiveRecord::Base` is first loaded and constantizes the grant model too early. The association is now added from Doorkeeper's `AccessGrant` mixin `included` callback — at the model's own load time, without constantizing — mirroring the fix doorkeeper made in [#1830](https://github.com/doorkeeper-gem/doorkeeper/pull/1830) ([#306](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/306))
 
 ## v1.10.2 (2026-06-22)
 

--- a/lib/doorkeeper/openid_connect/orm/active_record.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/lazy_load_hooks"
-
 module Doorkeeper
   module OpenidConnect
     autoload :AccessGrant, "doorkeeper/openid_connect/orm/active_record/access_grant"
@@ -14,51 +12,43 @@ module Doorkeeper
                    "doorkeeper/openid_connect/orm/active_record/mixins/openid_request"
         end
 
-        def run_hooks
-          super
-
-          ActiveSupport.on_load(:active_record) do
-            require "doorkeeper/openid_connect/orm/active_record/access_grant"
-            require "doorkeeper/openid_connect/orm/active_record/request"
-
-            if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.0")
-              Doorkeeper.config.access_grant_model.prepend Doorkeeper::OpenidConnect::AccessGrant
-            else
-              Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
-            end
-
-            if Doorkeeper.configuration.respond_to?(:active_record_options) && Doorkeeper.configuration.active_record_options[:establish_connection]
-              [Doorkeeper::OpenidConnect.configuration.open_id_request_model].each do |c|
-                c.send :establish_connection,
-                       Doorkeeper.configuration.active_record_options[:establish_connection]
-              end
-            end
-          end
-        end
-
-        def initialize_models!
-          super
-          ActiveSupport.on_load(:active_record) do
-            require "doorkeeper/openid_connect/orm/active_record/access_grant"
-            require "doorkeeper/openid_connect/orm/active_record/request"
-
-            if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.0")
-              Doorkeeper.config.access_grant_model.prepend Doorkeeper::OpenidConnect::AccessGrant
-            else
-              Doorkeeper::AccessGrant.prepend Doorkeeper::OpenidConnect::AccessGrant
-            end
-
-            if Doorkeeper.configuration.active_record_options[:establish_connection]
-              [Doorkeeper::OpenidConnect.configuration.open_id_request_model].each do |c|
-                c.send :establish_connection,
-                       Doorkeeper.configuration.active_record_options[:establish_connection]
-              end
-            end
+        # Prepended onto the singleton class of Doorkeeper's AccessGrant
+        # mixin so that every model which includes
+        # `Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant` — the default
+        # `Doorkeeper::AccessGrant` as well as any (possibly namespaced)
+        # custom access grant model — also gains the OpenID Connect
+        # `openid_request` association.
+        #
+        # The association is wired from the mixin's `included` callback, at
+        # the moment the host model is loaded: `base` is the model class
+        # itself, handed to us by Ruby. Nothing reaches out to constantize
+        # the configured grant class, so the re-entrant
+        # `ActiveSupport.on_load(:active_record)` window that broke
+        # namespaced custom models is gone.
+        #
+        # Background: doorkeeper-openid_connect v1.10.0 (#241) wrapped the
+        # grant-model prepend in `ActiveSupport.on_load(:active_record)`,
+        # following doorkeeper #1804. doorkeeper later reverted that in
+        # #1830 (v5.9.2) because the hook fires while `ActiveRecord::Base`
+        # is first loaded — e.g. mid-evaluation of
+        # `class ApplicationRecord < ActiveRecord::Base` — at which point
+        # constantizing `Auth::OAuthAccessGrant < ApplicationRecord` raises
+        # `NameError: uninitialized constant Auth::ApplicationRecord` (#306).
+        # We follow the same fix: wire from the mixin instead of on_load.
+        module AccessGrantExtension
+          def included(base)
+            super
+            # `base` is a Module (not the model) when the mixin is included
+            # into an intermediate ActiveSupport::Concern; the concern defers
+            # the include, so this hook fires again with the model class.
+            base.prepend(OpenidConnect::AccessGrant) if base.is_a?(Class)
           end
         end
       end
     end
   end
 
-  Orm::ActiveRecord.singleton_class.send :prepend, OpenidConnect::Orm::ActiveRecord
+  Orm::ActiveRecord::Mixins::AccessGrant.singleton_class.prepend(
+    OpenidConnect::Orm::ActiveRecord::AccessGrantExtension,
+  )
 end

--- a/lib/doorkeeper/openid_connect/orm/active_record/mixins/openid_request.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/mixins/openid_request.rb
@@ -11,6 +11,18 @@ module Doorkeeper
             included do
               self.table_name = "#{table_name_prefix}oauth_openid_requests#{table_name_suffix}".to_sym
 
+              # Legacy multi-database support: older Doorkeeper releases let
+              # users route the ORM models to a separate connection via
+              # `active_record_options[:establish_connection]`. Doorkeeper
+              # 5.9.x no longer exposes `active_record_options`, so the guard
+              # makes this a no-op there. It used to live in the ORM adapter's
+              # `run_hooks`; wiring it from the model's own `included` block
+              # keeps it off the re-entrant `on_load(:active_record)` path.
+              if Doorkeeper.configuration.respond_to?(:active_record_options) &&
+                 (connection_options = Doorkeeper.configuration.active_record_options[:establish_connection])
+                establish_connection(connection_options)
+              end
+
               validates :access_grant_id, :nonce, presence: true
 
               if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.0")

--- a/spec/lib/orm/active_record_spec.rb
+++ b/spec/lib/orm/active_record_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression coverage for #306.
+#
+# doorkeeper-openid_connect v1.10.0 (#241) wired the `openid_request`
+# association onto the access grant model from inside an
+# `ActiveSupport.on_load(:active_record)` block. That hook fires while
+# `ActiveRecord::Base` is first loaded — e.g. mid-evaluation of
+# `class ApplicationRecord < ActiveRecord::Base` — so constantizing a
+# namespaced custom grant model (`Auth::OAuthAccessGrant < ApplicationRecord`)
+# from the hook raised `NameError: uninitialized constant Auth::ApplicationRecord`.
+#
+# The fix wires the association from Doorkeeper's AccessGrant mixin
+# `included` callback instead, at the host model's own load time, without
+# constantizing anything. These specs pin that behavior.
+describe "Doorkeeper::OpenidConnect ActiveRecord ORM integration" do
+  describe "the openid_request association" do
+    it "is wired onto the default access grant model" do
+      association = Doorkeeper.config.access_grant_model.reflect_on_association(:openid_request)
+      expect(association).not_to be_nil
+    end
+
+    it "is wired onto a namespaced custom model that includes Doorkeeper's mixin" do
+      # Mirrors the #306 reporter's setup: a namespaced model subclassing
+      # the host app's ApplicationRecord and including the doorkeeper mixin.
+      # Because the association is added from the mixin's `included` callback
+      # (not a deferred load hook), the model is wired at its own load time
+      # without anything constantizing the configured grant class.
+      stub_const("Auth306", Module.new)
+      custom_model = Class.new(ApplicationRecord) do
+        self.table_name = "oauth_access_grants"
+        include Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant
+      end
+      Auth306.const_set(:OAuthAccessGrant, custom_model)
+
+      association = custom_model.reflect_on_association(:openid_request)
+      expect(association).not_to be_nil
+      expect(association.options[:class_name])
+        .to eq(Doorkeeper::OpenidConnect.configuration.open_id_request_class)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #306

## Problem

Since v1.10.0, apps using a **namespaced custom access grant model** crash on Rails boot:

```ruby
# config/initializers/doorkeeper.rb
Doorkeeper.configure do
  access_grant_class "Auth::OAuthAccessGrant"
end

# app/models/auth/o_auth_access_grant.rb
module Auth
  class OAuthAccessGrant < ApplicationRecord
    include Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant
  end
end
```

```
NameError: uninitialized constant Auth::ApplicationRecord (NameError)
```

## Root cause

v1.10.0 (#241) wrapped the access-grant prepend in `ActiveSupport.on_load(:active_record)`, following doorkeeper's [#1804](https://github.com/doorkeeper-gem/doorkeeper/pull/1804). doorkeeper itself later reverted that approach in [#1830](https://github.com/doorkeeper-gem/doorkeeper/pull/1830) (v5.9.2, see [doorkeeper#1828](https://github.com/doorkeeper-gem/doorkeeper/issues/1828)): the `:active_record` load hook fires while `ActiveRecord::Base` is first being loaded — typically mid-evaluation of `class ApplicationRecord < ActiveRecord::Base`. Constantizing the configured grant class from inside the hook at that moment resolves `ApplicationRecord` relative to the model's namespace before `::ApplicationRecord` has been registered, raising the `NameError`.

## Fix

Follow the same direction as doorkeeper [#1830](https://github.com/doorkeeper-gem/doorkeeper/pull/1830): wire from the mixin, not from a deferred load hook.

- Drop the `run_hooks` / `initialize_models!` overrides and the `on_load(:active_record)` block entirely.
- Prepend a small extension onto the singleton class of `Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant`. Its `included` callback prepends `Doorkeeper::OpenidConnect::AccessGrant` (which adds the `openid_request` association) onto every model that includes the mixin — the default `Doorkeeper::AccessGrant` as well as any custom model.
- This runs at the host model's own load time, with the model class handed in by Ruby as `base`. Nothing constantizes the configured grant class anymore, so the re-entrant load window is gone. The string `class_name:` keeps the association target resolved lazily by ActiveRecord.
- The prepend is guarded with `base.is_a?(Class)`: if the mixin is included into an intermediate `ActiveSupport::Concern`, the hook first fires with that module as `base`; the concern defers the include, so the hook fires again with the actual model class.
- The legacy `active_record_options[:establish_connection]` handling moves into the `OpenidRequest` mixin's `included` block (guarded with `respond_to?`; a no-op on doorkeeper 5.9.x, which no longer exposes `active_record_options`).
- The old `doorkeeper < 5.5` fallback branch (`Doorkeeper::AccessGrant.prepend ...`) is removed — the gemspec already requires `doorkeeper >= 5.5`, where `Mixins::AccessGrant` exists.

### Behavior note

Previously only the configured `Doorkeeper.config.access_grant_model` was prepended; now every model that includes doorkeeper's `Mixins::AccessGrant` gains the association. For documented setups these are equivalent, and the new behavior matches the include semantics doorkeeper itself uses since #1830.

## Testing

- New regression specs in `spec/lib/orm/active_record_spec.rb`:
  - the default access grant model has the `openid_request` association;
  - a namespaced custom model that includes doorkeeper's mixin (mirroring the #306 reporter's setup) is wired with the association. This spec fails under the old `on_load` implementation, since the custom model is wired only via the mixin hook.
  - The boot-time `NameError` itself cannot be reproduced inside the suite (ActiveRecord is already loaded by then), so the specs pin the wiring mechanism instead; the original crash was reproduced and verified fixed manually in a Rails app using the #306 reporter's setup.
- Full suite: **293 examples, 0 failures** (from a clean test DB), RuboCop clean.