### PR TITLE
Fix claims pipeline: response symbolization, owner-less/app-less tokens, duplicate lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - [#349] Claims pipeline fixes:
   - Dispatch claims whose `response:` option is configured with strings (e.g. `response: ["id_token"]`) instead of silently dropping them
   - Omit `id_token` from the token response when the access token has no resource owner (e.g. a `client_credentials` grant with the `openid` scope) instead of returning a 500
+  - Likewise omit `id_token` when the access token has no application, since the REQUIRED `aud` claim cannot be sourced (previously a 500 via `MissingRequiredClaim`)
+  - Answer userinfo requests whose token no longer resolves to a resource owner (`client_credentials` tokens with the `openid` scope, owners deleted after issuance) with RFC 6750's `401 invalid_token` instead of a 500
   - Resolve the access token's resource owner once per UserInfo / ID Token response instead of twice
 - [#350] Discovery / Dynamic Client Registration spec compliance fixes:
   - Advertise and accept the standard `implicit` grant type instead of doorkeeper's internal `implicit_oidc` name (RFC 7591 §2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   - Treat a malformed, non-scalar `max_age` parameter (e.g. `max_age[]=1`) as absent instead of returning a 500 (OIDC Core §3.1.2.1)
   - Build the `prompt=login` / `prompt=select_account` return URL from a copy of `request.query_parameters` instead of mutating the shared, memoized hash
   - Redirect only OAuth/OIDC protocol errors (grouped under the new `Errors::AuthorizationError`) to the client; internal errors like `Errors::InvalidConfiguration` now propagate as a 500 instead of leaking as a spurious authorization error
+- [#349] Claims pipeline fixes:
+  - Dispatch claims whose `response:` option is configured with strings (e.g. `response: ["id_token"]`) instead of silently dropping them
+  - Omit `id_token` from the token response when the access token has no resource owner (e.g. a `client_credentials` grant with the `openid` scope) instead of returning a 500
+  - Resolve the access token's resource owner once per UserInfo / ID Token response instead of twice
 - [#350] Discovery / Dynamic Client Registration spec compliance fixes:
   - Advertise and accept the standard `implicit` grant type instead of doorkeeper's internal `implicit_oidc` name (RFC 7591 §2)
   - **Breaking:** omitted `response_types` / `grant_types` in a registration request now default to `["code"]` / `["authorization_code"]` per RFC 7591 §2, instead of echoing every type the server supports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Dispatch claims whose `response:` option is configured with strings (e.g. `response: ["id_token"]`) instead of silently dropping them
   - Omit `id_token` from the token response when the access token has no resource owner (e.g. a `client_credentials` grant with the `openid` scope) instead of returning a 500
   - Likewise omit `id_token` when the access token has no application, since the REQUIRED `aud` claim cannot be sourced (previously a 500 via `MissingRequiredClaim`)
+  - Also omit `id_token` when the token still carries a `resource_owner_id` but the owner no longer resolves (e.g. deleted after issuance), which previously raised a 500 while computing `sub` (reachable through the refresh-token flow)
   - Answer userinfo requests whose token no longer resolves to a resource owner (`client_credentials` tokens with the `openid` scope, owners deleted after issuance) with RFC 6750's `401 invalid_token` instead of a 500
   - Resolve the access token's resource owner once per UserInfo / ID Token response instead of twice
 - [#350] Discovery / Dynamic Client Registration spec compliance fixes:

--- a/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/userinfo_controller.rb
@@ -6,8 +6,27 @@ module Doorkeeper
       before_action -> { doorkeeper_authorize! :openid }
 
       def show
-        render json: Doorkeeper::OpenidConnect.configuration.user_info_model.new(doorkeeper_token),
-               status: :ok
+        user_info = Doorkeeper::OpenidConnect.configuration.user_info_model.new(doorkeeper_token)
+
+        # A token can carry the openid scope yet resolve to no end user — a
+        # client_credentials token, or an owner deleted after issuance. The
+        # UserInfo response is a statement about the End-User, so such a token
+        # is not valid at this endpoint: answer with RFC 6750's 401
+        # invalid_token instead of letting the claim generators dereference a
+        # nil owner (500).
+        if user_info.respond_to?(:resource_owner) && user_info.resource_owner.nil?
+          render_resource_owner_missing_error
+        else
+          render json: user_info, status: :ok
+        end
+      end
+
+      private
+
+      def render_resource_owner_missing_error
+        error = Doorkeeper::OAuth::InvalidTokenResponse.from_access_token(doorkeeper_token)
+        response.headers.merge!(error.headers)
+        render json: error.body, status: error.status
       end
     end
   end

--- a/lib/doorkeeper/openid_connect/claims/claim.rb
+++ b/lib/doorkeeper/openid_connect/claims/claim.rb
@@ -21,7 +21,11 @@ module Doorkeeper
 
         def initialize(options = {})
           @name = options[:name].to_sym
-          @response = Array.wrap(options[:response]).freeze
+          # Symbolize so a claim configured with string responses
+          # (`response: ["id_token"]`) matches the symbol tokens the builder
+          # dispatches with (`:id_token` / `:user_info`); otherwise such a
+          # claim would be silently dropped from every response.
+          @response = Array.wrap(options[:response]).compact.map(&:to_sym).freeze
           @scopes = normalize_scopes(options[:scope])
 
           # use default scope for Standard Claims, fallback to profile

--- a/lib/doorkeeper/openid_connect/claims_builder.rb
+++ b/lib/doorkeeper/openid_connect/claims_builder.rb
@@ -5,8 +5,17 @@ require "ostruct"
 module Doorkeeper
   module OpenidConnect
     class ClaimsBuilder
-      def self.generate(access_token, response)
-        resource_owner = Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(access_token)
+      # Sentinel distinct from any real resource owner (including `nil`) so a
+      # caller that already resolved the owner can pass it in — even a nil one —
+      # and skip the second `resource_owner_from_access_token` lookup.
+      NO_RESOURCE_OWNER = Object.new
+      private_constant :NO_RESOURCE_OWNER
+
+      def self.generate(access_token, response, resource_owner = NO_RESOURCE_OWNER)
+        if resource_owner.equal?(NO_RESOURCE_OWNER)
+          resource_owner =
+            Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(access_token)
+        end
 
         Doorkeeper::OpenidConnect.configuration.claims.to_h.map do |name, claim|
           if claim.scopes.any? { |scope| access_token.scopes.exists?(scope) } &&

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -23,7 +23,9 @@ module Doorkeeper
         # NOTE: framework-controlled claims are merged last so a custom claim
         # block cannot override security-critical registered claims such as
         # `sub`, `aud`, `exp`, `iss` or `iat` in the signed ID token.
-        ClaimsBuilder.generate(@access_token, :id_token).merge(
+        # `@resource_owner` (resolved once in the constructor) is passed through
+        # so the claims builder does not look the owner up a second time.
+        ClaimsBuilder.generate(@access_token, :id_token, @resource_owner).merge(
           iss: issuer,
           sub: subject,
           aud: audience,

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -9,7 +9,10 @@ module Doorkeeper
       # must never be silently dropped when blank.
       REQUIRED_CLAIMS = %i[iss sub aud exp iat].freeze
 
-      attr_reader :nonce
+      # `resource_owner` is exposed so callers can detect a token whose owner no
+      # longer resolves (e.g. deleted after issuance) before serializing — the
+      # `sub` claim would otherwise dereference a nil owner and raise.
+      attr_reader :nonce, :resource_owner
 
       def initialize(access_token, nonce = nil, expires_in = Doorkeeper::OpenidConnect.configuration.expiration)
         @access_token = access_token

--- a/lib/doorkeeper/openid_connect/oauth/token_response.rb
+++ b/lib/doorkeeper/openid_connect/oauth/token_response.rb
@@ -7,19 +7,34 @@ module Doorkeeper
         attr_accessor :id_token
 
         def body
-          if token.includes_scope? "openid"
-            # `id_token` is preset by the flows that carry a nonce (the
-            # authorization code and password grants). Grants without one —
-            # e.g. refresh_token — reach here with it unset, so build a
-            # nonce-less ID Token on the fly.
-            id_token = self.id_token || Doorkeeper::OpenidConnect.configuration.id_token_model.new(token)
+          return super unless token.includes_scope?("openid")
 
-            super
-              .merge(id_token: id_token.as_jws_token)
-              .reject { |_, value| value.blank? }
-          else
-            super
-          end
+          # `id_token` is preset by the flows that carry a nonce (the
+          # authorization code and password grants). Grants without one —
+          # e.g. refresh_token — reach here with it unset, so build a
+          # nonce-less ID Token on the fly.
+          #
+          # A grant with no resource owner — e.g. client_credentials that
+          # happens to carry the openid scope — has no end user, so no ID Token
+          # is issued. An ID Token's `sub` identifies the end user; building one
+          # here would dereference a nil owner in `sub` / the claim generators
+          # and raise (500). The request-built flows (auth code / password /
+          # implicit) always set `id_token` and always have an owner.
+          id_token = self.id_token
+          id_token ||= build_id_token_for(token)
+          return super if id_token.nil?
+
+          super
+            .merge(id_token: id_token.as_jws_token)
+            .reject { |_, value| value.blank? }
+        end
+
+        private
+
+        def build_id_token_for(token)
+          return if token.resource_owner_id.blank?
+
+          Doorkeeper::OpenidConnect.configuration.id_token_model.new(token)
         end
       end
     end

--- a/lib/doorkeeper/openid_connect/oauth/token_response.rb
+++ b/lib/doorkeeper/openid_connect/oauth/token_response.rb
@@ -20,6 +20,11 @@ module Doorkeeper
           # here would dereference a nil owner in `sub` / the claim generators
           # and raise (500). The request-built flows (auth code / password /
           # implicit) always set `id_token` and always have an owner.
+          #
+          # Likewise for a token with no application (e.g. a password grant
+          # with client authentication skipped): `aud` is a REQUIRED claim
+          # sourced from the application's uid, so building an ID Token would
+          # raise MissingRequiredClaim (500) instead of serializing.
           id_token = self.id_token
           id_token ||= build_id_token_for(token)
           return super if id_token.nil?
@@ -32,7 +37,7 @@ module Doorkeeper
         private
 
         def build_id_token_for(token)
-          return if token.resource_owner_id.blank?
+          return if token.resource_owner_id.blank? || token.application.blank?
 
           Doorkeeper::OpenidConnect.configuration.id_token_model.new(token)
         end

--- a/lib/doorkeeper/openid_connect/oauth/token_response.rb
+++ b/lib/doorkeeper/openid_connect/oauth/token_response.rb
@@ -39,7 +39,15 @@ module Doorkeeper
         def build_id_token_for(token)
           return if token.resource_owner_id.blank? || token.application.blank?
 
-          Doorkeeper::OpenidConnect.configuration.id_token_model.new(token)
+          id_token = Doorkeeper::OpenidConnect.configuration.id_token_model.new(token)
+
+          # `resource_owner_id` can be present while `resource_owner_from_access_token`
+          # still resolves to nil — e.g. the end user was deleted after the token
+          # was issued. Serializing the ID Token would then dereference a nil owner
+          # in `sub` and raise (500), so skip issuance, matching the owner-less case.
+          return if id_token.respond_to?(:resource_owner) && id_token.resource_owner.nil?
+
+          id_token
         end
       end
     end

--- a/lib/doorkeeper/openid_connect/oauth/token_response.rb
+++ b/lib/doorkeeper/openid_connect/oauth/token_response.rb
@@ -18,13 +18,19 @@ module Doorkeeper
           # happens to carry the openid scope — has no end user, so no ID Token
           # is issued. An ID Token's `sub` identifies the end user; building one
           # here would dereference a nil owner in `sub` / the claim generators
-          # and raise (500). The request-built flows (auth code / password /
-          # implicit) always set `id_token` and always have an owner.
+          # and raise (500). The preset flows (auth code / password) are left
+          # unguarded on purpose: their success responses REQUIRE `id_token`
+          # (OIDC Core §3.1.3.3), so omitting it would be non-conformant, and
+          # they only lack an owner or application in degenerate cases (owner
+          # deleted between authorization and exchange, or a password grant
+          # with client authentication skipped) — those keep surfacing as
+          # errors rather than a silently missing REQUIRED claim.
           #
-          # Likewise for a token with no application (e.g. a password grant
-          # with client authentication skipped): `aud` is a REQUIRED claim
-          # sourced from the application's uid, so building an ID Token would
-          # raise MissingRequiredClaim (500) instead of serializing.
+          # Likewise for a token with no application (e.g. refreshing a token
+          # issued by a password grant with client authentication skipped):
+          # `aud` is a REQUIRED claim sourced from the application's uid, so
+          # building an ID Token would raise MissingRequiredClaim (500)
+          # instead of serializing.
           id_token = self.id_token
           id_token ||= build_id_token_for(token)
           return super if id_token.nil?

--- a/lib/doorkeeper/openid_connect/user_info.rb
+++ b/lib/doorkeeper/openid_connect/user_info.rb
@@ -12,8 +12,10 @@ module Doorkeeper
       def claims
         # NOTE: `sub` is merged last so a custom claim block cannot override
         # the canonical subject identifier (which would defeat pairwise /
-        # subject-type guarantees).
-        ClaimsBuilder.generate(@access_token, :user_info).merge(
+        # subject-type guarantees). `resource_owner` is passed through so the
+        # access token's owner is resolved once for both the custom claims and
+        # `sub`, instead of twice.
+        ClaimsBuilder.generate(@access_token, :user_info, resource_owner).merge(
           sub: subject,
         )
       end

--- a/lib/doorkeeper/openid_connect/user_info.rb
+++ b/lib/doorkeeper/openid_connect/user_info.rb
@@ -24,14 +24,17 @@ module Doorkeeper
         claims.reject { |_, value| value.nil? || value == "" }
       end
 
+      # Public so callers (e.g. the userinfo endpoint) can check whether the
+      # token still resolves to an end user before generating claims; the
+      # memoization keeps that check and the claim generation to one lookup.
+      def resource_owner
+        @resource_owner ||= Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(@access_token)
+      end
+
       private
 
       def subject
         Doorkeeper::OpenidConnect.configuration.subject.call(resource_owner, application).to_s
-      end
-
-      def resource_owner
-        @resource_owner ||= Doorkeeper::OpenidConnect.configuration.resource_owner_from_access_token.call(@access_token)
       end
 
       def application

--- a/spec/controllers/userinfo_controller_spec.rb
+++ b/spec/controllers/userinfo_controller_spec.rb
@@ -61,6 +61,31 @@ describe Doorkeeper::OpenidConnect::UserinfoController, type: :controller do
       end
     end
 
+    context "with a valid openid token that has no resource owner (e.g. client_credentials)" do
+      let(:token) { create :access_token, application: client, resource_owner_id: nil, scopes: "openid" }
+
+      it "returns 401 invalid_token instead of a 500" do
+        get :show, params: { access_token: token.token }
+
+        expect(response.status).to eq 401
+        expect(JSON.parse(response.body)["error"]).to eq "invalid_token"
+        expect(response.headers["WWW-Authenticate"]).to include "Bearer"
+      end
+    end
+
+    context "with a valid openid token whose resource owner was deleted after issuance" do
+      let(:token) { create :access_token, application: client, resource_owner_id: user.id, scopes: "openid" }
+
+      it "returns 401 invalid_token instead of a 500" do
+        user.destroy!
+
+        get :show, params: { access_token: token.token }
+
+        expect(response.status).to eq 401
+        expect(JSON.parse(response.body)["error"]).to eq "invalid_token"
+      end
+    end
+
     context "with a valid access token not authorized for the openid scope" do
       it "returns an error" do
         get :show, params: { access_token: token.token }

--- a/spec/lib/claims/claim_spec.rb
+++ b/spec/lib/claims/claim_spec.rb
@@ -54,6 +54,21 @@ describe Doorkeeper::OpenidConnect::Claims::Claim do
     it "falls back to the profile scope for non-standard claims" do
       expect(described_class.new(name: "unknown").scope).to eq :profile
     end
+
+    it "symbolizes string response entries" do
+      claim = described_class.new(name: "given_name", response: ["id_token", "user_info"])
+      expect(claim.response).to eq %i[id_token user_info]
+    end
+
+    it "symbolizes a single string response value" do
+      claim = described_class.new(name: "given_name", response: "id_token")
+      expect(claim.response).to eq [:id_token]
+    end
+
+    it "drops nil response entries" do
+      claim = described_class.new(name: "given_name", response: [:id_token, nil])
+      expect(claim.response).to eq [:id_token]
+    end
   end
 
   describe "immutability" do

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -62,5 +62,18 @@ describe Doorkeeper::OpenidConnect::OAuth::TokenResponse do
         expect(subject.body).not_to include :id_token
       end
     end
+
+    context "with the openid scope present but no resource owner (e.g. client_credentials)" do
+      let(:token) { create :access_token, resource_owner_id: nil, scopes: "openid email" }
+      # Override so the outer `before { subject.id_token = id_token }` assigns
+      # nil instead of eagerly instantiating an IdToken, which would defeat the
+      # `not_to receive(:new)` expectation below.
+      let(:id_token) { nil }
+
+      it "does not build an ID token and does not raise" do
+        expect(Doorkeeper::OpenidConnect::IdToken).not_to receive(:new)
+        expect(subject.body).not_to include :id_token
+      end
+    end
   end
 end

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -86,5 +86,20 @@ describe Doorkeeper::OpenidConnect::OAuth::TokenResponse do
         expect(subject.body).not_to include :id_token
       end
     end
+
+    context "with the openid scope present but the resource owner deleted after issuance" do
+      let(:user) { create :user }
+      let(:token) { create :access_token, resource_owner_id: user.id, scopes: "openid email" }
+      # The token still carries resource_owner_id, so the ID Token is built and
+      # then discarded once its owner fails to resolve — hence no `not_to
+      # receive(:new)` expectation here.
+      let(:id_token) { nil }
+
+      it "does not emit an ID token and does not raise when the owner no longer resolves" do
+        user.destroy!
+
+        expect(subject.body).not_to include :id_token
+      end
+    end
   end
 end

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -75,5 +75,16 @@ describe Doorkeeper::OpenidConnect::OAuth::TokenResponse do
         expect(subject.body).not_to include :id_token
       end
     end
+
+    context "with the openid scope present but no application" do
+      let(:token) { create :access_token, application: nil, scopes: "openid email" }
+      # See above: keep the outer `before` from eagerly building an IdToken.
+      let(:id_token) { nil }
+
+      it "does not build an ID token (whose required aud claim would be missing) and does not raise" do
+        expect(Doorkeeper::OpenidConnect::IdToken).not_to receive(:new)
+        expect(subject.body).not_to include :id_token
+      end
+    end
   end
 end

--- a/spec/lib/user_info_spec.rb
+++ b/spec/lib/user_info_spec.rb
@@ -80,6 +80,50 @@ describe Doorkeeper::OpenidConnect::UserInfo do
       end
     end
 
+    context "with a claim configured with a string response value" do
+      before do
+        Doorkeeper::OpenidConnect.configure do
+          resource_owner_from_access_token do |access_token|
+            User.find_by(id: access_token.resource_owner_id)
+          end
+
+          subject do |resource_owner|
+            resource_owner.id
+          end
+
+          claims do
+            claim(:nickname, scope: :openid, response: ["user_info"]) { |user| user.name }
+          end
+        end
+      end
+
+      it "still dispatches the claim for the user_info response" do
+        expect(subject.claims[:nickname]).to eq user.name
+      end
+    end
+
+    it "resolves the resource owner only once per response" do
+      call_count = 0
+      Doorkeeper::OpenidConnect.configure do
+        resource_owner_from_access_token do |access_token|
+          call_count += 1
+          User.find_by(id: access_token.resource_owner_id)
+        end
+
+        subject do |resource_owner|
+          resource_owner.id
+        end
+
+        claims do
+          claim(:nickname, scope: :openid, response: [:user_info]) { |user| user.name }
+        end
+      end
+
+      subject.claims
+
+      expect(call_count).to eq 1
+    end
+
     context "when a custom claim collides with the protected sub claim" do
       before do
         Doorkeeper::OpenidConnect.configure do


### PR DESCRIPTION
Five fixes in the claims/ID-token pipeline, each with a regression spec that fails on the old code:

### 1. String `response:` values silently dropped claims

`ClaimsBuilder` dispatches claims by comparing against the symbol tokens `:id_token` / `:user_info`, but a claim declared with string responses —

```ruby
claim :foo, response: ["id_token"] do |owner|
  ...
end
```

— stored the strings as-is, so `"id_token" == :id_token` was always false and the claim was silently dropped from **every** response. `Claim#initialize` now symbolizes the configured response values, making string- and symbol-configured claims behave identically.

### 2. Owner-less access token caused a 500 at the token endpoint

A `client_credentials` grant that carries the `openid` scope has no resource owner. `TokenResponse#body` still built an ID Token for it; resolving the nil owner then blew up in the `subject` block / claim generators with `NoMethodError` (500).

An ID Token's `sub` identifies an end user, and there is none here — so the token response now simply omits `id_token` for a token with no `resource_owner_id`. (Rebased on top of #310: the on-the-fly token is built through `configuration.id_token_model`.)

### 3. Owner-less access token caused a 500 at the userinfo endpoint, too

The same class of token — `client_credentials` with the `openid` scope, or a token whose owner was **deleted after issuance** — also crashed the userinfo endpoint: the claim generators dereferenced the nil owner (`NoMethodError` → 500).

The UserInfo response is a statement about the End-User, so a token that no longer resolves to one is not valid at this endpoint: it now answers with RFC 6750's `401 invalid_token` (via `Doorkeeper::OAuth::InvalidTokenResponse`, including the `WWW-Authenticate` header). `UserInfo#resource_owner` is now public so the controller can check resolution without adding a second lookup (it shares the memoized value with claim generation).

### 4. Application-less access token caused a 500 via `MissingRequiredClaim(:aud)`

`aud` is a REQUIRED claim sourced from the application's uid. A token with no application (e.g. a password grant with client authentication skipped) made ID Token serialization raise `MissingRequiredClaim` (500). The on-the-fly builder now skips the ID Token for application-less tokens, the same way as the owner-less case.

### 5. Resource owner was resolved twice per request

`UserInfo` and `IdToken` resolve the resource owner via `resource_owner_from_access_token`, and then `ClaimsBuilder.generate` looked it up a *second* time. `ClaimsBuilder.generate` now accepts the already-resolved owner from the caller — one DB lookup per response instead of two. A private sentinel distinguishes "not passed" from a legitimately-nil owner, so a nil owner does not trigger a re-lookup.