### PR TITLE
Tests only - Add specs for uncovered branches reachable on current Doorkeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#310] Add escape hatches via `id_token_class` and `user_info_class` for advanced customization of the ID Token and UserInfo response objects.
 - [#341] Fix dynamic client registration to use `Doorkeeper.configuration.application_model` instead of `Doorkeeper::Application` directly, so that the `application_class` configuration is respected when registering clients.
 - [#342] CI: pin `dangoslen/changelog-enforcer` to `v3.7.0` so the changelog job runs on the Node 24 build of the action. The floating `v3` tag still points at a `node20` build, which triggers GitHub's [Node 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on every run. Dependabot now also watches GitHub Actions versions, and PRs labeled `dependencies` or `Skip-Changelog` are exempt from changelog enforcement
+- [#346] Add specs for previously uncovered branches that are reachable on current Doorkeeper
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -845,4 +845,71 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       expect(assigns(:pre_auth).nonce).to eq "123456"
     end
   end
+
+  context "with the implicit OIDC flows enabled" do
+    before do
+      allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(["implicit_oidc"])
+    end
+
+    def implicit_params(params = {})
+      {
+        response_type: "id_token",
+        current_user: user.id,
+        client_id: application.uid,
+        scope: default_scopes,
+        redirect_uri: application.redirect_uri,
+        nonce: "123456",
+        state: "somestate",
+      }.merge(params)
+    end
+
+    def redirected_fragment
+      expect(response).to be_redirect
+      expect(response.location).to start_with "#{application.redirect_uri}#"
+      Rack::Utils.parse_query(URI.parse(response.location).fragment)
+    end
+
+    describe "#create" do
+      it "issues an ID token via the fragment for response_type=id_token" do
+        post :create, params: implicit_params
+
+        fragment = redirected_fragment
+        expect(fragment["state"]).to eq "somestate"
+
+        payload, header = JWT.decode(fragment["id_token"], nil, false)
+        expect(header["alg"]).to eq "RS256"
+        expect(payload["iss"]).to eq "dummy"
+        expect(payload["nonce"]).to eq "123456"
+        expect(payload["aud"]).to eq application.uid
+      end
+
+      it "issues an access token alongside the ID token for response_type=id_token token" do
+        post :create, params: implicit_params(response_type: "id_token token")
+
+        fragment = redirected_fragment
+        expect(fragment["access_token"]).to be_present
+        expect(fragment["token_type"]).to eq "Bearer"
+        expect(fragment["state"]).to eq "somestate"
+
+        # OIDC Core 1.0 §3.2.2.9: when an access token is issued with the ID
+        # Token from the authorization endpoint, at_hash is REQUIRED.
+        payload, = JWT.decode(fragment["id_token"], nil, false)
+        expect(payload["nonce"]).to eq "123456"
+        expect(payload["at_hash"]).to be_present
+      end
+    end
+
+    describe "#destroy" do
+      it "denies response_type=id_token with access_denied in the fragment" do
+        expect do
+          delete :destroy, params: implicit_params
+        end.not_to change(Doorkeeper::AccessToken, :count)
+
+        fragment = redirected_fragment
+        expect(fragment["error"]).to eq "access_denied"
+        expect(fragment["state"]).to eq "somestate"
+        expect(fragment).not_to have_key "id_token"
+      end
+    end
+  end
 end

--- a/spec/lib/claims/normal_claim_spec.rb
+++ b/spec/lib/claims/normal_claim_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Doorkeeper::OpenidConnect::Claims::NormalClaim do
+  subject { described_class.new(name: "name", scope: :profile, generator: generator) }
+
+  let(:generator) { ->(user) { user.name } }
+
+  it "exposes the generator" do
+    expect(subject.generator).to eq generator
+  end
+
+  describe "#type" do
+    it "is :normal" do
+      expect(subject.type).to eq :normal
+    end
+  end
+end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -43,6 +43,44 @@ describe Doorkeeper::OpenidConnect, "configuration" do
         end
       end.not_to raise_error
     end
+
+    it "fails validation if user_info is missing as_json" do
+      # ActiveSupport defines `#as_json` on Object, so the method has to be
+      # undefined explicitly to model a class that does not fulfill the contract.
+      stub_const("CustomUserInfo", Class.new { undef_method :as_json })
+
+      expect do
+        described_class.configure do
+          user_info_class "CustomUserInfo"
+        end
+      end.to raise_error Doorkeeper::OpenidConnect::Errors::InvalidConfiguration,
+                         "The configured user_info_class (CustomUserInfo) is missing the following " \
+                         "required methods: as_json"
+    end
+  end
+
+  describe ".configuration" do
+    it "raises MissingConfiguration when the gem has not been configured" do
+      saved = described_class.instance_variable_get(:@config)
+      described_class.instance_variable_set(:@config, nil)
+
+      expect do
+        described_class.configuration
+      end.to raise_error Doorkeeper::OpenidConnect::Errors::MissingConfiguration,
+                         /doorkeeper_openid_connect initializer/
+    ensure
+      described_class.instance_variable_set(:@config, saved)
+    end
+  end
+
+  describe "jws_public_key" do
+    it "warns that the setting is no longer needed" do
+      expect do
+        described_class.configure do
+          jws_public_key "public_key"
+        end
+      end.to output(/DEPRECATION WARNING: `jws_public_key` is not needed anymore/).to_stderr
+    end
   end
 
   describe "jws_private_key" do

--- a/spec/lib/id_token_token_spec.rb
+++ b/spec/lib/id_token_token_spec.rb
@@ -65,5 +65,21 @@ describe Doorkeeper::OpenidConnect::IdTokenToken do
         expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA512))
       end
     end
+
+    context "when signing_algorithm is HS384" do
+      before { configure_doorkeeper("the_greatest_secret_key", :HS384) }
+
+      it "uses SHA-384" do
+        expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA384))
+      end
+    end
+
+    context "when the signing algorithm name carries no digest length (e.g. EdDSA)" do
+      before { configure_doorkeeper("the_greatest_secret_key", :EdDSA) }
+
+      it "falls back to SHA-256" do
+        expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA256))
+      end
+    end
   end
 end

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -7,6 +7,18 @@ describe Doorkeeper::OpenidConnect do
     it "returns the signing_algorithm as an uppercase symbol" do
       expect(subject.signing_algorithm).to eq :RS256
     end
