### PR TITLE
Restore compatibility with the full `doorkeeper >= 5.5` range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
         exclude:
           - ruby: head
             gemfile: gemfiles/rails_7.0.gemfile
+        # Oldest supported Doorkeeper series — one Ruby each is enough to
+        # keep the `>= 5.5` gemspec constraint honest.
+        include:
+          - ruby: "3.4"
+            os: ubuntu-latest
+            gemfile: gemfiles/doorkeeper_5.5.gemfile
+          - ruby: "3.4"
+            os: ubuntu-latest
+            gemfile: gemfiles/doorkeeper_5.6.gemfile
+          - ruby: "3.4"
+            os: ubuntu-latest
+            gemfile: gemfiles/doorkeeper_5.7.gemfile
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- [#329] Restore compatibility with the full `doorkeeper >= 5.5` range declared in the gemspec ([#328](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/328)). Doorkeeper 5.5.x raised `NameError: uninitialized constant Doorkeeper::Orm::ActiveRecord::Mixins` at load time (the mixin file ships since 5.5.0 but is only autoloadable since 5.6.0 — it is now required explicitly when absent), and Doorkeeper 5.6/5.7 broke the discovery endpoint because `pkce_code_challenge_methods` only exists since 5.8.0 (the discovery response now falls back to `plain S256`, which is what those versions accept). CI now exercises the oldest supported Doorkeeper series via `gemfiles/doorkeeper_5.{5,6,7}.gemfile`
 - Please add here
 
 ## v1.10.4 (2026-07-07)

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -83,6 +83,10 @@ module Doorkeeper
       def code_challenge_methods_supported(doorkeeper)
         return unless doorkeeper.access_grant_model.pkce_supported?
 
+        # Doorkeeper < 5.8 has no `pkce_code_challenge_methods` option and
+        # always accepts both methods whenever PKCE is available.
+        return %w[plain S256] unless doorkeeper.respond_to?(:pkce_code_challenge_methods)
+
         doorkeeper.pkce_code_challenge_methods
       end
 

--- a/gemfiles/doorkeeper_5.5.gemfile
+++ b/gemfiles/doorkeeper_5.5.gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "doorkeeper", "~> 5.5.0"
+gem "rails", "~> 8.0.0"
+gem "rails-controller-testing"
+gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
+
+gemspec path: "../"

--- a/gemfiles/doorkeeper_5.6.gemfile
+++ b/gemfiles/doorkeeper_5.6.gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "doorkeeper", "~> 5.6.0"
+gem "rails", "~> 8.0.0"
+gem "rails-controller-testing"
+gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
+
+gemspec path: "../"

--- a/gemfiles/doorkeeper_5.7.gemfile
+++ b/gemfiles/doorkeeper_5.7.gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "doorkeeper", "~> 5.7.0"
+gem "rails", "~> 8.0.0"
+gem "rails-controller-testing"
+gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
+
+gemspec path: "../"

--- a/lib/doorkeeper/openid_connect/orm/active_record.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record.rb
@@ -48,6 +48,13 @@ module Doorkeeper
     end
   end
 
+  # Doorkeeper 5.5.x ships the very same mixin file, but only 5.6.0+
+  # registers an autoload for `Doorkeeper::Orm::ActiveRecord::Mixins`, so
+  # on 5.5.x the constant has to be resolved by requiring it explicitly.
+  unless defined?(Orm::ActiveRecord::Mixins::AccessGrant)
+    require "doorkeeper/orm/active_record/mixins/access_grant"
+  end
+
   Orm::ActiveRecord::Mixins::AccessGrant.singleton_class.prepend(
     OpenidConnect::Orm::ActiveRecord::AccessGrantExtension,
   )

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -164,7 +164,8 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       end
     end
 
-    context "when pkce_code_challenge_methods is configured with only S256" do
+    context "when pkce_code_challenge_methods is configured with only S256",
+            if: Doorkeeper::Config.method_defined?(:pkce_code_challenge_methods) do
       before { Doorkeeper.configure { pkce_code_challenge_methods %w[S256] } }
 
       it "return only S256 in code_challenge_methods_supported" do
@@ -175,7 +176,8 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       end
     end
 
-    context "when pkce_code_challenge_methods is configured with only plain" do
+    context "when pkce_code_challenge_methods is configured with only plain",
+            if: Doorkeeper::Config.method_defined?(:pkce_code_challenge_methods) do
       before { Doorkeeper.configure { pkce_code_challenge_methods %w[plain] } }
 
       it "return only plain in code_challenge_methods_supported" do

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -79,17 +79,24 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
 
       context "when pre_authorization is invalid" do
+        # Doorkeeper renders the error template with a 200 before 5.6.7;
+        # doorkeeper-gem/doorkeeper@6cd5cca2 started propagating the error
+        # status to the response.
+        let(:error_status) do
+          Gem::Version.new(Doorkeeper::VERSION::STRING) >= Gem::Version.new("5.6.7") ? :bad_request : :ok
+        end
+
         it "render error when client_id is missing" do
           authorize!(client_id: nil)
 
-          expect(response).to have_http_status(:bad_request)
+          expect(response).to have_http_status(error_status)
           expect(response).to render_template("doorkeeper/authorizations/error")
         end
 
         it "render error when response_type is missing" do
           authorize!(response_type: nil)
 
-          expect(response).to have_http_status(:bad_request)
+          expect(response).to have_http_status(error_status)
           expect(response).to render_template("doorkeeper/authorizations/error")
         end
       end

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -434,7 +434,10 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
 
     context "when Scopes#allowed is unavailable (doorkeeper < 5.8.1)" do
       before do
-        Doorkeeper.configuration.scopes.singleton_class.send(:undef_method, :allowed)
+        # On doorkeeper < 5.8.1 the method is genuinely absent, so there is
+        # nothing to undefine — the fallback is then exercised natively.
+        scopes = Doorkeeper.configuration.scopes
+        scopes.singleton_class.send(:undef_method, :allowed) if scopes.respond_to?(:allowed)
       end
 
       it "still drops the unconfigured scopes via plain intersection" do


### PR DESCRIPTION
Fixes #328

## Summary

The gemspec declares `doorkeeper >= 5.5, < 6.0`, but in practice the gem only worked on Doorkeeper `5.8+`. This PR restores support for the whole declared range **without pinning the floor up to 5.8** — keeping the gem usable for large downstreams (GitLab, Mastodon, …) that track older Doorkeeper series.

The gap turned out to be much smaller than it looks: no polyfills, no vendored code — three narrow capability guards plus a couple of version-tolerant specs.

Verified locally:

| Doorkeeper | Result |
| --- | --- |
| 5.5.4 | 305 examples, **0 failures** |
| 5.6.7 | 305 examples, **0 failures** |
| 5.7.1 | 305 examples, **0 failures** |
| 5.9.3 | 307 examples, **0 failures** (no regression) |

RuboCop clean.

## The breakages, and why the fixes are safe

### 1. Doorkeeper 5.5.x — `NameError` at load time

`lib/doorkeeper/openid_connect/orm/active_record.rb` referenced `Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant` at require time, which raised `NameError` on 5.5.x and took the whole gem (and suite) down.

The key finding: **the mixin file has shipped since Doorkeeper 5.5.0**, and the `Doorkeeper::AccessGrant` model has always included it. What 5.5 lacks is only the *autoload registration* for the `Mixins` namespace — that was added in 5.6.0's rewrite of `orm/active_record.rb`. So this isn't a missing API; the constant simply isn't autoloadable yet.

Fix: require the file explicitly when the constant isn't already defined (a no-op on 5.6+, where it's autoloaded):

