### PR TITLE
Require id_token_class / user_info_class to inherit from the defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Upgrading? [Migration from Old Versions](https://github.com/doorkeeper-gem/doork
 
 ## Unreleased
 
+- [#364] Require `id_token_class` / `user_info_class` overrides to inherit from `Doorkeeper::OpenidConnect::IdToken` / `UserInfo` ([#344](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/344)) — the previous method-presence check was effectively a no-op for `user_info_class`, and a from-scratch implementation had to reproduce security-critical behavior (required-claim enforcement, the claim merge order that keeps the `claims` configuration block from overriding `sub`/`aud`/`exp`, nonce and `at_hash` handling). Also adds an `IdToken#select_key` hook returning the signing key material and algorithm together (`IdToken::SigningKey`) for per-client, rotating, or multi-tenant keys, and binds the hybrid flow's `at_hash` digest to the selected key's algorithm (OIDC Core §3.2.2.10) instead of the global `signing_algorithm`. [#335] has not shipped in a release, so no released configuration is affected
 - [#387] **Breaking:** Remove the deprecated `jws_private_key` and `jws_public_key` initializer settings
 - Add entry here
 

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -131,15 +131,19 @@ module Doorkeeper
       option :open_id_request_class, default: "Doorkeeper::OpenidConnect::Request"
 
       # A class that provides custom behavior for generating ID tokens.
-      # Should probably inherit from `Doorkeeper::OpenidConnect::IdToken`, but may also be completely custom
-      # so long as it responds to `#as_json`, `#as_jws_token`, `#issuer`, exposes the access token via
-      # an `#access_token` reader (public or private), and has the same initializer. The reader is what
-      # `HybridIdTokenConcern` uses to compute the `at_hash` claim in the hybrid `id_token token` flow.
+      # Must inherit from `Doorkeeper::OpenidConnect::IdToken`, which carries the
+      # security-critical invariants (required-claim enforcement, the merge order that keeps the
+      # `claims` configuration block from overriding `sub`/`aud`/`exp`, nonce and `at_hash`
+      # handling), so a subclass only overrides what it actually needs — typically `claims`
+      # (call `super.merge(...)` so the registered claims are always present; a key you add that
+      # collides with one of them does replace it, so keep your keys distinct unless replacing it
+      # is what you mean), `audience`, or `select_key` for custom signing-key selection.
       option :id_token_class, default: "Doorkeeper::OpenidConnect::IdToken"
 
       # A class that provides custom behavior for generating the UserInfo response.
-      # Should probably inherit from `Doorkeeper::OpenidConnect::UserInfo`, but may also be completely custom
-      # so long as it responds to `#as_json` and has the same initializer.
+      # Must inherit from `Doorkeeper::OpenidConnect::UserInfo`; a subclass typically only
+      # overrides `claims` (call `super.merge(...)`, and leave `sub` out of the merged hash unless
+      # replacing the canonical subject identifier is what you mean).
       option :user_info_class, default: "Doorkeeper::OpenidConnect::UserInfo"
 
       # Doorkeeper OpenID Request model class.
@@ -151,26 +155,32 @@ module Doorkeeper
       end
 
       def id_token_model
-        resolve_validated_model(:id_token, id_token_class, %i[as_json as_jws_token issuer access_token])
+        resolve_validated_model(:id_token, id_token_class, IdToken)
       end
 
       def user_info_model
-        resolve_validated_model(:user_info, user_info_class, %i[as_json])
+        resolve_validated_model(:user_info, user_info_class, UserInfo)
       end
 
       private
 
       # Resolves an `id_token_class` / `user_info_class` override to its class
-      # and validates that the required methods exist (presence only, not
-      # correctness). Both happen lazily at first use rather than inside
-      # `Doorkeeper::OpenidConnect.configure`: constantizing an app-defined
-      # class while initializers run breaks zeitwerk on Rails 7+, because
-      # reloadable constants must not be referenced during boot — the same
-      # reason `open_id_request_model` constantizes lazily. The class is also
-      # deliberately not memoized, so code reloading in development never
-      # hands back a stale class; only the validation result is cached, keyed
-      # on the resolved class so a reloaded class is re-validated.
-      def resolve_validated_model(kind, class_name, required_methods)
+      # and validates that it inherits from the corresponding default. The
+      # ancestry check replaced the earlier method-presence list: presence
+      # could be satisfied by any class (ActiveSupport defines `as_json` on
+      # `Object`), while inheritance also carries the security-critical
+      # behavior — required-claim enforcement, the claim merge order, nonce
+      # and `at_hash` handling — that a from-scratch implementation would
+      # have to reproduce. Both resolution and validation happen lazily at
+      # first use rather than inside `Doorkeeper::OpenidConnect.configure`:
+      # constantizing an app-defined class while initializers run breaks
+      # zeitwerk on Rails 7+, because reloadable constants must not be
+      # referenced during boot — the same reason `open_id_request_model`
+      # constantizes lazily. The class is also deliberately not memoized, so
+      # code reloading in development never hands back a stale class; only
+      # the validation result is cached, keyed on the resolved class so a
+      # reloaded class is re-validated.
+      def resolve_validated_model(kind, class_name, base_model)
         # `safe_constantize` (unlike a bare `constantize` rescue) only reports
         # nil when the configured constant itself is missing; a NameError
         # raised while loading the class body still surfaces as-is.
@@ -183,14 +193,9 @@ module Doorkeeper
         @validated_models ||= {}
         return model if @validated_models[kind] == model
 
-        missing_methods = required_methods.reject do |method|
-          model.method_defined?(method) || model.private_method_defined?(method)
-        end
-
-        unless missing_methods.empty?
+        unless model.is_a?(Class) && model <= base_model
           raise Errors::InvalidConfiguration,
-                "The configured #{kind}_class (#{class_name}) is missing the following " \
-                "required methods: #{missing_methods.join(", ")}"
+                "The configured #{kind}_class (#{class_name}) must inherit from #{base_model.name}"
         end
 
         @validated_models[kind] = model

--- a/lib/doorkeeper/openid_connect/hybrid_id_token_concern.rb
+++ b/lib/doorkeeper/openid_connect/hybrid_id_token_concern.rb
@@ -3,9 +3,10 @@
 module Doorkeeper
   module OpenidConnect
     # Adds the `at_hash` claim required by the hybrid `id_token token` flow.
-    # The host object must implement `#claims` and expose the access token
-    # via an `#access_token` reader (public or private), as
-    # `Doorkeeper::OpenidConnect::IdToken` does.
+    # The host object must implement `#claims`, expose the access token via an
+    # `#access_token` reader, and resolve its signing key via `#selected_key` —
+    # all provided by `Doorkeeper::OpenidConnect::IdToken`, which configured
+    # `id_token_class` overrides must inherit from.
     module HybridIdTokenConcern
       def claims
         super.merge(at_hash: at_hash)
@@ -37,8 +38,12 @@ module Doorkeeper
         Base64.urlsafe_encode64(first_half).tr("=", "")
       end
 
+      # OIDC Core §3.2.2.10 requires the digest to match the `alg` of the ID
+      # Token's actual JOSE header — derived from the key the token is signed
+      # with (`selected_key`, shared with `as_jws_token`), not from the global
+      # `signing_algorithm`, which a `select_key` override may diverge from.
       def at_hash_digest
-        case Doorkeeper::OpenidConnect.signing_algorithm.to_s
+        case selected_key.algorithm.to_s
         when /256\z/ then Digest::SHA256
         when /384\z/ then Digest::SHA384
         when /512\z/ then Digest::SHA512

--- a/lib/doorkeeper/openid_connect/id_token.rb
+++ b/lib/doorkeeper/openid_connect/id_token.rb
@@ -9,6 +9,12 @@ module Doorkeeper
       # must never be silently dropped when blank.
       REQUIRED_CLAIMS = %i[iss sub aud exp iat].freeze
 
+      # The return type of `select_key`: the key material and the algorithm it
+      # signs with, kept together so `at_hash` can always be computed with the
+      # digest matching the algorithm in the token's actual JOSE header
+      # (OIDC Core §3.2.2.10).
+      SigningKey = Struct.new(:keypair, :kid, :algorithm, keyword_init: true)
+
       # `resource_owner` is exposed so callers can detect a token whose owner no
       # longer resolves (e.g. deleted after issuance) before serializing — the
       # `sub` claim would otherwise dereference a nil owner and raise.
@@ -58,10 +64,31 @@ module Doorkeeper
       end
 
       def as_jws_token
+        key = selected_key
+
         ::JWT.encode(as_json,
-                     Doorkeeper::OpenidConnect.signing_key.keypair,
-                     Doorkeeper::OpenidConnect.signing_algorithm.to_s,
-                     { typ: "JWT", kid: Doorkeeper::OpenidConnect.signing_key.kid }).to_s
+                     key.keypair,
+                     key.algorithm.to_s,
+                     { typ: "JWT", kid: key.kid }).to_s
+      end
+
+      # Override point for custom signing-key selection (per-client keys, key
+      # rotation, multi-tenant setups, …). Must return an object responding to
+      # `#keypair`, `#kid` and `#algorithm` — use `SigningKey` for convenience.
+      # Keys returned from here are not advertised automatically: a custom
+      # implementation is responsible for exposing any additional keys through
+      # its own JWKS handling so clients can validate the signature.
+      def select_key
+        # Resolved once: `signing_key` builds a fresh JWK per call and honors
+        # callable configuration, so reading `keypair` and `kid` from separate
+        # calls could pair values from two different keys.
+        jwk = Doorkeeper::OpenidConnect.signing_key
+
+        SigningKey.new(
+          keypair: jwk.keypair,
+          kid: jwk.kid,
+          algorithm: Doorkeeper::OpenidConnect.signing_algorithm.to_s,
+        )
       end
 
       # Public: the RFC 9207 `iss` authorization response parameter must be
@@ -77,6 +104,15 @@ module Doorkeeper
       end
 
       private
+
+      # `select_key` resolved exactly once per token, mirroring the `issuer`
+      # memoization above: the signature (`as_jws_token`) and the `at_hash`
+      # digest (`HybridIdTokenConcern`) must agree on the algorithm, so a
+      # dynamic `select_key` implementation must not be re-invoked between
+      # the two.
+      def selected_key
+        @selected_key ||= select_key
+      end
 
       def subject
         Doorkeeper::OpenidConnect.configuration.subject.call(

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -208,12 +208,20 @@ Doorkeeper::OpenidConnect.configure do
   # different apps may need different claim sets) or if you need to transform data before returning
   # it to external clients.
   #
-  # It is generally recommended to subclass the default models, but you can implement your own so
-  # long as they respond to `#as_json` (and, for the ID Token, also to `#as_jws_token`, `#issuer`,
-  # and an `#access_token` reader — the latter is used to compute the `at_hash` claim in the hybrid
-  # `id_token token` response type), and have the same initializer. These methods may be private;
-  # their presence is validated when the class is first used. Depending on the implementation, this
-  # may or may not override the provided behavior of the `claims` block.
+  # Custom classes must inherit from Doorkeeper::OpenidConnect::IdToken /
+  # Doorkeeper::OpenidConnect::UserInfo (validated when the class is first used). The base classes
+  # carry the security-critical behavior — required-claim enforcement, the claim merge order that
+  # keeps the `claims` configuration block from overriding `sub`/`aud`/`exp`, nonce and `at_hash`
+  # handling — so a subclass only overrides what it actually needs. Typical override points:
+  #
+  #   - `claims` — call `super.merge(...)` so the base claims are always present. A key you add
+  #     that collides with a registered claim replaces it, so keep your keys distinct unless
+  #     replacing it is what you mean
+  #   - `audience` (ID Token) — the `aud` claim may be a string or an array per OIDC Core
+  #   - `select_key` (ID Token) — return a Doorkeeper::OpenidConnect::IdToken::SigningKey to sign
+  #     with a different key/algorithm (per-client keys, rotation, multi-tenancy). The `at_hash`
+  #     digest follows the selected algorithm automatically; advertising any additional keys via
+  #     JWKS is the application's responsibility.
   #
   # Refer to Doorkeeper::OpenidConnect::IdToken and Doorkeeper::OpenidConnect::UserInfo for more
   # information and implementation details.

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -56,7 +56,11 @@ describe Doorkeeper::OpenidConnect, "configuration" do
                          "not resolve to a defined class"
     end
 
-    it "fails validation at first use if id_token doesn't implement required methods" do
+    it "fails validation at first use if id_token_class does not inherit from IdToken" do
+      # A duck-typed implementation is no longer enough: the base class
+      # carries the security-critical invariants (required-claim enforcement,
+      # claim merge order, nonce and at_hash handling), so the ancestry is
+      # what gets validated.
       stub_const("CustomIdToken", Class.new)
 
       described_class.configure do
@@ -66,27 +70,16 @@ describe Doorkeeper::OpenidConnect, "configuration" do
       expect do
         subject.id_token_model
       end.to raise_error Doorkeeper::OpenidConnect::Errors::InvalidConfiguration,
-                         "The configured id_token_class (CustomIdToken) is missing the following " \
-                         "required methods: as_jws_token, issuer, access_token"
+                         "The configured id_token_class (CustomIdToken) must inherit from " \
+                         "Doorkeeper::OpenidConnect::IdToken"
     end
 
-    it "fails validation at first use if user_info doesn't implement required methods" do
-      # BasicObject is the only class that escapes ActiveSupport's Object#as_json.
-      described_class.configure do
-        user_info_class "BasicObject"
-      end
-
-      expect do
-        subject.user_info_model
-      end.to raise_error Doorkeeper::OpenidConnect::Errors::InvalidConfiguration,
-                         "The configured user_info_class (BasicObject) is missing the following " \
-                         "required methods: as_json"
-    end
-
-    it "fails validation at first use if user_info is missing as_json" do
-      # ActiveSupport defines `#as_json` on Object, so the method has to be
-      # undefined explicitly to model a class that does not fulfill the contract.
-      stub_const("CustomUserInfo", Class.new { undef_method :as_json })
+    it "fails validation at first use if user_info_class does not inherit from UserInfo" do
+      # Under the earlier method-presence validation this was a no-op for
+      # user_info_class, because ActiveSupport defines `as_json` on `Object`
+      # and any class passed. The ancestry check cannot be satisfied
+      # accidentally.
+      stub_const("CustomUserInfo", Class.new)
 
       described_class.configure do
         user_info_class "CustomUserInfo"
@@ -95,29 +88,46 @@ describe Doorkeeper::OpenidConnect, "configuration" do
       expect do
         subject.user_info_model
       end.to raise_error Doorkeeper::OpenidConnect::Errors::InvalidConfiguration,
-                         "The configured user_info_class (CustomUserInfo) is missing the following " \
-                         "required methods: as_json"
+                         "The configured user_info_class (CustomUserInfo) must inherit from " \
+                         "Doorkeeper::OpenidConnect::UserInfo"
     end
 
-    it "accepts required methods implemented as private" do
-      private_id_token = Class.new do
-        private
-
-        attr_reader :access_token
-
-        def as_json(*); end
-
-        def as_jws_token; end
-
-        def issuer; end
-      end
-      stub_const("PrivateIdToken", private_id_token)
+    it "fails validation at first use if the configured constant is not a class" do
+      stub_const("ModuleIdToken", Module.new)
 
       described_class.configure do
-        id_token_class "PrivateIdToken"
+        id_token_class "ModuleIdToken"
       end
 
-      expect { subject.id_token_model }.not_to raise_error
+      expect do
+        subject.id_token_model
+      end.to raise_error Doorkeeper::OpenidConnect::Errors::InvalidConfiguration,
+                         "The configured id_token_class (ModuleIdToken) must inherit from " \
+                         "Doorkeeper::OpenidConnect::IdToken"
+    end
+
+    it "accepts subclasses of the default models" do
+      stub_const("InheritingIdToken", Class.new(Doorkeeper::OpenidConnect::IdToken))
+      stub_const("InheritingUserInfo", Class.new(Doorkeeper::OpenidConnect::UserInfo))
+
+      described_class.configure do
+        id_token_class "InheritingIdToken"
+        user_info_class "InheritingUserInfo"
+      end
+
+      expect(subject.id_token_model).to eq(InheritingIdToken)
+      expect(subject.user_info_model).to eq(InheritingUserInfo)
+    end
+
+    it "accepts indirect descendants of the default models" do
+      stub_const("BaseCustomIdToken", Class.new(Doorkeeper::OpenidConnect::IdToken))
+      stub_const("DeepCustomIdToken", Class.new(BaseCustomIdToken))
+
+      described_class.configure do
+        id_token_class "DeepCustomIdToken"
+      end
+
+      expect(subject.id_token_model).to eq(DeepCustomIdToken)
     end
   end
 

--- a/spec/lib/hybrid_id_token_concern_spec.rb
+++ b/spec/lib/hybrid_id_token_concern_spec.rb
@@ -75,10 +75,40 @@ describe Doorkeeper::OpenidConnect::HybridIdTokenConcern do
     end
 
     context "when the signing algorithm name carries no digest length (e.g. EdDSA)" do
-      before { configure_doorkeeper("the_greatest_secret_key", :EdDSA) }
+      before do
+        configure_doorkeeper("the_greatest_secret_key", :EdDSA)
+
+        # `select_key` resolves the key material eagerly, and the dummy string
+        # above is not a parseable EdDSA key — this context only exercises the
+        # digest fallback, so the key resolution is stubbed out.
+        allow(Doorkeeper::OpenidConnect).to receive(:signing_key)
+          .and_return(instance_double(JWT::JWK::RSA, keypair: nil, kid: "stub"))
+      end
 
       it "falls back to SHA-256" do
         expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA256))
+      end
+    end
+
+    context "when a select_key override signs with a different algorithm than the global config" do
+      subject { custom_class.new(access_token, nonce).extend(described_class) }
+
+      let(:custom_class) do
+        Class.new(Doorkeeper::OpenidConnect::IdToken) do
+          def select_key
+            Doorkeeper::OpenidConnect::IdToken::SigningKey.new(
+              keypair: "per-tenant-secret",
+              kid: "tenant-1",
+              algorithm: "HS512",
+            )
+          end
+        end
+      end
+
+      it "derives the digest from the selected algorithm, not the global signing_algorithm" do
+        # The global config stays RS256 (SHA-256); the token is actually
+        # signed with HS512, so §3.2.2.10 demands SHA-512.
+        expect(subject.claims[:at_hash]).to eq(expected_at_hash(token_value, Digest::SHA512))
       end
     end
 

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -326,4 +326,58 @@ describe Doorkeeper::OpenidConnect::IdToken do
       it_behaves_like "a jws token"
     end
   end
+
+  describe "#select_key" do
+    it "returns the globally configured key material, kid and algorithm" do
+      key = subject.select_key
+
+      # `signing_key` builds a fresh JWK per call, so key material is compared
+      # by its PEM export rather than object identity.
+      expect(key.keypair.to_pem).to eq Doorkeeper::OpenidConnect.signing_key.keypair.to_pem
+      expect(key.kid).to eq Doorkeeper::OpenidConnect.signing_key.kid
+      expect(key.algorithm).to eq Doorkeeper::OpenidConnect.signing_algorithm.to_s
+    end
+
+    it "resolves the global signing key once, so keypair and kid come from the same JWK" do
+      # A callable `signing_key` is re-evaluated per call, so reading keypair
+      # and kid from separate calls could pair values from different keys.
+      expect(Doorkeeper::OpenidConnect).to receive(:signing_key).once.and_call_original
+
+      subject.select_key
+    end
+
+    context "when overridden by a subclass" do
+      let(:custom_class) do
+        Class.new(described_class) do
+          def select_key
+            Doorkeeper::OpenidConnect::IdToken::SigningKey.new(
+              keypair: "per-tenant-secret",
+              kid: "tenant-1",
+              algorithm: "HS512",
+            )
+          end
+        end
+      end
+
+      before { stub_const("CustomIdToken", custom_class) }
+
+      it "signs the JWS token with the selected key, algorithm and kid" do
+        instance = CustomIdToken.new(access_token, nonce)
+
+        data, headers = ::JWT.decode(instance.as_jws_token, "per-tenant-secret", true, { algorithms: ["HS512"] })
+
+        expect(headers["alg"]).to eq "HS512"
+        expect(headers["kid"]).to eq "tenant-1"
+        expect(data["sub"]).to eq user.id.to_s
+      end
+
+      it "resolves the key exactly once per token" do
+        instance = CustomIdToken.new(access_token, nonce)
+        expect(instance).to receive(:select_key).once.and_call_original
+
+        instance.as_jws_token
+        instance.as_jws_token
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Implements the direction discussed in #344 with @KazWolfe (option B — inheritance + a `select_key` hook): `id_token_class` / `user_info_class` overrides must now inherit from `Doorkeeper::OpenidConnect::IdToken` / `UserInfo`, and `IdToken` gains a `select_key` override point that also closes the `at_hash` digest gap found in #339's discussion.

>[!NOTE]
>**Timing note for @nbulaj**: this changes the class-override contract introduced in #335 from duck typing to required inheritance. Since #335 has not shipped in any release, doing this now is a zero-cost change — once 2.0 is out, it becomes breaking for real configurations. That window is why I'd like to land (or explicitly reject) this before the release. The design discussion is in #344; happy to adapt if you prefer a different direction.

## Changes

### 1. Ancestry validation replaces the method-presence list

`resolve_validated_model` now checks `model <= IdToken` / `model <= UserInfo` instead of probing for method names. Two problems with the old check:

- For `user_info_class` it was effectively a no-op — ActiveSupport defines `as_json` on `Object`, so any class (including `Object` itself) passed.
- Passing it said nothing about correctness: a duck-typed implementation had to reproduce the base classes' security-critical behavior on its own (required-claim enforcement, the merge order that keeps custom claims from overriding `sub`/`aud`/`exp`, nonce and `at_hash` handling). A subclass gets all of that for free and overrides only what it needs — typically `claims` (with `super.merge(...)`), `audience`, or `select_key`.

The lazy resolution and non-memoization semantics from #337 (zeitwerk safety, dev code reloading) are unchanged, as is the per-class validation cache.

### 2. `select_key` hook on `IdToken`

Key selection used to be hardwired into `as_jws_token` via the global config, so per-client / per-tenant keys required overriding all of `as_jws_token`. `select_key` extracts it into an override point that returns the key material *and* the algorithm together:

```ruby
def select_key
  SigningKey.new(
    keypair: Doorkeeper::OpenidConnect.signing_key.keypair,
    kid: Doorkeeper::OpenidConnect.signing_key.kid,
    algorithm: Doorkeeper::OpenidConnect.signing_algorithm.to_s,
  )
end
```

`SigningKey` is a small keyword-init `Struct` nested in `IdToken`; any object responding to `#keypair` / `#kid` / `#algorithm` works. The result is resolved **once per token** through a private memoized reader (`selected_key`), mirroring the existing `issuer` memoization and for the same reason: the JWS signature and the `at_hash` digest must agree on the algorithm, so a dynamic implementation must not be re-invoked between the two.

Keys returned from an override are deliberately **not** auto-advertised — an implementation doing per-application keys owns its JWKS/key-management story (as discussed in #344). The default implementation keeps returning the globally configured key, so the JWKS endpoint remains correct out of the box.

### 3. `at_hash` digest bound to the selected key

`HybridIdTokenConcern#at_hash_digest` previously derived the hash from the global `signing_algorithm`. [OIDC Core §3.2.2.10](https://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken) requires it to match the `alg` of the ID Token's **actual** JOSE header, so a custom class signing with a different algorithm computed `at_hash` with the wrong digest. The digest now derives from `selected_key.algorithm` — the same value the token is signed with — closing the gap found in [#339's thread](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/339#issuecomment-5019419744) as a side effect.

### 4. Docs and specs

- Initializer template: the class-override section now documents the inheritance requirement and the typical override points (`claims` / `audience` / `select_key`).
- `config_spec`: the validation section is rewritten around ancestry (non-inheriting class, non-class constant, direct and indirect subclasses).
- New specs: `select_key` default values, a subclass override signing with a different key/algorithm/kid (verified by decoding the JWT), once-per-token resolution, and the hybrid `at_hash` digest following the selected algorithm while the global config stays RS256.

I'll add a Migration-guide section for the inheritance requirement to the wiki once this lands (the 2.0 section from #345 already assumes `class MyIdToken < IdToken` in its examples, so the guides stay consistent).

## Out of scope

- The initializer arity check from #339 — stacked as a separate PR on top of this branch, per the split agreed in that thread.
- Claims-generator / proc-based extension points floated in #344 — larger redesign, no consensus that it's needed yet.

Closes #344.