### PR TITLE
CI: exercise the released Rails 8.1 series

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - gemfiles/rails_7.1.gemfile
           - gemfiles/rails_7.2.gemfile
           - gemfiles/rails_8.0.gemfile
+          - gemfiles/rails_8.1.gemfile
           - gemfiles/doorkeeper_master.gemfile
         exclude:
           - ruby: head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [#355] Compute the hybrid `id_token token` flow's `at_hash` claim from the plaintext access token instead of the stored value, so ID Token validation by conforming clients succeeds when `hash_token_secrets` is enabled — completing the response-side alignment from [#351]
 - [#356] Fix a boot failure on Doorkeeper < 6.0 in applications that define a top-level `MetadataResponse` constant. The Doorkeeper 6.0 capability probe introduced in [#353] used `const_defined?` with its default `inherit: true`, which continues the lookup into `Object` — and reports true for a constant Zeitwerk has merely registered for autoloading — so a host application's own unrelated class made the gem take the 6.0 branch and raise `NameError: uninitialized constant Doorkeeper::MetadataController` from the engine's `to_prepare`. The probe now lives in one place as `Doorkeeper::OpenidConnect.doorkeeper_metadata_endpoint?` and is asked with `inherit: false`, instead of being repeated at each branch. [#353] has not shipped in a release, so no released version is affected
 - [#357] Add specs for the conditional `registration_endpoint` and `end_session_endpoint` members of the enriched RFC 8414 document, which were previously only asserted in their omission branches
+- [#366] CI: exercise the released Rails 8.1 series via `gemfiles/rails_8.1.gemfile` — the test matrix previously stopped at Rails 8.0
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rails", "~> 8.1.0"
+gem "rails-controller-testing"
+gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
+
+gemspec path: "../"


### PR DESCRIPTION
The build matrix stops at `gemfiles/rails_8.0.gemfile`, but the Rails 8.1 series has been out for a while (latest: 8.1.3.1). This adds it to CI so 2.0 ships with the current Rails release actually exercised.