### PR TITLE
Resolve `token_endpoint_auth_methods_supported` via Doorkeeper's client authentication registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [#320] Add first-class support for mounting the engine under multiple named scopes. Passing `as:` to `use_doorkeeper_openid_connect` (e.g. `scope :users, as: :users { use_doorkeeper_openid_connect as: :users }`) makes the discovery document resolve that namespace's own URL helpers (`users_oauth_*`), so each mount advertises its own endpoints instead of always pointing at the first mount. Single-mount setups are unaffected ([#192](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/192))
+- [#323] Resolve `token_endpoint_auth_methods_supported` from Doorkeeper's new client authentication methods registry when available, falling back to translating legacy `client_credentials_methods` on older Doorkeeper versions. The advertised methods remain unchanged: the `none` public-client pseudo-method is filtered out of discovery/registration responses and is only considered during dynamic client registration validation.
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/lib/doorkeeper/openid_connect/token_endpoint_auth_methods_supported_mixin.rb
+++ b/lib/doorkeeper/openid_connect/token_endpoint_auth_methods_supported_mixin.rb
@@ -3,15 +3,61 @@
 module Doorkeeper
   module OpenidConnect
     module TokenEndpointAuthMethodsSupportedMixin
+      # Maps Doorkeeper's legacy +client_credentials+ method identifiers to the
+      # RFC 8414 +token_endpoint_auth_methods_supported+ names. Only used on
+      # Doorkeeper versions that predate the client authentication methods
+      # registry (doorkeeper-gem/doorkeeper#1840); newer versions expose the
+      # RFC 8414 names directly via +client_authentication_methods+.
       CLIENT_CREDENTIALS_METHOD_MAPPING = {
         from_basic: "client_secret_basic",
         from_params: "client_secret_post",
       }.freeze
 
+      # The "none" pseudo-method (public clients, RFC 8414) is not a token
+      # endpoint authentication method advertised by the discovery metadata,
+      # and the dynamic client registration request appends it separately when
+      # validating public clients (see +PUBLIC_CLIENT_AUTH_METHOD+). The legacy
+      # mapping never produced it; the new registry includes it in the default
+      # +client_authentication+ set, so it is filtered out here to keep the
+      # advertised methods identical across both code paths.
+      PUBLIC_CLIENT_AUTH_METHOD_NAME = "none"
+
       def token_endpoint_auth_methods_supported
-        ::Doorkeeper.config.client_credentials_methods.filter_map do |method|
-          CLIENT_CREDENTIALS_METHOD_MAPPING[method]
-        end
+        config = doorkeeper_config
+
+        # Doorkeeper >= the release shipping the client authentication methods
+        # registry (doorkeeper-gem/doorkeeper#1840) exposes
+        # +client_authentication_methods+, returning
+        # +Doorkeeper::ClientAuthentication::Method+ objects whose +name+ is
+        # already the RFC 8414 identifier (e.g. :client_secret_basic), so no
+        # translation is needed. Older versions only expose
+        # +client_credentials_methods+, returning bare strategy symbols
+        # (:from_basic / :from_params) that the mapping above translates.
+        #
+        # TODO: once a Doorkeeper release ships +client_authentication_methods+,
+        # bump the gemspec Doorkeeper version constraint and remove the
+        # +respond_to?+ guard, the legacy +else+ branch, and the
+        # +CLIENT_CREDENTIALS_METHOD_MAPPING+ constant.
+        names =
+          if config.respond_to?(:client_authentication_methods)
+            config.client_authentication_methods.map { |method| method.name.to_s }
+          else
+            config.client_credentials_methods.filter_map do |method|
+              CLIENT_CREDENTIALS_METHOD_MAPPING[method]
+            end
+          end
+
+        names.reject { |name| name == PUBLIC_CLIENT_AUTH_METHOD_NAME }
+      end
+
+      private
+
+      # Indirection over +Doorkeeper.config+ so specs can supply a stand-in
+      # configuration (the registry API only exists on unreleased Doorkeeper)
+      # without replacing +Doorkeeper.config+ wholesale, which would otherwise
+      # leak into the per-example configuration reload.
+      def doorkeeper_config
+        ::Doorkeeper.config
       end
     end
   end

--- a/spec/lib/token_endpoint_auth_methods_supported_mixin_spec.rb
+++ b/spec/lib/token_endpoint_auth_methods_supported_mixin_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Doorkeeper::OpenidConnect::TokenEndpointAuthMethodsSupportedMixin do
+  subject(:host) do
+    Class.new do
+      include Doorkeeper::OpenidConnect::TokenEndpointAuthMethodsSupportedMixin
+    end.new
+  end
+
+  describe "#token_endpoint_auth_methods_supported" do
+    context "when Doorkeeper exposes the client authentication methods registry (doorkeeper#1840)" do
+      # Doorkeeper >= the release shipping the registry returns
+      # Doorkeeper::ClientAuthentication::Method objects whose `name` is already
+      # the RFC 8414 identifier. We emulate that surface with doubles so the new
+      # path can be exercised regardless of the installed Doorkeeper version
+      # (CI/local currently track a Doorkeeper that predates the registry).
+      def auth_method(name)
+        double("Doorkeeper::ClientAuthentication::Method", name: name)
+      end
+
+      let(:doorkeeper_config) do
+        instance = double("Doorkeeper::Config")
+        allow(instance).to receive(:client_authentication_methods).and_return(
+          [
+            auth_method(:client_secret_basic),
+            auth_method(:client_secret_post),
+            auth_method(:none),
+          ],
+        )
+        # The deprecated alias still exists on this Doorkeeper version; stub it
+        # so we can assert it is *not* consulted.
+        allow(instance).to receive(:client_credentials_methods)
+        instance
+      end
+
+      before { allow(host).to receive(:doorkeeper_config).and_return(doorkeeper_config) }
+
+      it "uses the registry's RFC 8414 names verbatim" do
+        expect(host.token_endpoint_auth_methods_supported)
+          .to eq %w[client_secret_basic client_secret_post]
+      end
+
+      it "excludes the public client (none) pseudo-method" do
+        expect(host.token_endpoint_auth_methods_supported).not_to include("none")
+      end
+
+      it "prefers the registry API over the deprecated client_credentials_methods alias" do
+        host.token_endpoint_auth_methods_supported
+
+        expect(doorkeeper_config).to have_received(:client_authentication_methods)
+        expect(doorkeeper_config).not_to have_received(:client_credentials_methods)
+      end
+
+      it "preserves the configured order of the remaining methods" do
+        allow(doorkeeper_config).to receive(:client_authentication_methods).and_return(
+          [auth_method(:client_secret_post), auth_method(:client_secret_basic)],
+        )
+
+        expect(host.token_endpoint_auth_methods_supported)
+          .to eq %w[client_secret_post client_secret_basic]
+      end
+    end
+
+    context "when the installed Doorkeeper predates the registry" do
+      # A bare double does not respond to `client_authentication_methods`, so
+      # the `respond_to?` guard must fall back to translating the legacy
+      # `client_credentials_methods` symbols through the mapping.
+      let(:doorkeeper_config) do
+        double("Doorkeeper::Config", client_credentials_methods: %i[from_basic from_params])
+      end
+
+      before { allow(host).to receive(:doorkeeper_config).and_return(doorkeeper_config) }
+
+      it "does not respond to the registry API in this emulation" do
+        expect(doorkeeper_config).not_to respond_to(:client_authentication_methods)
+      end
+
+      it "translates the legacy method identifiers via the mapping" do
+        expect(host.token_endpoint_auth_methods_supported)
+          .to eq %w[client_secret_basic client_secret_post]
+      end
+
+      it "ignores unknown legacy identifiers" do
+        allow(doorkeeper_config).to receive(:client_credentials_methods)
+          .and_return(%i[from_basic something_custom])
+
+        expect(host.token_endpoint_auth_methods_supported).to eq %w[client_secret_basic]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Refs #321. Companion to [doorkeeper#1840](https://github.com/doorkeeper-gem/doorkeeper/pull/1840) (client authentication methods registry).

Doorkeeper #1840 renames `client_credentials_methods` to `client_authentication_methods` and returns `Doorkeeper::ClientAuthentication::Method` objects whose `name` is already the RFC 8414 identifier (`:client_secret_basic`, `:client_secret_post`, etc.). This means the hardcoded `CLIENT_CREDENTIALS_METHOD_MAPPING` translation table is no longer needed — the mixin can read the names directly from the registry.

## What changed

`token_endpoint_auth_methods_supported` now branches on `respond_to?(:client_authentication_methods)`:

- **New Doorkeeper** (with registry) → `config.client_authentication_methods.map { |m| m.name.to_s }`, filtered to exclude `"none"`.
- **Old Doorkeeper** (pre-registry) → existing `client_credentials_methods` + `CLIENT_CREDENTIALS_METHOD_MAPPING` translation, unchanged.

`CLIENT_CREDENTIALS_METHOD_MAPPING` is retained for the legacy fallback and will be removed once the gemspec Doorkeeper constraint is bumped.

## Why `"none"` is excluded

Doorkeeper's default `client_authentication` includes `:none` (the public-client pseudo-method). The legacy `client_credentials` DSL also appends `:none` when converting. If advertised in discovery metadata, `"none"` would duplicate the `PUBLIC_CLIENT_AUTH_METHOD` already appended separately in dynamic client registration validation, and would break the existing discovery spec expectations (`%w[client_secret_basic client_secret_post]`). The advertised methods are unchanged from before this PR.

## Compatibility

The `respond_to?` guard keeps this a no-op on Doorkeeper versions that predate the registry. A TODO marks where to remove the guard, the legacy branch, and the mapping constant once a Doorkeeper release ships `client_authentication_methods`.

## Dependency

This PR is ready to merge once [doorkeeper#1840](https://github.com/doorkeeper-gem/doorkeeper/pull/1840) ships. The `respond_to?` guard ensures CI passes on current Doorkeeper (5.9.3) in the meantime. Locally tested against both the #1840 branch (new API path) and Doorkeeper 5.9.3 (legacy fallback path) — full suite green on both.
