### PR TITLE
Raise on blank REQUIRED ID Token claims instead of silently dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#305] Document the `auth_time_from_access_token` config option in the README (per-grant `auth_time`), clarifying that it only affects the ID Token `auth_time` claim and not `max_age` enforcement
 - [#307] Fix `bundle exec rake server` for the test application
 - [#313] Move Configuration documentation from README to Wiki
+- [#312] Raise `Errors::MissingRequiredClaim` instead of silently dropping a blank REQUIRED ID Token claim (`iss`/`sub`/`aud`/`exp`/`iat`) in `IdToken#as_json`, which previously could emit a non-conformant ID Token (OIDC Core 1.0 §2). OPTIONAL claims such as `nonce`/`auth_time` are still omitted when blank
 
 ## v1.10.1 (2026-06-03)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,3 +24,5 @@ en:
           signing_key_not_configured: 'Doorkeeper::OpenidConnect.configure.signing_key must resolve to at least one key.'
           issuer_not_configured: 'Doorkeeper::OpenidConnect.configure.issuer must resolve to a non-blank value.'
           dynamic_client_registration_unauthorized: 'Authorization required for client registration'
+          # ID Token claim error messages
+          missing_required_claim: 'Required ID Token claim `%{claim}` is missing or blank'

--- a/lib/doorkeeper/openid_connect/errors.rb
+++ b/lib/doorkeeper/openid_connect/errors.rb
@@ -12,6 +12,18 @@ module Doorkeeper
       # internal errors
       class InvalidConfiguration < OpenidConnectError; end
 
+      # Raised when a REQUIRED ID Token claim (OIDC Core §2: iss/sub/aud/exp/iat)
+      # resolves to a blank value, which would otherwise be silently dropped and
+      # produce a non-conformant ID Token.
+      class MissingRequiredClaim < OpenidConnectError
+        attr_reader :claim
+
+        def initialize(claim)
+          @claim = claim
+          super(I18n.translate("doorkeeper.openid_connect.errors.messages.missing_required_claim", claim: claim))
+        end
+      end
+
       class MissingConfiguration < OpenidConnectError
         def initialize
           super("Configuration for Doorkeeper OpenID Connect missing. Do you have doorkeeper_openid_connect initializer?")

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -5,6 +5,10 @@ module Doorkeeper
     class IdToken
       include ActiveModel::Validations
 
+      # OIDC Core 1.0 §2 — these claims are REQUIRED in every ID Token, so they
+      # must never be silently dropped when blank.
+      REQUIRED_CLAIMS = %i[iss sub aud exp iat].freeze
+
       attr_reader :nonce
 
       def initialize(access_token, nonce = nil, expires_in = Doorkeeper::OpenidConnect.configuration.expiration)
@@ -31,7 +35,19 @@ module Doorkeeper
       end
 
       def as_json(*_)
-        claims.reject { |_, value| value.nil? || value == "" }
+        claims.each_with_object({}) do |(key, value), result|
+          blank = value.nil? || value == ""
+
+          if blank
+            # A REQUIRED claim must never be silently omitted; surface the
+            # misconfiguration instead of issuing a non-conformant ID Token.
+            raise Errors::MissingRequiredClaim, key if REQUIRED_CLAIMS.include?(key)
+
+            next
+          end
+
+          result[key] = value
+        end
       end
 
       def as_jws_token

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -191,14 +191,42 @@ describe Doorkeeper::OpenidConnect::IdToken do
   end
 
   describe "#as_json" do
-    it "returns claims with nil values and empty strings removed" do
-      allow(subject).to receive_messages(issuer: nil, subject: "", audience: " ")
+    let(:valid_claims) do
+      {
+        iss: "dummy",
+        sub: user.id.to_s,
+        aud: access_token.application.uid,
+        exp: 180,
+        iat: 60,
+        nonce: "123456",
+      }
+    end
+
+    it "removes OPTIONAL claims with nil or empty values" do
+      # nonce / auth_time and custom claims are OPTIONAL, so blanks are dropped
+      # while the REQUIRED claims remain present.
+      allow(subject).to receive(:claims).and_return(
+        valid_claims.merge(nonce: nil, auth_time: "", custom: " "),
+      )
 
       json = subject.as_json
 
-      expect(json).not_to include :iss
-      expect(json).not_to include :sub
-      expect(json).to include :aud
+      expect(json).not_to include :nonce
+      expect(json).not_to include :auth_time
+      expect(json).to include :iss, :sub, :aud, :exp, :iat, :custom
+    end
+
+    Doorkeeper::OpenidConnect::IdToken::REQUIRED_CLAIMS.each do |claim|
+      [nil, ""].each do |blank|
+        it "raises MissingRequiredClaim when the REQUIRED #{claim} claim is #{blank.inspect}" do
+          allow(subject).to receive(:claims).and_return(valid_claims.merge(claim => blank))
+
+          expect { subject.as_json }
+            .to raise_error(Doorkeeper::OpenidConnect::Errors::MissingRequiredClaim) do |error|
+              expect(error.claim).to eq(claim)
+            end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

`IdToken#as_json` rejected **every** claim whose value was `nil` or `""`:

```ruby
def as_json(*_)
  claims.reject { |_, value| value.nil? || value == "" }
end
```

That blanket rule is correct for OPTIONAL claims (`nonce`, `auth_time`, custom claims), but for **REQUIRED** claims it silently produces a non-conformant ID Token. Per **[OIDC Core 1.0 §2](https://openid.net/specs/openid-connect-core-1_0.html#IDToken)**, `iss`, `sub`, `aud`, `exp`, and `iat` are REQUIRED in every ID Token. If e.g. a misconfigured `subject`/`issuer` block resolves to `nil`/`""`, the old behaviour emitted a signed ID Token with the claim **missing entirely** — relying parties would reject it (or worse, mis-handle it) with no signal at the issuer.

This PR makes the issuer fail fast: a blank REQUIRED claim now raises `Doorkeeper::OpenidConnect::Errors::MissingRequiredClaim`. OPTIONAL claims are still omitted when blank, exactly as before.

## Changes

- **`lib/doorkeeper/openid_connect/id_token.rb`**
  - Add `REQUIRED_CLAIMS = %i[iss sub aud exp iat].freeze` (OIDC Core §2)
  - Rewrite `#as_json` to raise `MissingRequiredClaim` when a REQUIRED claim is blank, otherwise drop blanks as before (behaviour for all non-blank / OPTIONAL claims is unchanged)
- **`lib/doorkeeper/openid_connect/errors.rb`**
  - Add `Errors::MissingRequiredClaim < OpenidConnectError`, carrying the offending `claim` name
- **`spec/lib/id_token_spec.rb`**
  - Invert the old "REQUIRED claims are silently removed" expectation
  - Assert OPTIONAL blank claims (`nonce`, `auth_time`, custom) are still dropped while REQUIRED claims remain
  - Assert each REQUIRED claim × `[nil, ""]` raises `MissingRequiredClaim` with the correct `claim`

## Spec conformance

| Spec | Requirement |
|------|-------------|
| [OIDC Core 1.0 §2](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) | `iss` / `sub` / `aud` / `exp` / `iat` are REQUIRED in the ID Token |

## Backward compatibility

**Behaviour change (intentional):** generating an ID Token with a blank REQUIRED claim now raises instead of returning a malformed token. This only triggers on a configuration that was *already* producing an invalid ID Token, so no correct configuration is affected.

**Note:** When this error is raised in the token endpoint path, it currently surfaces as a 500 since there is no `rescue` for this error class. A follow-up PR will map it to an appropriate OAuth error response (e.g. `server_error`).

`aud` is treated as REQUIRED per the spec. No token-generation path in the suite builds an ID Token without an audience, so the full suite stays green. If a downstream relies on issuing audience-less ID Tokens (non-conformant), that path would now raise — flagged here for reviewer awareness.

## Testing

```
bundle exec rspec spec/lib/id_token_spec.rb
# 23 examples, 0 failures

bundle exec rspec
# 301 examples, 0 failures
```
