### PR TITLE
Drop EOL Ruby 3.1, require Ruby >= 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby:
-          - "3.1"
           - "3.2"
           - "3.3"
           - "3.4"
@@ -35,10 +34,6 @@ jobs:
           - gemfiles/rails_8.0.gemfile
           - gemfiles/doorkeeper_master.gemfile
         exclude:
-          - ruby: 3.1
-            gemfile: gemfiles/rails_8.0.gemfile
-          - ruby: 3.1
-            gemfile: gemfiles/doorkeeper_master.gemfile
           - ruby: head
             gemfile: gemfiles/rails_7.0.gemfile
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ plugins:
   - rubocop-rails
   - rubocop-rspec
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   Exclude:
     # CI installs gems into ./vendor/bundle (ruby/setup-ruby bundler-cache),
     # which RuboCop would otherwise lint. Defining AllCops/Exclude overrides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Please add here
+- [#315] Drop support for EOL Ruby 3.1 (EOL 2025-03-25) and require Ruby `>= 3.2`. `i18n 1.15.0` uses the `Fiber[]` storage API which only exists on Ruby 3.2+, so the Ruby 3.1 CI row no longer loads; the matrix now tests Ruby 3.2 as the minimum
 - [#303] execute account selection even without owner, and `select_account_for_resource_owner` can now receive `nil` as the first argument.
 - [#304] allow handle auth_time per grant
 - [#305] Document the `auth_time_from_access_token` config option in the README (per-grant `auth_time`), clarifying that it only affects the ID Token `auth_time` claim and not `max_age` enforcement

--- a/doorkeeper-openid_connect.gemspec
+++ b/doorkeeper-openid_connect.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.add_runtime_dependency "doorkeeper", ">= 5.5", "< 6.0"
   spec.add_runtime_dependency "jwt", ">= 2.5"


### PR DESCRIPTION
Closes #314

[i18n 1.15.0](https://github.com/ruby-i18n/i18n/releases/tag/v1.15.0) (released 2026-06-17) uses the `Fiber[]` storage API, which only exists on Ruby 3.2+. Since Ruby 3.1 reached EOL on 2025-03-25, this drops it from the CI matrix rather than pinning `i18n`.

**Changes:**

- Remove `ruby: 3.1` from the CI matrix and its two `exclude` entries (Rails 8.0 / doorkeeper master)
- Bump `required_ruby_version` in the gemspec from `'>= 3.1'` to `'>= 3.2'`
- CHANGELOG entry
- Bump `TargetRubyVersion` in the .rubocop.yml from `3.1'` to `3.2'`
