### PR TITLE
Follow-up to #351: compute at_hash from the plaintext access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - Define `#issued_token` on `IdTokenResponse` / `IdTokenTokenResponse`, so `after_successful_authorization` hooks can read `context.issued_token` without raising
   - Attach the ID token before the `after_successful_strategy_response` hook fires in the authorization-code flow, matching the password flow
 - [#354] Remove stale TODO/FIXME markers and the Doorkeeper < 5.5 bridging code behind them, made obsolete by the `doorkeeper >= 5.5` requirement. No behavior change; see the individual commits for details
+- [#355] Compute the hybrid `id_token token` flow's `at_hash` claim from the plaintext access token instead of the stored value, so ID Token validation by conforming clients succeeds when `hash_token_secrets` is enabled — completing the response-side alignment from [#351]
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/lib/doorkeeper/openid_connect/hybrid_id_token_concern.rb
+++ b/lib/doorkeeper/openid_connect/hybrid_id_token_concern.rb
@@ -24,7 +24,11 @@ module Doorkeeper
       #   access_token value with SHA-256, then take the left-most 128 bits and
       #   base64url-encode them. The at_hash value is a case-sensitive string.
       def at_hash
-        hashed_token = at_hash_digest.digest(@access_token.token)
+        # `plaintext_token`, not `token`: with a hashing token-secret
+        # strategy (`hash_token_secrets`) the stored `token` is a digest,
+        # while the client receives the plaintext value, so at_hash must
+        # be computed over the same octets the client will hash.
+        hashed_token = at_hash_digest.digest(@access_token.plaintext_token)
         first_half = hashed_token[0...hashed_token.length / 2]
         Base64.urlsafe_encode64(first_half).tr("=", "")
       end

--- a/spec/lib/id_token_token_spec.rb
+++ b/spec/lib/id_token_token_spec.rb
@@ -81,5 +81,15 @@ describe Doorkeeper::OpenidConnect::IdTokenToken do
         expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA256))
       end
     end
+
+    context "when token secrets are stored hashed (hash_token_secrets)" do
+      before do
+        allow(access_token).to receive_messages(plaintext_token: token_value, token: "hashed-#{token_value}")
+      end
+
+      it "computes at_hash over the plaintext token the client receives, not the stored digest" do
+        expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA256))
+      end
+    end
   end
 end


### PR DESCRIPTION
Completes the response-contract alignment started in #351.

#351 switched the hybrid `id_token token` response body to return `plaintext_token`, so the access token stays usable when Doorkeeper's `hash_token_secrets` strategy is enabled. However, the `at_hash` claim inside the ID Token was still computed over the *stored* token value — which, under a hashing strategy, is a SHA-256 digest rather than the value the client receives.

Per OIDC Core 1.0 §3.2.2.9, `at_hash` must be derived from the octets of the access token as delivered to the client, so a conforming RP hashing the token it received would never match and would reject an otherwise valid ID Token. This only bites with `hash_token_secrets` enabled (non-default) in the hybrid flow; with the default plain strategy `plaintext_token == token`, so behavior there is unchanged.

Changes:

- `HybridIdTokenConcern#at_hash` now digests `@access_token.plaintext_token`, mirroring the response-body change from #351.
- Added a spec simulating a hashing token-secret strategy (stubbing the `plaintext_token` / `token` seam, same pattern as the #351 specs) that asserts `at_hash` is derived from the plaintext value.

> [!NOTE]
> 
> No `plaintext_token == nil` path is reachable here: the ID Token is built at issuance time (raw token in memory), and Doorkeeper itself force-disables `reuse_access_token` when the token secret strategy cannot restore secrets. Doorkeeper core's own `TokenResponse` calls `plaintext_token` unconditionally under the same assumptions.