### PR TITLE
Align discovery and DCR responses with RFC 7591 / RFC 7033

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
   - Treat a malformed, non-scalar `max_age` parameter (e.g. `max_age[]=1`) as absent instead of returning a 500 (OIDC Core §3.1.2.1)
   - Build the `prompt=login` / `prompt=select_account` return URL from a copy of `request.query_parameters` instead of mutating the shared, memoized hash
   - Redirect only OAuth/OIDC protocol errors (grouped under the new `Errors::AuthorizationError`) to the client; internal errors like `Errors::InvalidConfiguration` now propagate as a 500 instead of leaking as a spurious authorization error
+- [#350] Discovery / Dynamic Client Registration spec compliance fixes:
+  - Advertise and accept the standard `implicit` grant type instead of doorkeeper's internal `implicit_oidc` name (RFC 7591 §2)
+  - **Breaking:** omitted `response_types` / `grant_types` in a registration request now default to `["code"]` / `["authorization_code"]` per RFC 7591 §2, instead of echoing every type the server supports
+  - Replace the invented `invalid_client_params` DCR error code with RFC 7591 §3.2.2's `invalid_redirect_uri` / `invalid_client_metadata`
+  - Serve WebFinger responses as `application/jrd+json` with `Access-Control-Allow-Origin: *` (RFC 7033)
+  - Create dynamically registered clients through `Doorkeeper.configuration.application_model` so custom application models work with DCR
 - [#351] Align the OpenID Connect token/authorization responses with doorkeeper's core response contract:
   - Return the plaintext access token from the `id_token token` implicit response, so it stays usable when `hash_token_secrets` is enabled
   - Define `#issued_token` on `IdTokenResponse` / `IdTokenTokenResponse`, so `after_successful_authorization` hooks can read `context.issued_token` without raising

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -14,7 +14,11 @@ module Doorkeeper
       end
 
       def webfinger
-        render json: webfinger_response
+        # RFC 7033 §5: the WebFinger resource must be queryable from browser
+        # scripts on other origins, §10.2: JRD responses use the dedicated
+        # `application/jrd+json` media type.
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        render json: webfinger_response, content_type: "application/jrd+json"
       end
 
       def keys

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -16,8 +16,10 @@ module Doorkeeper
         client = Doorkeeper.configuration.application_model.create!(application_params(registration))
         render json: registration_response(client, registration), status: :created
       rescue ActiveRecord::RecordInvalid => e
-        render json: { error: "invalid_client_params", error_description: e.record.errors.full_messages.join(", ") },
-               status: :bad_request
+        render json: {
+          error: registration_error_code(e.record),
+          error_description: e.record.errors.full_messages.join(", "),
+        }, status: :bad_request
       end
 
       private
@@ -45,6 +47,12 @@ module Doorkeeper
         else
           authorizer
         end
+      end
+
+      # RFC 7591 §3.2.2 registration error codes: `invalid_redirect_uri` for
+      # redirect URI problems, `invalid_client_metadata` for everything else.
+      def registration_error_code(record)
+        record.errors.include?(:redirect_uri) ? "invalid_redirect_uri" : "invalid_client_metadata"
       end
 
       def application_params(registration)

--- a/lib/doorkeeper/openid_connect/grant_types_supported_mixin.rb
+++ b/lib/doorkeeper/openid_connect/grant_types_supported_mixin.rb
@@ -3,8 +3,21 @@
 module Doorkeeper
   module OpenidConnect
     module GrantTypesSupportedMixin
+      # `implicit_oidc` is the internal grant flow this gem registers to add
+      # the `id_token` / `id_token token` response types on top of
+      # Doorkeeper's `implicit` flow. Externally (RFC 7591 §2 / OIDC
+      # Discovery `grant_types_supported`) the registered grant type name is
+      # `implicit` — the internal flow name must not leak into responses.
+      INTERNAL_GRANT_TYPE_MAPPING = {
+        "implicit_oidc" => "implicit",
+      }.freeze
+
       def grant_types_supported(doorkeeper)
-        grant_types_supported = doorkeeper.grant_flows.dup
+        # `uniq` also covers a configuration listing both `implicit` and
+        # `implicit_oidc`, which map to the same external grant type.
+        grant_types_supported = doorkeeper.grant_flows.map do |flow|
+          INTERNAL_GRANT_TYPE_MAPPING.fetch(flow, flow)
+        end.uniq
 
         # `use_refresh_token` enables the refresh_token grant without it being
         # listed in `grant_flows`, so it is appended here — but only when it is

--- a/lib/doorkeeper/openid_connect/oauth/dynamic_registration_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/dynamic_registration_request.rb
@@ -12,6 +12,11 @@ module Doorkeeper
         PUBLIC_CLIENT_AUTH_METHOD = "none"
         DEFAULT_APPLICATION_TYPE = "web"
         SUPPORTED_APPLICATION_TYPES = %w[web native].freeze
+        # RFC 7591 §2: when omitted, a client registers for the
+        # `authorization_code` grant type and the `code` response type — not
+        # for everything the server happens to support.
+        DEFAULT_RESPONSE_TYPES = %w[code].freeze
+        DEFAULT_GRANT_TYPES = %w[authorization_code].freeze
 
         validate :token_endpoint_auth_method, error: :invalid_client_metadata
         validate :application_type,           error: :invalid_client_metadata
@@ -34,12 +39,12 @@ module Doorkeeper
 
         def requested_response_types
           types = Array(@params[:response_types]).compact_blank
-          types.presence || server_response_types
+          types.presence || DEFAULT_RESPONSE_TYPES
         end
 
         def requested_grant_types
           types = Array(@params[:grant_types]).compact_blank
-          types.presence || server_grant_types
+          types.presence || DEFAULT_GRANT_TYPES
         end
 
         def confidential_client?

--- a/spec/controllers/discovery_controller_spec.rb
+++ b/spec/controllers/discovery_controller_spec.rb
@@ -20,7 +20,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
         "scopes_supported" => ["openid"],
         "response_types_supported" => ["code", "token", "id_token", "id_token token"],
         "response_modes_supported" => %w[query fragment form_post],
-        "grant_types_supported" => %w[authorization_code client_credentials implicit_oidc],
+        "grant_types_supported" => %w[authorization_code client_credentials implicit],
 
         "token_endpoint_auth_methods_supported" => %w[client_secret_basic client_secret_post],
         "authorization_response_iss_parameter_supported" => false,
@@ -84,7 +84,7 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
         "scopes_supported" => ["openid"],
         "response_types_supported" => ["code", "token", "id_token", "id_token token"],
         "response_modes_supported" => %w[query fragment form_post],
-        "grant_types_supported" => %w[authorization_code client_credentials implicit_oidc],
+        "grant_types_supported" => %w[authorization_code client_credentials implicit],
 
         "token_endpoint_auth_methods_supported" => %w[client_secret_basic client_secret_post],
         "authorization_response_iss_parameter_supported" => false,
@@ -424,6 +424,13 @@ describe Doorkeeper::OpenidConnect::DiscoveryController, type: :controller do
       expect do
         get :webfinger
       end.to raise_error ActionController::ParameterMissing
+    end
+
+    it "responds with the JRD media type and allows cross-origin requests" do
+      get :webfinger, params: { resource: "user@example.com" }
+
+      expect(response.media_type).to eq "application/jrd+json"
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq "*"
     end
 
     it "returns the OpenID Connect relation" do

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -52,8 +52,8 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
           "redirect_uris" => redirect_uris,
           "token_endpoint_auth_method" => "client_secret_basic",
           "token_endpoint_auth_methods_supported" => %w[client_secret_basic client_secret_post],
-          "response_types" => ["code", "token", "id_token", "id_token token"],
-          "grant_types" => %w[authorization_code client_credentials implicit_oidc],
+          "response_types" => ["code"],
+          "grant_types" => %w[authorization_code],
           "scope" => "public",
           "application_type" => "web",
         })
