### PR TITLE
Omit symmetric (oct) keys from the JWKS endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#341] Fix dynamic client registration to use `Doorkeeper.configuration.application_model` instead of `Doorkeeper::Application` directly, so that the `application_class` configuration is respected when registering clients.
 - [#342] CI: pin `dangoslen/changelog-enforcer` to `v3.7.0` so the changelog job runs on the Node 24 build of the action. The floating `v3` tag still points at a `node20` build, which triggers GitHub's [Node 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on every run. Dependabot now also watches GitHub Actions versions, and PRs labeled `dependencies` or `Skip-Changelog` are exempt from changelog enforcement
 - [#346] Add specs for previously uncovered branches that are reachable on current Doorkeeper
+- [#347] Omit symmetric (`oct`) keys from the JWKS endpoint when signing with an HMAC algorithm — an HMAC JWK is the shared secret, not a verification key (RFC 7517)
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -43,12 +43,7 @@ require "doorkeeper/openid_connect/rails/routes"
 module Doorkeeper
   module OpenidConnect
     def self.signing_algorithm
-      algo = if configuration.signing_algorithm.respond_to?(:call)
-               configuration.signing_algorithm.call
-             else
-               configuration.signing_algorithm
-             end
-      algo.to_s.upcase.to_sym
+      unwrap_callable(configuration.signing_algorithm).to_s.upcase.to_sym
     end
 
     # Returns the active signing key used when issuing new ID tokens.
@@ -74,9 +69,16 @@ module Doorkeeper
     # Returns every configured key formatted for inclusion in the JWKS
     # response, with `use` and `alg` already merged. The discovery
     # controller renders this verbatim inside `keys: [...]`.
+    #
+    # Symmetric (`kty: "oct"`) keys are dropped: a JWKS is meant to publish
+    # verification keys, but an HMAC JWK *is* the shared secret and cannot
+    # serve as a public verification key, so it does not belong in a public
+    # discovery document (RFC 7517). HMAC (HS256/HS384/HS512) configurations
+    # therefore yield an empty `keys` array here.
     def self.signing_keys_normalized
       alg = signing_algorithm
-      signing_keys.map { |jwk| jwk.export.merge(use: "sig", alg: alg) }
+      exported = signing_keys.map(&:export).reject { |jwk| jwk[:kty] == "oct" }
+      exported.map { |jwk| jwk.merge(use: "sig", alg: alg) }
     end
 
     def self.unwrap_callable(value)

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -491,7 +491,14 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
     context "when using an HMAC key" do
       before { configure_hmac }
 
-      it_behaves_like "a key response", expected_parameters: %i[kty kid use alg]
+      it "returns an empty JWKS" do
+        subject
+        data = JSON.parse(response.body)
+
+        # An HMAC JWK is the shared secret itself, not a public verification
+        # key, so it is omitted from the published JWKS (RFC 7517).
+        expect(data["keys"]).to eq []
+      end
     end
 
     context "when multiple signing keys are configured" do

--- a/spec/lib/openid_connect_spec.rb
+++ b/spec/lib/openid_connect_spec.rb
@@ -261,6 +261,16 @@ describe Doorkeeper::OpenidConnect do
         expect(normalized).to all(include(use: "sig", alg: :RS256))
       end
     end
+
+    context "when signing with an HMAC algorithm" do
+      before { configure_hmac }
+
+      it "omits symmetric (oct) keys" do
+        # An HMAC JWK is the shared secret itself, not a public verification
+        # key, so it has no place in a public JWKS (RFC 7517).
+        expect(subject.signing_keys_normalized).to eq []
+      end
+    end
   end
 
   describe ".signing_key_normalized" do


### PR DESCRIPTION
A JWKS publishes *verification* keys, but an HMAC JWK **is** the shared secret itself: relying parties cannot use it to verify tokens the way they use a public key, so it does not belong in a public discovery document (RFC 7517).

`signing_keys_normalized` now drops `kty: "oct"` entries, so `/oauth/discovery/keys` returns an empty `keys` array for HMAC (HS256/HS384/HS512) configurations.

Note: on `jwt >= 2.5` the exported `oct` JWK already omits the secret material (`k`), so the previous behavior published a useless-but-harmless stub entry, not the secret. This change is spec hygiene — an empty `keys` array is the honest answer for a symmetric configuration — not a vulnerability fix.

Also folds in a small tidy-up: `signing_algorithm` now resolves callables through the existing `unwrap_callable` helper instead of an inline `respond_to?(:call)` branch (keeps the module within RuboCop's `Metrics/ModuleLength` default after the rebase).