### PR TITLE
ci: pin changelog-enforcer to v3.7.0 (node24 build)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
 - package-ecosystem: bundler
   directory: "/"
   schedule:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,3 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: dangoslen/changelog-enforcer@v3.7.0
+      with:
+        # Dependabot PRs are labeled "dependencies" automatically and don't
+        # need a changelog entry; "Skip-Changelog" keeps a manual escape hatch.
+        skipLabels: "Skip-Changelog,dependencies"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,4 +12,4 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: dangoslen/changelog-enforcer@v3
+    - uses: dangoslen/changelog-enforcer@v3.7.0

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,8 +12,8 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: dangoslen/changelog-enforcer@v3.7.0
-      with:
-        # Dependabot PRs are labeled "dependencies" automatically and don't
-        # need a changelog entry; "Skip-Changelog" keeps a manual escape hatch.
-        skipLabels: "Skip-Changelog,dependencies"
+      - uses: dangoslen/changelog-enforcer@v3.7.0
+        with:
+          # Dependabot PRs are labeled "dependencies" automatically and don't
+          # need a changelog entry; "Skip-Changelog" keeps a manual escape hatch.
+          skipLabels: "Skip-Changelog,dependencies"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#333] RFC 9207 companion for [doorkeeper#1849](https://github.com/doorkeeper-gem/doorkeeper/pull/1849): emit the `iss` parameter (identical to the ID Token `iss` claim) on `id_token` / `id_token token` authorization responses and on OIDC error redirects, advertise `authorization_response_iss_parameter_supported` in the discovery document, and warn at boot when the OpenID Connect and Doorkeeper `issuer` settings diverge. No behavior change until Doorkeeper is configured with an `issuer`
 - [#310] Add escape hatches via `id_token_class` and `user_info_class` for advanced customization of the ID Token and UserInfo response objects.
 - [#341] Fix dynamic client registration to use `Doorkeeper.configuration.application_model` instead of `Doorkeeper::Application` directly, so that the `application_class` configuration is respected when registering clients.
+- [#342] CI: pin `dangoslen/changelog-enforcer` to `v3.7.0` so the changelog job runs on the Node 24 build of the action. The floating `v3` tag still points at a `node20` build, which triggers GitHub's [Node 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on every run
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [#333] RFC 9207 companion for [doorkeeper#1849](https://github.com/doorkeeper-gem/doorkeeper/pull/1849): emit the `iss` parameter (identical to the ID Token `iss` claim) on `id_token` / `id_token token` authorization responses and on OIDC error redirects, advertise `authorization_response_iss_parameter_supported` in the discovery document, and warn at boot when the OpenID Connect and Doorkeeper `issuer` settings diverge. No behavior change until Doorkeeper is configured with an `issuer`
 - [#310] Add escape hatches via `id_token_class` and `user_info_class` for advanced customization of the ID Token and UserInfo response objects.
 - [#341] Fix dynamic client registration to use `Doorkeeper.configuration.application_model` instead of `Doorkeeper::Application` directly, so that the `application_class` configuration is respected when registering clients.
-- [#342] CI: pin `dangoslen/changelog-enforcer` to `v3.7.0` so the changelog job runs on the Node 24 build of the action. The floating `v3` tag still points at a `node20` build, which triggers GitHub's [Node 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on every run
+- [#342] CI: pin `dangoslen/changelog-enforcer` to `v3.7.0` so the changelog job runs on the Node 24 build of the action. The floating `v3` tag still points at a `node20` build, which triggers GitHub's [Node 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on every run. Dependabot now also watches GitHub Actions versions, and PRs labeled `dependencies` or `Skip-Changelog` are exempt from changelog enforcement
 - Add entry here
 
 ## v1.10.5 (2026-07-09)


### PR DESCRIPTION
## Why

Every run of the "Changelog verifier" job currently emits GitHub's Node 20 deprecation warning:

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

The workflow references the floating `v3` tag of `dangoslen/changelog-enforcer`, and that tag still resolves to a build whose `action.yml` declares `using: 'node20'`. The `v3.7.0` release is built with `using: 'node24'`, so pinning to it makes the warning go away (verified by comparing `action.yml` at both refs).

## What changed

Commit 1 — pin the action:

- `.github/workflows/changelog.yml`: `dangoslen/changelog-enforcer@v3` → `@v3.7.0`

Commit 2 — keep it (and the other actions) up to date going forward:

- `.github/dependabot.yml`: add a `github-actions` ecosystem entry, so future action releases (including the one that eventually drops node24) arrive as Dependabot PRs instead of deprecation warnings
- `.github/workflows/changelog.yml`: set `skipLabels: "Skip-Changelog,dependencies"`. Dependabot labels its PRs `dependencies` automatically (see e.g. #234), so its bumps pass the changelog check without an entry; `Skip-Changelog` (the action's default skip label) is kept as a manual escape hatch — note that label doesn't exist in the repo yet, create it if wanted
- `CHANGELOG.md`: entry added as `[#342]`

No behavior change to the enforcement of regular PRs — same major version of the action, just an exact pin to the release that carries the node24 runtime, plus the skip-label list.