@@ -297,6 +297,36 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
       end
     end
 
+    context "when grant_types is the standard implicit grant type" do
+      it "accepts it although doorkeeper's internal flow name is implicit_oidc" do
+        post :register, params: {
+          client_name: "implicit_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          grant_types: ["implicit"],
+        }
+
+        expect(response.status).to eq 201
+        body = JSON.parse(response.body)
+        expect(body["grant_types"]).to eq(["implicit"])
+      end
+    end
+
+    context "when grant_types is doorkeeper's internal implicit_oidc flow name" do
+      it "rejects the request with invalid_client_metadata" do
+        post :register, params: {
+          client_name: "internal_name_client",
+          redirect_uris: redirect_uris,
+          scope: "public",
+          grant_types: ["implicit_oidc"],
+        }
+
+        expect(response.status).to eq 400
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("invalid_client_metadata")
+      end
+    end
+
     context "when grant_types is a subset of the server's supported types" do
       it "echoes the requested grant_types back in the response" do
         post :register, params: {
@@ -497,7 +527,7 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
 
         expect(response.status).to eq 400
         expect(JSON.parse(response.body)).to eq({
-          "error" => "invalid_client_params",
+          "error" => "invalid_redirect_uri",
           "error_description" => "Redirect URI must be an HTTPS/SSL URI.",
         })
       end

--- a/spec/lib/grant_types_supported_mixin_spec.rb
+++ b/spec/lib/grant_types_supported_mixin_spec.rb
@@ -14,10 +14,22 @@ RSpec.describe Doorkeeper::OpenidConnect::GrantTypesSupportedMixin do
       double("Doorkeeper::Config", grant_flows: grant_flows, refresh_token_enabled?: refresh_token_enabled)
     end
 
-    it "returns the configured grant flows as-is when refresh tokens are disabled" do
+    it "returns the configured grant flows when refresh tokens are disabled" do
+      config = doorkeeper_config(grant_flows: %w[authorization_code client_credentials], refresh_token_enabled: false)
+
+      expect(host.grant_types_supported(config)).to eq %w[authorization_code client_credentials]
+    end
+
+    it "maps the internal implicit_oidc flow name to the standard implicit grant type" do
       config = doorkeeper_config(grant_flows: %w[authorization_code implicit_oidc], refresh_token_enabled: false)
 
-      expect(host.grant_types_supported(config)).to eq %w[authorization_code implicit_oidc]
+      expect(host.grant_types_supported(config)).to eq %w[authorization_code implicit]
+    end
+
+    it "does not duplicate implicit when both implicit and implicit_oidc are configured" do
+      config = doorkeeper_config(grant_flows: %w[implicit implicit_oidc], refresh_token_enabled: false)
+
+      expect(host.grant_types_supported(config)).to eq %w[implicit]
     end
 
     it "appends refresh_token when use_refresh_token is enabled" do


### PR DESCRIPTION
## Summary

Spec-compliance fixes for the discovery document, Dynamic Client Registration, and WebFinger:

### 1. `grant_types_supported` leaked the internal `implicit_oidc` flow name

This gem registers doorkeeper's `implicit_oidc` grant flow internally for the `id_token` / `id_token token` response types, and that internal name leaked verbatim into the discovery document and DCR responses. It is now mapped to the standard `implicit` grant type; DCR registration requesting `implicit` is accepted, and the internal `implicit_oidc` name is rejected as `invalid_client_metadata`.

### 2. DCR defaults claimed every server-supported type

When `response_types` / `grant_types` are omitted from a registration request, the response claimed the client registered for everything the server supports. RFC 7591 §2 specifies the defaults: `response_types` → `["code"]`, `grant_types` → `["authorization_code"]`.

### 3. DCR used an invented error code

Registration failures returned `invalid_client_params`, which appears in no RFC. RFC 7591 §3.2.2 defines the registration error codes; the endpoint now returns `invalid_redirect_uri` for redirect URI validation failures and `invalid_client_metadata` for everything else.

### 4. WebFinger response headers

The WebFinger endpoint now serves `application/jrd+json` and `Access-Control-Allow-Origin: *` per RFC 7033 §5 / §10.2. (A missing `resource` parameter already maps to 400 via `ParameterMissing`.)

### 5. Custom application model support

Clients are created through `Doorkeeper.configuration.application_model` instead of the hardcoded `Doorkeeper::Application`, so installations with a custom application model can use dynamic registration. (Master already made this change for the `create!` call in #341; this branch's remaining diff aligns the rest.)

>[!NOTE]
> Item 3 changes an error code that clients may have been matching on (`invalid_client_params` → RFC codes). It was never a registered code, but calling it out as the one behavior change with a (small) compatibility surface.