+
+    context "when the configured signing_algorithm is callable" do
+      before do
+        described_class.configure do
+          signing_algorithm -> { "rs384" }
+        end
+      end
+
+      it "calls it and returns the result as an uppercase symbol" do
+        expect(subject.signing_algorithm).to eq :RS384
+      end
+    end
   end
 
   describe ".signing_key" do

--- a/spec/lib/orm/active_record_spec.rb
+++ b/spec/lib/orm/active_record_spec.rb
@@ -40,5 +40,26 @@ describe "Doorkeeper::OpenidConnect ActiveRecord ORM integration" do
       expect(association.options[:class_name])
         .to eq(Doorkeeper::OpenidConnect.configuration.open_id_request_class)
     end
+
+    it "defers wiring when the mixin is included via an intermediate concern" do
+      # `AccessGrantExtension#included` first fires with the intermediate
+      # module itself (not a class); the concern machinery re-fires it with
+      # the model class once that includes the concern, and only then must
+      # the association be wired.
+      intermediate = Module.new do
+        extend ActiveSupport::Concern
+        include Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant
+      end
+
+      expect(intermediate.ancestors).not_to include(Doorkeeper::OpenidConnect::AccessGrant)
+
+      custom_model = Class.new(ApplicationRecord) do
+        self.table_name = "oauth_access_grants"
+        include intermediate
+      end
+
+      expect(custom_model.ancestors).to include(Doorkeeper::OpenidConnect::AccessGrant)
+      expect(custom_model.reflect_on_association(:openid_request)).not_to be_nil
+    end
   end
 end

