### PR TITLE
Harden the OIDC authorization endpoint against malformed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - [#342] CI: pin `dangoslen/changelog-enforcer` to `v3.7.0` so the changelog job runs on the Node 24 build of the action. The floating `v3` tag still points at a `node20` build, which triggers GitHub's [Node 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on every run. Dependabot now also watches GitHub Actions versions, and PRs labeled `dependencies` or `Skip-Changelog` are exempt from changelog enforcement
 - [#346] Add specs for previously uncovered branches that are reachable on current Doorkeeper
 - [#347] Omit symmetric (`oct`) keys from the JWKS endpoint when signing with an HMAC algorithm — an HMAC JWK is the shared secret, not a verification key (RFC 7517)
+- [#348] Authorization endpoint hardening:
+  - Treat a malformed, non-scalar `max_age` parameter (e.g. `max_age[]=1`) as absent instead of returning a 500 (OIDC Core §3.1.2.1)
+  - Build the `prompt=login` / `prompt=select_account` return URL from a copy of `request.query_parameters` instead of mutating the shared, memoized hash
+  - Redirect only OAuth/OIDC protocol errors (grouped under the new `Errors::AuthorizationError`) to the client; internal errors like `Errors::InvalidConfiguration` now propagate as a 500 instead of leaking as a spurious authorization error
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/lib/doorkeeper/openid_connect/errors.rb
+++ b/lib/doorkeeper/openid_connect/errors.rb
@@ -30,16 +30,22 @@ module Doorkeeper
         end
       end
 
+      # Errors that translate into an OAuth 2.0 / OIDC error response reported
+      # back to the client via a redirect, as opposed to the internal
+      # server-side errors above (a misconfigured server must surface as a 500,
+      # not be leaked to the client as a bogus authorization error).
+      class AuthorizationError < OpenidConnectError; end
+
       # OAuth 2.0 errors
       # https://tools.ietf.org/html/rfc6749#section-4.1.2.1
-      class InvalidRequest < OpenidConnectError; end
+      class InvalidRequest < AuthorizationError; end
 
       # OpenID Connect 1.0 errors
       # http://openid.net/specs/openid-connect-core-1_0.html#AuthError
-      class LoginRequired < OpenidConnectError; end
-      class ConsentRequired < OpenidConnectError; end
-      class InteractionRequired < OpenidConnectError; end
-      class AccountSelectionRequired < OpenidConnectError; end
+      class LoginRequired < AuthorizationError; end
+      class ConsentRequired < AuthorizationError; end
+      class InteractionRequired < AuthorizationError; end
+      class AccountSelectionRequired < AuthorizationError; end
     end
   end
 end

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -68,7 +68,11 @@ module Doorkeeper
             handle_oidc_max_age_param!(owner) if oidc_authorization_request?
             handle_oidc_prompt_param!(owner)
           end
-        rescue Errors::OpenidConnectError => e
+        rescue Errors::AuthorizationError => e
+          # Only OAuth/OIDC protocol errors are reported to the client. Internal
+          # errors (e.g. Errors::InvalidConfiguration from an unconfigured
+          # callback) must propagate as a 500 rather than being leaked to the
+          # client as a spurious authorization error.
           handle_oidc_error!(e)
         end
 

--- a/lib/doorkeeper/openid_connect/helpers/controller/max_age.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller/max_age.rb
@@ -11,8 +11,8 @@ module Doorkeeper
           private
 
           def handle_oidc_max_age_param!(owner)
-            max_age = params[:max_age].to_i
-            return unless (params[:max_age].to_s == "0" || max_age > 0) && owner
+            max_age = oidc_max_age_seconds
+            return unless max_age && owner
 
             auth_time = normalized_oidc_auth_time(owner)
 
@@ -30,6 +30,24 @@ module Doorkeeper
             raise Errors::LoginRequired if oidc_prompt_values == ["none"]
 
             reauthenticate_oidc_resource_owner(owner)
+          end
+
+          # Parse the `max_age` request parameter into a non-negative number of
+          # seconds, or nil when it is absent, malformed, or non-scalar.
+          #
+          # `max_age` is a single string per OIDC Core §3.1.2.1. A malformed
+          # request can supply an Array (`max_age[]=1`) or a hash-like
+          # ActionController::Parameters (`max_age[a]=1`), which does not
+          # respond to `to_i` — such values are ignored rather than raising a
+          # 500.
+          def oidc_max_age_seconds
+            raw_max_age = params[:max_age]
+            return unless raw_max_age.is_a?(String) || raw_max_age.is_a?(Integer)
+
+            max_age = raw_max_age.to_i
+            return unless raw_max_age.to_s == "0" || max_age > 0
+
+            max_age
           end
 
           # Normalize non-Time values (e.g. an Integer epoch) so that the

--- a/lib/doorkeeper/openid_connect/helpers/controller/prompt.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller/prompt.rb
@@ -70,10 +70,21 @@ module Doorkeeper
 
           def return_without_oidc_prompt_param(prompt_value)
             return_to = URI.parse(request.path)
-            return_to.query = request.query_parameters.tap do |params|
-              params["prompt"] = params["prompt"].to_s.sub(/\b#{prompt_value}\s*\b/, "").strip
-              params.delete("prompt") if params["prompt"].blank?
-            end.to_query
+            # Work on a copy: `request.query_parameters` is memoized and shared, so
+            # mutating it in place would corrupt the parameters seen by the rest of
+            # the request (and any subsequent prompt value in the same loop).
+            query = request.query_parameters.dup
+            # Remove every occurrence of the value: the raw query string may
+            # contain duplicates (e.g. `prompt=login login`) even though
+            # #oidc_prompt_values deduplicates, and a leftover `prompt=login`
+            # in the return URL would trigger reauthentication again.
+            remaining = query["prompt"].to_s.split(/ +/).reject(&:blank?) - [prompt_value]
+            if remaining.any?
+              query["prompt"] = remaining.join(" ")
+            else
+              query.delete("prompt")
+            end
+            return_to.query = query.to_query
             return_to.to_s
           end
 

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -128,6 +128,22 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
     end
   end
 
+  describe "error handling in #authenticate_resource_owner!" do
+    context "when OIDC param handling raises a server-side configuration error" do
+      before do
+        allow(Doorkeeper::OpenidConnect.configuration)
+          .to receive(:select_account_for_resource_owner)
+          .and_return(->(*) { raise Doorkeeper::OpenidConnect::Errors::InvalidConfiguration })
+      end
+
+      it "propagates the error instead of redirecting it to the client" do
+        expect do
+          authorize! prompt: "select_account"
+        end.to raise_error(Doorkeeper::OpenidConnect::Errors::InvalidConfiguration)
+      end
+    end
+  end
+
   describe "#handle_oidc_prompt_param!" do
     it "is ignored when the openid scope is not present" do
       authorize! scope: "profile", prompt: "invalid"
@@ -430,6 +446,12 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
 
         expect(response).to redirect_to("/reauthenticate")
       end
+
+      it "does not mutate the request's query parameters when building the return URL" do
+        authorize! prompt: "login"
+
+        expect(request.query_parameters["prompt"]).to eq "login"
+      end
     end
 
     context "with a prompt=consent parameter" do
@@ -518,6 +540,20 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
 
           expect_authorization_form!
         end
+      end
+    end
+
+    context "with a non-scalar max_age parameter" do
+      it "ignores an array value instead of raising" do
+        authorize! max_age: %w[10 20]
+
+        expect_authorization_form!
+      end
+
+      it "ignores a hash value instead of raising" do
+        authorize! max_age: { nested: "10" }
+
+        expect_authorization_form!
       end
     end
 
@@ -759,6 +795,21 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       return_params = Rack::Utils.parse_query(URI.parse(return_to).query)
 
       expect(return_params["prompt"]).to eq "consent select_account"
+    end
+
+    context "when the query string contains duplicate prompt values" do
+      before do
+        allow(subject.request).to receive(:query_parameters) {
+          { client_id: "foo", prompt: "login consent login" }.with_indifferent_access
+        }
+      end
+
+      it "removes every occurrence of the value from the return path" do
+        _, return_to = reauthenticate!
+        return_params = Rack::Utils.parse_query(URI.parse(return_to).query)
+
+        expect(return_params["prompt"]).to eq "consent"
+      end
     end
 
     context "with a reauthenticator that does not generate a response" do


### PR DESCRIPTION
Three independent robustness fixes for the authorization endpoint, each with a regression spec that fails on the old code:

### 1. Non-scalar `max_age` caused a 500

A request like `GET /oauth/authorize?...&max_age[]=1` arrives as an `Array` (or `ActionController::Parameters` for a hash), which does not respond to `#to_i`, so `handle_oidc_max_age_param!` raised `NoMethodError` and returned a 500.

`max_age` is a single string value per OIDC Core §3.1.2.1. Parsing now goes through `oidc_max_age_seconds`, which accepts only `String`/`Integer` and returns `nil` otherwise, so a malformed `max_age` is treated as absent.

### 2. `prompt` handling mutated the shared `request.query_parameters`

`return_without_oidc_prompt_param` stripped the `prompt` value out of `request.query_parameters` in place via `.tap`. That hash is memoized and shared for the lifetime of the request, so the mutation corrupted the parameters seen by everything after it — including any subsequent prompt value processed in the same loop (`prompt=login select_account`). The return URL is now built from a `dup`.

### 3. Internal configuration errors leaked to the client as OAuth errors

`authenticate_resource_owner!` rescued `Errors::OpenidConnectError` — the base class — so an internal `Errors::InvalidConfiguration` (e.g. from an unconfigured `reauthenticate_resource_owner` / `select_account_for_resource_owner` callback) was caught and redirected to the client as a bogus `error=invalid_configuration` authorization response. A server misconfiguration is not a protocol error the client can act on.

This introduces an intermediate `Errors::AuthorizationError` grouping the redirectable OAuth/OIDC protocol errors (`InvalidRequest`, `LoginRequired`, `ConsentRequired`, `InteractionRequired`, `AccountSelectionRequired`), and rescues only that. Internal errors now surface as 500s.

>[!NOTE]
> ### Compatibility note
> the protocol error classes remain `OpenidConnectError` subclasses, so existing `rescue OpenidConnectError` handlers in host applications are unaffected.