### PR TITLE
Remove stale TODO/FIXME markers and the dead compat code behind them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Return the plaintext access token from the `id_token token` implicit response, so it stays usable when `hash_token_secrets` is enabled
   - Define `#issued_token` on `IdTokenResponse` / `IdTokenTokenResponse`, so `after_successful_authorization` hooks can read `context.issued_token` without raising
   - Attach the ID token before the `after_successful_strategy_response` hook fires in the authorization-code flow, matching the password flow
+- [#354] Remove stale TODO/FIXME markers and the Doorkeeper < 5.5 bridging code behind them, made obsolete by the `doorkeeper >= 5.5` requirement. No behavior change; see the individual commits for details
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -40,7 +40,6 @@ module Doorkeeper
 
           scopes_supported: doorkeeper.scopes,
 
-          # TODO: support id_token response type
           response_types_supported: doorkeeper.authorization_response_types,
           response_modes_supported: response_modes_supported(doorkeeper),
           grant_types_supported: grant_types_supported(doorkeeper),

--- a/lib/doorkeeper/oauth/id_token_request.rb
+++ b/lib/doorkeeper/oauth/id_token_request.rb
@@ -12,11 +12,7 @@ module Doorkeeper
 
       def authorize
         @auth = Authorization::Token.new(pre_auth, resource_owner)
-        if @auth.respond_to?(:issue_token!)
-          @auth.issue_token!
-        else
-          @auth.issue_token
-        end
+        @auth.issue_token!
         response
       end
 

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -43,13 +43,6 @@ module Doorkeeper
 
         private
 
-        # FIXME: remove after Doorkeeper will merge it
-        def current_resource_owner
-          return @current_resource_owner if defined?(@current_resource_owner)
-
-          super
-        end
-
         def authenticate_resource_owner!
           super.tap do |owner|
             next unless oidc_authorization_request? ||

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -91,7 +91,9 @@ module Doorkeeper
         def clear_oidc_response
           self.response_body = nil
 
-          # FIXME: workaround for Rails 5, see https://github.com/rails/rails/issues/25106
+          # Setting `response_body` to nil only resets the response object's
+          # body and leaves `@_response_body` assigned, so `performed?` would
+          # still return true (rails/rails#25106, still present in Rails 8).
           @_response_body = nil
         end
       end

--- a/lib/doorkeeper/openid_connect/oauth/authorization/code.rb
+++ b/lib/doorkeeper/openid_connect/oauth/authorization/code.rb
@@ -5,22 +5,13 @@ module Doorkeeper
     module OAuth
       module Authorization
         module Code
-          if Doorkeeper::OAuth::Authorization::Code.method_defined?(:issue_token!)
-            def issue_token!
-              super.tap do |access_grant|
-                create_openid_request(access_grant) if pre_auth.nonce.present?
-              end
-            end
-
-            alias issue_token issue_token!
-          else
-            # FIXME: drop this after dropping support of Doorkeeper < 5.4
-            def issue_token
-              super.tap do |access_grant|
-                create_openid_request(access_grant) if pre_auth.nonce.present?
-              end
+          def issue_token!
+            super.tap do |access_grant|
+              create_openid_request(access_grant) if pre_auth.nonce.present?
             end
           end
+
+          alias issue_token issue_token!
 
           private
 

--- a/spec/lib/oauth/id_token_response_spec.rb
+++ b/spec/lib/oauth/id_token_response_spec.rb
@@ -26,13 +26,7 @@ describe Doorkeeper::OAuth::IdTokenResponse do
   let(:owner) { build_stubbed(:user) }
 
   let(:auth) do
-    Doorkeeper::OAuth::Authorization::Token.new(pre_auth, owner).tap do |c|
-      if c.respond_to?(:issue_token!)
-        c.issue_token!
-      else
-        c.issue_token
-      end
-    end
+    Doorkeeper::OAuth::Authorization::Token.new(pre_auth, owner).tap(&:issue_token!)
   end
   let(:id_token) { Doorkeeper::OpenidConnect::IdToken.new(token, pre_auth) }
 

--- a/spec/lib/oauth/id_token_token_response_spec.rb
+++ b/spec/lib/oauth/id_token_token_response_spec.rb
@@ -23,13 +23,7 @@ describe Doorkeeper::OAuth::IdTokenTokenResponse do
   end
   let(:owner) { build_stubbed(:user) }
   let(:auth) do
-    Doorkeeper::OAuth::Authorization::Token.new(pre_auth, owner).tap do |c|
-      if c.respond_to?(:issue_token!)
-        c.issue_token!
-      else
-        c.issue_token
-      end
-    end
+    Doorkeeper::OAuth::Authorization::Token.new(pre_auth, owner).tap(&:issue_token!)
   end
   let(:id_token) { Doorkeeper::OpenidConnect::IdToken.new(token, pre_auth) }
 


### PR DESCRIPTION
Prunes four stale TODO/FIXME markers and the dead code they guarded, one commit per marker so each removal carries its own rationale in the commit message. No behavior change.

## What was removed (and why it's safe)

Both compat shims below were introduced together in 430413d ("Add support for Doorkeeper 5.4", 2020) and self-declared their removal condition — both conditions have long been met by the `doorkeeper >= 5.5` gemspec requirement.

- **`current_resource_owner` override in `Helpers::Controller`** — marked "FIXME: remove after Doorkeeper will merge it". Doorkeeper merged the identical `defined?` memoization in 5.5.0 ([doorkeeper#1410](https://github.com/doorkeeper-gem/doorkeeper/pull/1410)), which is exactly the gemspec floor, so upstream now does the same thing on every supported version.
- **Doorkeeper < 5.4 `issue_token` fallback paths** — the `method_defined?(:issue_token!)` guard and its `else` branch in `OAuth::Authorization::Code`, plus the matching `respond_to?(:issue_token!)` checks in `IdTokenRequest` and the two id_token response specs. `issue_token!` exists on every installable version, so the legacy side was unreachable. The public `issue_token` alias is kept, so the gem's API is unchanged.
- **"support id_token response type" TODO in the discovery controller** — `id_token` / `id_token token` flows have been registered by this gem for years, and `response_types_supported` is built dynamically from `doorkeeper.authorization_response_types`.

## What was deliberately NOT removed

The `@_response_body = nil` line in `clear_oidc_response` was marked "FIXME: workaround for Rails 5", but [rails/rails#25106](https://github.com/rails/rails/issues/25106) is still present in Rails 8: `response_body = nil` only resets the response object's body and leaves `@_response_body` assigned, which would keep `performed?` returning true. The FIXME is replaced with a comment stating the constraint so the line doesn't read as removable.