### PR TITLE
Align OIDC token/authorization responses with doorkeeper core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   - Treat a malformed, non-scalar `max_age` parameter (e.g. `max_age[]=1`) as absent instead of returning a 500 (OIDC Core §3.1.2.1)
   - Build the `prompt=login` / `prompt=select_account` return URL from a copy of `request.query_parameters` instead of mutating the shared, memoized hash
   - Redirect only OAuth/OIDC protocol errors (grouped under the new `Errors::AuthorizationError`) to the client; internal errors like `Errors::InvalidConfiguration` now propagate as a 500 instead of leaking as a spurious authorization error
+- [#351] Align the OpenID Connect token/authorization responses with doorkeeper's core response contract:
+  - Return the plaintext access token from the `id_token token` implicit response, so it stays usable when `hash_token_secrets` is enabled
+  - Define `#issued_token` on `IdTokenResponse` / `IdTokenTokenResponse`, so `after_successful_authorization` hooks can read `context.issued_token` without raising
+  - Attach the ID token before the `after_successful_strategy_response` hook fires in the authorization-code flow, matching the password flow
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/lib/doorkeeper/oauth/id_token_response.rb
+++ b/lib/doorkeeper/oauth/id_token_response.rb
@@ -18,6 +18,15 @@ module Doorkeeper
         true
       end
 
+      # Expose the issued access token, mirroring core `CodeResponse` /
+      # `TokenResponse`. `after_successful_authorization` hooks read
+      # `context.issued_token` (via `Hooks::Context#issued_token`), which
+      # would otherwise raise `NoMethodError` for the `id_token` and
+      # `id_token token` response types.
+      def issued_token
+        auth.token
+      end
+
       def body
         {
           state: pre_auth.state,

--- a/lib/doorkeeper/oauth/id_token_token_response.rb
+++ b/lib/doorkeeper/oauth/id_token_token_response.rb
@@ -5,7 +5,11 @@ module Doorkeeper
     class IdTokenTokenResponse < IdTokenResponse
       def body
         super.merge({
-          access_token: auth.token.token,
+          # `plaintext_token`, not `token`: with a hashing token-secret
+          # strategy the stored `token` attribute is the hash, so returning it
+          # would hand the client an unusable access token (mirrors core
+          # `CodeResponse` / `TokenResponse`, which return `plaintext_token`).
+          access_token: auth.token.plaintext_token,
           token_type: auth.token.token_type,
           expires_in: auth.token.expires_in_seconds,
         })

--- a/lib/doorkeeper/openid_connect/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/authorization_code_request.rb
@@ -7,8 +7,6 @@ module Doorkeeper
         private
 
         def after_successful_response
-          super
-
           # The nonce was stashed on a one-time OpenidRequest row when the
           # authorization code was issued (see OAuth::Authorization::Code).
           # Read it before destroying the row so it can be bound to the ID
@@ -18,11 +16,17 @@ module Doorkeeper
           nonce = openid_request&.nonce
           openid_request&.destroy!
 
-          return unless access_token.includes_scope?("openid")
+          if access_token.includes_scope?("openid")
+            id_token = Doorkeeper::OpenidConnect.configuration.id_token_model
+                                                .new(access_token, nonce)
+            @response.id_token = id_token
+          end
 
-          id_token = Doorkeeper::OpenidConnect.configuration.id_token_model
-                                              .new(access_token, nonce)
-          @response.id_token = id_token
+          # Attach the ID token to the response *before* calling super, which
+          # fires `after_successful_strategy_response`. This matches
+          # PasswordAccessTokenRequest so a consumer's hook sees the complete
+          # token response (including `id_token`) in both flows.
+          super
         end
       end
     end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -41,6 +41,17 @@ describe Doorkeeper::OpenidConnect::OAuth::AuthorizationCodeRequest do
       expect(response.id_token.nonce).to be_nil
     end
 
+    it "attaches the ID token before the after_successful_strategy_response hook fires" do
+      id_token_at_hook_time = :hook_not_called
+      allow(Doorkeeper.config).to receive(:after_successful_strategy_response).and_return(
+        ->(_request, resp) { id_token_at_hook_time = resp.id_token },
+      )
+
+      subject.send :after_successful_response
+
+      expect(id_token_at_hook_time).to be_a Doorkeeper::OpenidConnect::IdToken
+    end
+
     context "when the access token does not include the openid scope" do
       let(:token) { create :access_token, scopes: "public" }
       let(:grant) { create :access_grant, openid_request: nil }

--- a/spec/lib/oauth/id_token_response_spec.rb
+++ b/spec/lib/oauth/id_token_response_spec.rb
@@ -80,6 +80,12 @@ describe Doorkeeper::OAuth::IdTokenResponse do
     end
   end
 
+  describe "#issued_token" do
+    it "returns the access token issued by the authorization, for hook contexts" do
+      expect(subject.issued_token).to eq(auth.token)
+    end
+  end
+
   describe "#redirect_uri" do
     it "includes id_token and state" do
       expect(subject.redirect_uri).to include("#{pre_auth.redirect_uri}#state=#{pre_auth.state}&" \

--- a/spec/lib/oauth/id_token_token_response_spec.rb
+++ b/spec/lib/oauth/id_token_token_response_spec.rb
@@ -38,7 +38,7 @@ describe Doorkeeper::OAuth::IdTokenTokenResponse do
       expect(subject.body).to eq({
         state: pre_auth.state,
         id_token: id_token.as_jws_token,
-        access_token: auth.token.token,
+        access_token: auth.token.plaintext_token,
         token_type: auth.token.token_type,
         expires_in: auth.token.expires_in_seconds,
       })
@@ -54,13 +54,25 @@ describe Doorkeeper::OAuth::IdTokenTokenResponse do
         expect(subject.body[:iss]).to eq(id_token.issuer)
       end
     end
+
+    it "returns the plaintext access token, not the stored (possibly hashed) value" do
+      allow(auth.token).to receive_messages(plaintext_token: "PLAINTEXT", token: "HASHED")
+
+      expect(subject.body[:access_token]).to eq("PLAINTEXT")
+    end
+  end
+
+  describe "#issued_token" do
+    it "returns the issued access token, for hook contexts" do
+      expect(subject.issued_token).to eq(auth.token)
+    end
   end
 
   describe "#redirect_uri" do
     it "includes id_token, info of access_token and state" do
       expect(subject.redirect_uri).to include("#{pre_auth.redirect_uri}#state=#{pre_auth.state}&" \
         "id_token=#{id_token.as_jws_token}&" \
-        "access_token=#{auth.token.token}&" \
+        "access_token=#{auth.token.plaintext_token}&" \
         "token_type=#{auth.token.token_type}&" \
         "expires_in=#{auth.token.expires_in_seconds}")
     end


### PR DESCRIPTION
## Summary

Three places where this gem's response classes diverge from doorkeeper core's, each with a regression spec that fails on the old code:

### 1. `id_token token` returned the stored token, not the plaintext

`IdTokenTokenResponse#body` returned `auth.token.token` for the implicit flow's `access_token`. With a hashing token-secret strategy (`hash_token_secrets`), the stored `token` attribute is the **hash**, so the client received an unusable access token. It now uses `plaintext_token`, matching core `CodeResponse` / `TokenResponse`.

### 2. Missing `issued_token` broke `after_successful_authorization` hooks

For the `id_token` and `id_token token` response types, `strategy.authorize` returns this gem's response objects, and doorkeeper's `Hooks::Context#issued_token` calls `auth.issued_token` on them. Core's `CodeResponse` / `TokenResponse` implement it; ours didn't, so a host application's `after_successful_authorization` hook reading `context.issued_token` raised `NoMethodError`. Both response classes now return the issued access token.

### 3. Auth-code flow fired the response hook before attaching `id_token`

The authorization-code flow attached the `id_token` to the response *after* calling `super` (which fires `after_successful_strategy_response`), while the password flow attaches it *before*. A consumer hook therefore saw the complete response (including `id_token`) in the password flow but an `id_token`-less one in the auth-code flow. The auth-code flow now attaches before `super`, matching the password flow. (Rebased on top of #310: the ID Token is built through `configuration.id_token_model`.)