### PR TITLE
Use Doorkeeper's `application_class` config for dynamic client registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#332] Fix `grant_types_supported` in the discovery document (and the grant types accepted by Dynamic Client Registration validation) listing `refresh_token` twice when it is both included in `grant_flows` explicitly and enabled via `use_refresh_token` — the same duplication doorkeeper fixed for its RFC 8414 metadata in [doorkeeper#1847](https://github.com/doorkeeper-gem/doorkeeper/pull/1847)
 - [#333] RFC 9207 companion for [doorkeeper#1849](https://github.com/doorkeeper-gem/doorkeeper/pull/1849): emit the `iss` parameter (identical to the ID Token `iss` claim) on `id_token` / `id_token token` authorization responses and on OIDC error redirects, advertise `authorization_response_iss_parameter_supported` in the discovery document, and warn at boot when the OpenID Connect and Doorkeeper `issuer` settings diverge. No behavior change until Doorkeeper is configured with an `issuer`
 - [#310] Add escape hatches via `id_token_class` and `user_info_class` for advanced customization of the ID Token and UserInfo response objects.
+- [#341] Fix dynamic client registration to use `Doorkeeper.configuration.application_model` instead of `Doorkeeper::Application` directly, so that the `application_class` configuration is respected when registering clients.
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -13,7 +13,7 @@ module Doorkeeper
           return
         end
 
-        client = Doorkeeper::Application.create!(application_params(registration))
+        client = Doorkeeper.configuration.application_model.create!(application_params(registration))
         render json: registration_response(client, registration), status: :created
       rescue ActiveRecord::RecordInvalid => e
         render json: { error: "invalid_client_params", error_description: e.record.errors.full_messages.join(", ") },

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -502,5 +502,36 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
         })
       end
     end
+
+    context "when a custom application class is configured" do
+      before do
+        stub_const(
+          "MyOauthApp",
+          Class.new(Doorkeeper::Application) do
+            before_create { self.name = name.upcase }
+          end,
+        )
+        Doorkeeper.configure do
+          default_scopes :public
+          application_class "MyOauthApp"
+        end
+      end
+
+      it "creates a client with configured custom class" do
+        expect do
+          post :register, params: {
+            client_name: "dummy_client",
+            redirect_uris: redirect_uris,
+            scope: "public",
+          }
+        end.to change(MyOauthApp, :count).by(1)
+        expect(response.status).to eq 201
+
+        body = JSON.parse(response.body)
+        my_oauth_app = MyOauthApp.find_by(uid: body["client_id"])
+        expect(my_oauth_app).to be_present
+        expect(my_oauth_app.name).to eq "DUMMY_CLIENT"
+      end
+    end
   end
 end


### PR DESCRIPTION
The dynamic client registration controller called `Doorkeeper::Application.create!` directly instead of going through
`Doorkeeper.configuration.application_model`, ignoring any class configured via Doorkeeper's `application_class` option. This change fixes that.

See also: https://github.com/doorkeeper-gem/doorkeeper/blob/f84797d265f1c4e8de85baf05e54aa5edbcdea74/app/controllers/doorkeeper/applications_controller.rb#L30-L31