--- a/spec/lib/routes_spec.rb
+++ b/spec/lib/routes_spec.rb
@@ -42,6 +42,54 @@ describe Doorkeeper::OpenidConnect::Rails::Routes, type: :routing do
     end
   end
 
+  describe "customizing the routes with a block" do
+    after { Rails.application.reload_routes! }
+
+    it "maps custom controllers via the controllers option" do
+      stub_const("CustomUserinfoController", Class.new(ApplicationController))
+
+      Rails.application.routes.draw do
+        use_doorkeeper_openid_connect do
+          controllers userinfo: "custom_userinfo"
+        end
+      end
+
+      expect(get: "oauth/userinfo").to route_to(
+        controller: "custom_userinfo",
+        action: "show",
+      )
+    end
+
+    it "does not map controllers listed in skip_controllers" do
+      # Keep the discovery routes: a draw ending up with an empty route set
+      # never calls Journey's add_route, which is the only place the memoized
+      # recognition cache is invalidated (actionpack 8.0.5), so recognition
+      # would still see the previously drawn routes.
+      Rails.application.routes.draw do
+        use_doorkeeper_openid_connect do
+          skip_controllers :userinfo
+        end
+      end
+
+      expect(get: "oauth/userinfo").not_to be_routable
+      expect(get: ".well-known/openid-configuration").to route_to(
+        controller: "doorkeeper/openid_connect/discovery",
+        action: "provider",
+      )
+    end
+
+    it "renames route helpers via the as option" do
+      Rails.application.routes.draw do
+        use_doorkeeper_openid_connect do
+          as userinfo: :custom_userinfo
+        end
+      end
+
+      expect(Rails.application.routes.url_helpers.oauth_custom_userinfo_url(host: "example.com"))
+        .to eq "http://example.com/oauth/userinfo"
+    end
+  end
+
   describe "dynamic_client_registration" do
     it "doesn't map by default" do
       Rails.application.reload_routes!


### PR DESCRIPTION
### Summary

This PR closes the test coverage gaps that correspond to real, reachable behavior on the current Doorkeeper release (5.9.x). Line coverage goes from 96.69% → 98.70%, branch coverage from 90.96% → 95.18%, with 15 new examples across 7 files.

### What's covered

- **Implicit OIDC flow E2E** (`AuthorizationsController`): approve `response_type=id_token` and `id_token token` (fragment redirect, nonce, aud, `at_hash` per OIDC Core §3.2.2.9) and deny via `#destroy` (`access_denied` in the fragment). Covers `IdToken`/`IdTokenToken` request strategies, `IdTokenRequest#deny`, and `IdTokenResponse#redirectable?`.
- **Callable `signing_algorithm`** configuration value.
- **Config validation**: `user_info_class` missing `as_json` → `InvalidConfiguration`; `jws_public_key` deprecation warning; `MissingConfiguration` when the gem is unconfigured.
- **`at_hash` digest selection**: HS384 (SHA-384) and fallback to SHA-256 for algorithms without a digest-length suffix (e.g. EdDSA).
- **`NormalClaim`** `#generator` / `#type` accessors.
- **Routes DSL block**: `controllers`, `skip_controllers`, and `as` options.
- **`AccessGrant` mixin** wiring deferred through an intermediate `ActiveSupport::Concern` (the non-Class branch of the `included` hook).

### What's intentionally left uncovered

The remaining uncovered lines/branches are old-Doorkeeper version compatibility paths (`id_token_request.rb:18`, `authorization/code.rb:18-20`, `password_access_token_request.rb:15-17`, `active_record.rb:55`, `openid_request.rb:22-23,33`) that are unreachable on Doorkeeper 5.9.x. Covering them would require stubbing `Gem.loaded_specs`, which is not representative of real behavior.

>[!NOTE]
>The `skip_controllers` routing spec keeps the discovery routes drawn rather than skipping all controllers, because `Journey::Routes#clear` does not invalidate the memoized recognition cache in actionpack 8.0.5 — only `add_route` does. An empty redraw leaves stale recognition behind. This has been reported upstream as [rails/rails#58170](https://github.com/rails/rails/pull/58170).