### PR TITLE
Add `client_secret_expires_at` to Dynamic Client Registration response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#307] Fix `bundle exec rake server` for the test application
 - [#313] Move Configuration documentation from README to Wiki
 - [#312] Raise `Errors::MissingRequiredClaim` instead of silently dropping a blank REQUIRED ID Token claim (`iss`/`sub`/`aud`/`exp`/`iat`) in `IdToken#as_json`, which previously could emit a non-conformant ID Token (OIDC Core 1.0 §2). OPTIONAL claims such as `nonce`/`auth_time` are still omitted when blank
+- [#311] Include the REQUIRED `client_secret_expires_at` member (value `0`, never expires) in the Dynamic Client Registration response whenever a `client_secret` is issued (RFC 7591 §3.2.1 / OpenID Connect Dynamic Client Registration 1.0 §3.2)
 
 ## v1.10.1 (2026-06-03)
 

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -72,6 +72,10 @@ module Doorkeeper
         if registration.confidential_client?
           response[:client_secret] =
             doorkeeper_application.plaintext_secret || doorkeeper_application.secret
+          # RFC 7591 §3.2.1 / OIDC Dynamic Client Registration 1.0 §3.2:
+          # client_secret_expires_at is REQUIRED when a client_secret is issued.
+          # Doorkeeper secrets never expire, so the value is 0 (no expiration).
+          response[:client_secret_expires_at] = 0
         end
 
         response

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -37,6 +37,7 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         body = JSON.parse(response.body)
         expect(body).to eq({
           "client_secret" => doorkeeper_application.plaintext_secret || doorkeeper_application.secret,
+          "client_secret_expires_at" => 0,
           "client_id" => doorkeeper_application.uid,
           "client_id_issued_at" => doorkeeper_application.created_at.to_i,
           "redirect_uris" => redirect_uris,
@@ -67,6 +68,7 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         body = JSON.parse(response.body)
         expect(body["token_endpoint_auth_method"]).to eq("client_secret_basic")
         expect(body["client_secret"]).to be_present
+        expect(body["client_secret_expires_at"]).to eq(0)
       end
     end
 
@@ -87,6 +89,7 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         body = JSON.parse(response.body)
         expect(body["token_endpoint_auth_method"]).to eq("client_secret_post")
         expect(body["client_secret"]).to be_present
+        expect(body["client_secret_expires_at"]).to eq(0)
       end
     end
 
@@ -107,6 +110,7 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         body = JSON.parse(response.body)
         expect(body["token_endpoint_auth_method"]).to eq("none")
         expect(body).not_to have_key("client_secret")
+        expect(body).not_to have_key("client_secret_expires_at")
       end
     end
 


### PR DESCRIPTION
## Summary

When the Dynamic Client Registration endpoint issues a `client_secret` (i.e. for confidential clients), the registration response is **missing the REQUIRED `client_secret_expires_at` member**.

- **RFC 7591 §3.2.1** (Client Information Response): `client_secret_expires_at` is **REQUIRED if `client_secret` is issued**.
- **OpenID Connect Dynamic Client Registration 1.0 §3.2** (Client Registration Response) inherits the same requirement.
- The value `0` is the spec-defined sentinel meaning *"the secret does not expire"*.

Doorkeeper-issued client secrets never expire, so this PR emits `client_secret_expires_at: 0` whenever a `client_secret` is present in the response. Public clients (`token_endpoint_auth_method: none`) receive neither `client_secret` nor `client_secret_expires_at`, which is also correct per spec.

## Changes

- **`dynamic_client_registration_controller.rb`** — add `client_secret_expires_at: 0` to the response inside the `confidential_client?` branch.
- **`dynamic_client_registration_controller_spec.rb`**
  - Extend the strict full-body assertion (default/omitted auth method) with the new member
  - Assert `client_secret_expires_at == 0` for `client_secret_basic` and `client_secret_post`
  - Assert the key is **absent** for the public (`none`) client

## Spec conformance

| Spec | Requirement |
|------|-------------|
| [RFC 7591 §3.2.1](https://www.rfc-editor.org/rfc/rfc7591#section-3.2.1) | `client_secret_expires_at` REQUIRED if a `client_secret` is issued; `0` = never expires |
| [OIDC DCR 1.0 §3.2](https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse) | Same, for the OIDC registration response |

## Backward compatibility

Additive only — a new member appears in the registration response for confidential clients. No existing field changes value or shape. Clients that ignore unknown members are unaffected; spec-compliant clients that validated the response against the RFC now see a conformant body.

## Testing

```
bundle exec rspec spec/controllers/dynamic_client_registration_controller_spec.rb
# 20 examples, 0 failures

bundle exec rspec
# 291 examples, 0 failures
```