```ruby
unless defined?(Orm::ActiveRecord::Mixins::AccessGrant)
  require "doorkeeper/orm/active_record/mixins/access_grant"
end
```

The `included`-callback wiring introduced in v1.10.3 (#308) works unchanged on 5.5, since the mixin's `included do` block only runs at the host model's own load time.

### 2. Doorkeeper 5.6 / 5.7 — `pkce_code_challenge_methods` `NoMethodError`

`DiscoveryController#code_challenge_methods_supported` called `doorkeeper.pkce_code_challenge_methods`, which only exists since Doorkeeper 5.8.0 (doorkeeper-gem/doorkeeper@e39cd62c[^pkce]).

Fix: fall back to `%w[plain S256]` when the option is absent:

```ruby
return %w[plain S256] unless doorkeeper.respond_to?(:pkce_code_challenge_methods)
```

This is semantically exact, not a guess: `%w[plain S256]` is both the 5.8 default **and** what pre-5.8 Doorkeeper actually accepts whenever PKCE is available — it's also the value this gem itself hardcoded until it switched to delegation in `42d90dd`.

### 3. Specs — version-tolerant expectations

Three spec-only adjustments so the suite reflects each version's real behavior:

- **`pkce_code_challenge_methods` contexts** are skipped where the config option doesn't exist (`if: Doorkeeper::Config.method_defined?(...)`).
- **The `Scopes#allowed` fallback test** previously simulated old Doorkeeper by `undef_method(:allowed)`; on genuinely-old Doorkeeper there's nothing to undefine, so it now guards on `respond_to?(:allowed)`. (`Scopes#allowed` landed in 5.8.1, [doorkeeper-gem/doorkeeper@e2b8dabb][^allowed]; the production guard in `dynamic_registration_request.rb` was already correct — only the spec broke.)
- **Invalid pre-authorization specs** expect `200` before Doorkeeper 5.6.7 and `400` from 5.6.7 on, since error-status propagation landed in [doorkeeper-gem/doorkeeper@6cd5cca2][^status].

## CI

Adds `gemfiles/doorkeeper_5.{5,6,7}.gemfile` and three matrix rows (single Ruby each) so the declared `>= 5.5` floor stays honest going forward. The 5.8+ range is already covered by the existing `rails_*` and `doorkeeper_master` gemfiles.

[^pkce]: https://github.com/doorkeeper-gem/doorkeeper/commit/e39cd62c
[^allowed]: https://github.com/doorkeeper-gem/doorkeeper/commit/e2b8dabb
[^status]: https://github.com/doorkeeper-gem/doorkeeper/commit/6cd5cca2
