### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,10 @@ on:
     # as defined in the (optional) "skipLabels" property.
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   # Enforces the update of a changelog file on every pull request
   changelog:


### PR DESCRIPTION
Potential fix for [https://github.com/doorkeeper-gem/doorkeeper-openid_connect/security/code-scanning/3](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/changelog.yml` so the workflow no longer relies on repository/org defaults.  
Best single fix without changing intended behavior: define permissions at the workflow root (applies to all jobs unless overridden) with the minimal scopes this PR workflow typically needs:
- `contents: read`
- `pull-requests: read`

This documents intent and prevents accidental privilege escalation if defaults change.  
Edit region: near the top of the workflow, after the `on:` trigger block and before `jobs:`.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
