### PR TITLE
Test: Cover the conditional members of the enriched RFC 8414 document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [#354] Remove stale TODO/FIXME markers and the Doorkeeper < 5.5 bridging code behind them, made obsolete by the `doorkeeper >= 5.5` requirement. No behavior change; see the individual commits for details
 - [#355] Compute the hybrid `id_token token` flow's `at_hash` claim from the plaintext access token instead of the stored value, so ID Token validation by conforming clients succeeds when `hash_token_secrets` is enabled — completing the response-side alignment from [#351]
 - [#356] Fix a boot failure on Doorkeeper < 6.0 in applications that define a top-level `MetadataResponse` constant. The Doorkeeper 6.0 capability probe introduced in [#353] used `const_defined?` with its default `inherit: true`, which continues the lookup into `Object` — and reports true for a constant Zeitwerk has merely registered for autoloading — so a host application's own unrelated class made the gem take the 6.0 branch and raise `NameError: uninitialized constant Doorkeeper::MetadataController` from the engine's `to_prepare`. The probe now lives in one place as `Doorkeeper::OpenidConnect.doorkeeper_metadata_endpoint?` and is asked with `inherit: false`, instead of being repeated at each branch. [#353] has not shipped in a release, so no released version is affected
+- [#357] Add specs for the conditional `registration_endpoint` and `end_session_endpoint` members of the enriched RFC 8414 document, which were previously only asserted in their omission branches
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/spec/controllers/doorkeeper/metadata_controller_spec.rb
+++ b/spec/controllers/doorkeeper/metadata_controller_spec.rb
@@ -9,6 +9,16 @@ require "rails_helper"
 # referencing Doorkeeper::MetadataController on a version that lacks it.
 if Doorkeeper::OpenidConnect.doorkeeper_metadata_endpoint?
   describe Doorkeeper::MetadataController, type: :controller do
+    # Restore the routes mutated by the registration_endpoint examples so no
+    # drawn route leaks into the rest of the suite. The configuration has to
+    # be restored first: this hook runs before the config-level reset in
+    # rails_helper, and reloading the routes while dynamic_client_registration
+    # is still enabled would redraw the very route being cleaned up.
+    after do
+      load Rails.root.join("config/initializers/doorkeeper_openid_connect.rb")
+      Rails.application.reload_routes!
+    end
+
     describe "#show" do
       it "enriches the document with the OpenID Connect metadata" do
         get :show
@@ -73,6 +83,47 @@ if Doorkeeper::OpenidConnect.doorkeeper_metadata_endpoint?
         expect(data["issuer"]).to eq "http://test.host"
         expect(data["userinfo_endpoint"]).to be_nil
         expect(data).not_to have_key("jwks_uri")
+      end
+
+      it "advertises the registration_endpoint when dynamic client registration is enabled and its route is drawn" do
+        Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
+          dynamic_client_registration true
+        end
+
+        Rails.application.reload_routes!
+
+        # Force Rails' lazy route loading to redraw now, so the route the
+        # option enables is present before the request. Doubles as the
+        # premise assertion, mirroring the example below where the same
+        # helper is required to be absent.
+        expect(Rails.application.routes.recognize_path("/oauth/registration", method: :post))
+          .to include(controller: "doorkeeper/openid_connect/dynamic_client_registration")
+
+        get :show
+
+        expect(response).to have_http_status(:ok)
+
+        data = JSON.parse(response.body)
+
+        expect(data["registration_endpoint"]).to eq "http://test.host/oauth/registration"
+      end
+
+      it "advertises the configured end_session_endpoint, evaluated in the controller's context" do
+        Doorkeeper::OpenidConnect.configure do
+          issuer "dummy"
+          end_session_endpoint -> { logout_url }
+        end
+
+        def controller.logout_url
+          "http://test.host/logout"
+        end
+
+        get :show
+
+        data = JSON.parse(response.body)
+
+        expect(data["end_session_endpoint"]).to eq "http://test.host/logout"
       end
 
       it "omits the registration_endpoint when dynamic client registration is enabled but its route is not drawn" do


### PR DESCRIPTION
`registration_endpoint` and `end_session_endpoint` were only ever asserted in their omission branches: the registration example requires the route to be absent, and the dummy app never configures an end-session endpoint. Deleting either line from `MetadataExtension#oidc_metadata` therefore left the whole suite green — neither member was pinned to anything.

This adds the positive branch for both:

- The registration example mirrors the existing omission example — it enables `dynamic_client_registration`, redraws the routes and forces Rails' lazy route loading to resolve now, so the premise that the URL helper exists is asserted rather than assumed.
- The end-session example additionally pins that the configured block is evaluated in the controller's context (`instance_exec`), matching the discovery document's own example.

Spec-only, no behavior change. Verified against Doorkeeper 6.0 (the file is gated on `Doorkeeper::OAuth::MetadataResponse`, so it is exercised by the `doorkeeper_6.0` gemfile leg): full suite green, and removing either member's line from `MetadataExtension#oidc_metadata` now fails exactly its example.