### PR TITLE
Add a Playwright end-to-end suite for the dummy app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,68 @@ jobs:
       - name: Run tests
         timeout-minutes: 10
         run: bundle exec rake spec
+  e2e:
+    name: E2E (${{ matrix.gemfile }})
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]'))
+    strategy:
+      fail-fast: false
+      matrix:
+        # Short names (not gemfile paths like the build matrix) so they can
+        # name the failure artifact below — expressions have no replace().
+        gemfile:
+          - rails_8.1
+          - doorkeeper_master
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Install Playwright
+        working-directory: e2e
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+
+      - name: Install Chromium
+        working-directory: e2e
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        timeout-minutes: 15
+        working-directory: e2e
+        run: npx playwright test
+
+      - name: Upload traces and report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts-${{ matrix.gemfile }}
+          path: |
+            e2e/playwright-report/
+            e2e/test-results/
+          retention-days: 7
   lint:
     name: RuboCop
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 /spec/dummy/log/*.log
 /spec/dummy/tmp/
 /spec/examples.txt
+/e2e/node_modules/
+/e2e/test-results/
+/e2e/playwright-report/
 /pkg
 gemfiles/*.lock
 *.gem

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This repository is the `doorkeeper-openid_connect` gem: a Rails engine that adds
 - `app/controllers/doorkeeper/openid_connect/**`: discovery, userinfo, dynamic registration endpoints
 - `spec/**`: test suite
 - `spec/dummy/**`: Rails app used by controller/integration-style specs
+- `e2e/**`: Playwright browser tests that drive the dummy app over real HTTP
 
 ## Test and lint commands
 
@@ -41,11 +42,23 @@ bundle exec rake spec
 bundle exec rubocop
 ```
 
+Browser end-to-end tests (require Node.js; Playwright boots the dummy app on
+port 3000 with its own sqlite database):
+
+```bash
+cd e2e && npm install && npx playwright install chromium && npx playwright test
+```
+
 Notes:
 
 - The default `Gemfile` uses `ENV["rails"]` and defaults to Rails `8.0.0`.
-- CI runs `bundle exec rake spec` across the matrix in `.github/workflows/ci.yml`.
+- CI runs `bundle exec rake spec` across the matrix in `.github/workflows/ci.yml`,
+  plus the `e2e` job on two gemfiles.
 - Use the root-level test command unless a task specifically requires a different `BUNDLE_GEMFILE`.
+- The dummy app runs the e2e suite in development mode; passing `force_consent=1`
+  to `/oauth/authorize` disables the development-only `skip_authorization` so the
+  consent screen renders. The dummy `resource_owner_authenticator` remembers
+  `params[:current_user]` in the session to survive the consent form POST.
 
 ## Change expectations
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ To run the local engine server:
 bundle exec rake server
 ```
 
+To run the browser end-to-end tests (requires Node.js; they boot the dummy app
+on port 3000 and drive its dashboard with [Playwright](https://playwright.dev/)):
+
+```sh
+cd e2e
+npm install
+npx playwright install chromium
+npx playwright test
+```
+
+Use `npx playwright test --ui` for interactive debugging. If a server started
+via `bundle exec rake server` is already listening on port 3000, the tests
+reuse it (with its existing database) instead of booting their own.
+
 By default, Rails 8.0 is used. To use a specific version run:
 
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -24,3 +24,10 @@ task :server do
     system("bin/rails server")
   end
 end
+
+desc "Run browser end-to-end tests against the test application"
+task :e2e do
+  Dir.chdir("e2e") do
+    system("npx playwright test", exception: true)
+  end
+end

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "doorkeeper-openid_connect-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "doorkeeper-openid_connect-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "doorkeeper-openid_connect-e2e",
+  "private": true,
+  "description": "Browser end-to-end tests driving spec/dummy over real HTTP",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// The dummy app must listen on port 3000: applications created through the
+// dashboard default to a http://localhost:3000/callback redirect URI.
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  fullyParallel: false,
+  workers: 1, // one shared server + one sqlite file
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    // A fresh DB every run; DATABASE_URL keeps db/development.sqlite3 untouched.
+    command: 'rm -f db/e2e.sqlite3* && bin/rails db:schema:load && exec bin/rails server -p 3000',
+    cwd: '../spec/dummy',
+    url: 'http://localhost:3000/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { RAILS_ENV: 'development', DATABASE_URL: 'sqlite3:db/e2e.sqlite3' },
+  },
+});

--- a/e2e/tests/auth-code.spec.ts
+++ b/e2e/tests/auth-code.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { setup, runAuthCodeFlow, idTokenPayload } from './helpers';
+
+test.describe('Authorization code flow', () => {
+  test('issues a code, exchanges it for tokens and serves userinfo', async ({ page }) => {
+    const s = await setup(page, 'authcode');
+    const { nonce } = await runAuthCodeFlow(page, s, { nonce: true });
+
+    const payload = await idTokenPayload(page);
+    expect(payload.iss).toBe('dummy');
+    expect(payload.sub).toBe(s.userId);
+    expect(payload.aud).toBe(s.app.uid);
+    expect(payload.nonce).toBe(nonce);
+    expect(typeof payload.exp).toBe('number');
+    expect(typeof payload.iat).toBe('number');
+    expect(payload.exp as number).toBeGreaterThan(payload.iat as number);
+    // Custom claims: without an explicit `response:` option they are
+    // userinfo-only, so the ID token carries just the id_token-targeted ones.
+    expect(payload).not.toHaveProperty('name');
+    expect(payload).toHaveProperty('id_token_response');
+    expect(payload).toHaveProperty('both_responses');
+    expect(payload).not.toHaveProperty('user_info_response');
+
+    await page.getByRole('button', { name: 'Get UserInfo' }).click();
+    const userinfo = page.locator('#userinfo_result');
+    await expect(userinfo).toContainText(`"sub": "${s.userId}"`);
+    // `name` defaults to the profile scope, which this client was not granted.
+    await expect(userinfo).not.toContainText('"name"');
+    await expect(userinfo).toContainText('"variable_name": "openid-name"');
+    await expect(userinfo).toContainText('"user_info_response": "user_info"');
+    await expect(userinfo).toContainText('"both_responses": "both"');
+    await expect(userinfo).not.toContainText('"id_token_response"');
+  });
+
+  test('rejects an already used authorization code', async ({ page }) => {
+    const s = await setup(page, 'authcode-reuse');
+    await runAuthCodeFlow(page, s);
+
+    // The code was consumed by the first exchange; replaying it must fail.
+    await page.getByRole('button', { name: 'Exchange' }).click();
+    await expect(page.locator('#exchange_result')).toContainText('invalid_grant');
+  });
+});

--- a/e2e/tests/consent.spec.ts
+++ b/e2e/tests/consent.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { setup, startAuthorization } from './helpers';
+
+// force_consent=1 disables the development-mode skip_authorization, so the
+// real Doorkeeper consent screen renders. Each test runs in a fresh browser
+// context, so the session-stored current_user never leaks between tests.
+test.describe('Consent screen', () => {
+  test('approving issues a code that can be exchanged', async ({ page }) => {
+    const s = await setup(page, 'consent-ok');
+    await startAuthorization(page, s, { forceConsent: true });
+
+    await expect(page.locator('body')).toContainText('Authorization required');
+    await expect(page.locator('body')).toContainText(s.app.name);
+
+    await page.getByRole('button', { name: 'Authorize' }).click();
+
+    await expect(page.locator('#authorize_result')).toContainText('"code"');
+    await page.getByRole('button', { name: 'Exchange' }).click();
+    await expect(page.locator('#exchange_result')).toContainText('"access_token"');
+  });
+
+  test('denying redirects back with access_denied', async ({ page }) => {
+    const s = await setup(page, 'consent-ng');
+    await startAuthorization(page, s, { forceConsent: true });
+
+    await expect(page.locator('body')).toContainText('Authorization required');
+    await page.getByRole('button', { name: 'Deny' }).click();
+
+    await expect(page.locator('#authorize_result')).toContainText('access_denied');
+    await expect(page.locator('#authorize_result')).not.toContainText('"code"');
+  });
+});

--- a/e2e/tests/discovery.spec.ts
+++ b/e2e/tests/discovery.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Discovery', () => {
+  test('serves the openid-configuration document', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'GET openid-configuration' }).click();
+
+    const pre = page.locator('#disc_config');
+    await expect(pre).toContainText('"issuer": "dummy"');
+
+    const config = JSON.parse((await pre.textContent())!);
+    expect(config.authorization_endpoint).toBe('http://localhost:3000/oauth/authorize');
+    expect(config.token_endpoint).toBe('http://localhost:3000/oauth/token');
+    expect(config.userinfo_endpoint).toBe('http://localhost:3000/oauth/userinfo');
+    expect(config.jwks_uri).toBe('http://localhost:3000/oauth/discovery/keys');
+    expect(config.scopes_supported).toContain('openid');
+    expect(config.response_types_supported).toEqual(
+      expect.arrayContaining(['code', 'id_token', 'id_token token']),
+    );
+    expect(config.code_challenge_methods_supported).toContain('S256');
+    expect(config.id_token_signing_alg_values_supported).toEqual(['RS256']);
+    expect(config.subject_types_supported).toEqual(['public']);
+  });
+
+  test('serves the JWKS with the RSA public key only', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'GET jwks (discovery/keys)' }).click();
+
+    const pre = page.locator('#disc_keys');
+    await expect(pre).toContainText('"kty": "RSA"');
+
+    const jwks = JSON.parse((await pre.textContent())!);
+    expect(jwks.keys).toHaveLength(1);
+    const key = jwks.keys[0];
+    expect(key.use).toBe('sig');
+    expect(key.alg).toBe('RS256');
+    expect(key.kid).toBeTruthy();
+    expect(key.n).toBeTruthy();
+    // Never expose private key material.
+    expect(key).not.toHaveProperty('d');
+    expect(key).not.toHaveProperty('p');
+    expect(key).not.toHaveProperty('q');
+  });
+});

--- a/e2e/tests/errors.spec.ts
+++ b/e2e/tests/errors.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { setup } from './helpers';
+
+test.describe('Authorization error responses', () => {
+  test('refuses a redirect_uri that does not match the client', async ({ page }) => {
+    const s = await setup(page, 'err-redirect');
+    const params = new URLSearchParams({
+      client_id: s.app.uid,
+      redirect_uri: 'http://evil.example/cb',
+      response_type: 'code',
+      scope: 'openid',
+      current_user: s.userId,
+    });
+    await page.goto(`/oauth/authorize?${params}`);
+
+    // The error must be rendered locally, never redirected to the evil host.
+    expect(new URL(page.url()).host).toBe('localhost:3000');
+    await expect(page.locator('body')).toContainText(/redirect uri/i);
+  });
+
+  test('rejects an unknown client_id', async ({ page }) => {
+    const s = await setup(page, 'err-client');
+    const params = new URLSearchParams({
+      client_id: 'this-client-does-not-exist',
+      redirect_uri: 'http://localhost:3000/callback',
+      response_type: 'code',
+      scope: 'openid',
+      current_user: s.userId,
+    });
+    await page.goto(`/oauth/authorize?${params}`);
+
+    expect(new URL(page.url()).host).toBe('localhost:3000');
+    await expect(page.locator('body')).toContainText(/client/i);
+  });
+});

--- a/e2e/tests/form-post.spec.ts
+++ b/e2e/tests/form-post.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+import { setup, runAuthCodeFlow } from './helpers';
+
+test.describe('response_mode=form_post', () => {
+  test('delivers the code via POST and the exchange still succeeds', async ({ page }) => {
+    const s = await setup(page, 'formpost');
+    await runAuthCodeFlow(page, s, { responseMode: 'form_post', nonce: true });
+    await expect(page.locator('#exchange_result')).toContainText('"id_token"');
+  });
+});

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,0 +1,109 @@
+import { Page, expect } from '@playwright/test';
+
+export interface App {
+  name: string;
+  uid: string;
+  secret: string;
+}
+
+export interface Setup {
+  userId: string;
+  userName: string;
+  app: App;
+}
+
+export interface AuthorizeOptions {
+  responseType?: 'code' | 'id_token' | 'id_token token';
+  responseMode?: 'query' | 'fragment' | 'form_post';
+  nonce?: boolean;
+  pkce?: boolean;
+  forceConsent?: boolean;
+}
+
+// Creates a user through the dashboard form and returns its id.
+export async function createUser(page: Page, name: string): Promise<string> {
+  await page.goto('/');
+  const form = page.locator('form[action="/users"]');
+  await form.locator('input[name="name"]').fill(name);
+  await form.getByRole('button', { name: 'Create user' }).click();
+  const row = page.getByRole('row').filter({ hasText: name }).first();
+  await expect(row).toBeVisible();
+  return (await row.locator('td').first().textContent())!.trim();
+}
+
+// Creates an OAuth application through the dashboard form and returns its
+// uid/secret, scraped from the client <select> the dashboard renders.
+export async function createApplication(page: Page, name: string): Promise<App> {
+  await page.goto('/');
+  const form = page.locator('form[action="/applications"]');
+  await form.locator('input[name="name"]').fill(name);
+  await form.getByRole('button', { name: 'Create application' }).click();
+  const option = page.locator('#auth_client option').filter({ hasText: name }).first();
+  await expect(option).toBeAttached();
+  return {
+    name,
+    uid: (await option.getAttribute('data-uid'))!,
+    secret: (await option.getAttribute('data-secret'))!,
+  };
+}
+
+// Creates a user + application pair with names unique to this run.
+export async function setup(page: Page, prefix: string): Promise<Setup> {
+  const suffix = Date.now().toString(36);
+  const userName = `${prefix}-user-${suffix}`;
+  const userId = await createUser(page, userName);
+  const app = await createApplication(page, `${prefix}-app-${suffix}`);
+  return { userId, userName, app };
+}
+
+// Fills in the dashboard's authorization form and clicks "Authorize →".
+// Returns the nonce value when one was requested.
+export async function startAuthorization(
+  page: Page,
+  s: Setup,
+  opts: AuthorizeOptions = {},
+): Promise<{ nonce?: string }> {
+  await page.goto('/');
+  await page.selectOption('#current_user', s.userId);
+  const clientOption = page.locator('#auth_client option').filter({ hasText: s.app.name }).first();
+  await page.selectOption('#auth_client', (await clientOption.getAttribute('value'))!);
+  await page.selectOption('#response_type', opts.responseType ?? 'code');
+  if (opts.responseMode) await page.selectOption('#response_mode', opts.responseMode);
+
+  let nonce: string | undefined;
+  if (opts.nonce) {
+    await page.check('#nonce_enabled');
+    nonce = await page.inputValue('#nonce');
+    expect(nonce).not.toBe('');
+  }
+  if (opts.pkce) {
+    await page.check('#pkce_enabled');
+    await expect(page.locator('#code_verifier')).not.toBeEmpty();
+  }
+  if (opts.forceConsent) await page.check('#force_consent');
+
+  await page.getByRole('button', { name: 'Authorize →' }).click();
+  return { nonce };
+}
+
+// Runs the full authorization code flow through the dashboard: authorize,
+// bounce through /callback, exchange the code. Leaves the page on the
+// dashboard with #exchange_result, #idtoken_payload and #userinfo_token set.
+export async function runAuthCodeFlow(
+  page: Page,
+  s: Setup,
+  opts: AuthorizeOptions = {},
+): Promise<{ nonce?: string }> {
+  const { nonce } = await startAuthorization(page, s, opts);
+  await expect(page.locator('#authorize_result')).toContainText('"code"');
+  await page.getByRole('button', { name: 'Exchange' }).click();
+  await expect(page.locator('#exchange_result')).toContainText('"access_token"');
+  await expect(page.locator('#exchange_result')).toContainText('"id_token"');
+  return { nonce };
+}
+
+// Parses the decoded ID token payload the dashboard renders.
+export async function idTokenPayload(page: Page): Promise<Record<string, unknown>> {
+  await expect(page.locator('#idtoken_payload')).toContainText('"iss"');
+  return JSON.parse((await page.locator('#idtoken_payload').textContent())!);
+}

--- a/e2e/tests/implicit.spec.ts
+++ b/e2e/tests/implicit.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { setup, startAuthorization, idTokenPayload } from './helpers';
+
+test.describe('Implicit flow (id_token token)', () => {
+  test('returns tokens in the fragment and binds them with at_hash', async ({ page }) => {
+    const s = await setup(page, 'implicit');
+    const { nonce } = await startAuthorization(page, s, {
+      responseType: 'id_token token',
+      nonce: true,
+    });
+
+    // The callback page relays the fragment parameters back to the dashboard.
+    const result = page.locator('#authorize_result');
+    await expect(result).toContainText('"access_token"');
+    await expect(result).toContainText('"id_token"');
+    await expect(result).not.toContainText('"code"');
+
+    const payload = await idTokenPayload(page);
+    expect(payload.iss).toBe('dummy');
+    expect(payload.sub).toBe(s.userId);
+    expect(payload.aud).toBe(s.app.uid);
+    expect(payload.nonce).toBe(nonce);
+    expect(payload.at_hash).toBeTruthy();
+
+    // The fragment access token is auto-filled; it must work against userinfo.
+    await page.getByRole('button', { name: 'Get UserInfo' }).click();
+    await expect(page.locator('#userinfo_result')).toContainText(`"sub": "${s.userId}"`);
+  });
+});

--- a/e2e/tests/pkce.spec.ts
+++ b/e2e/tests/pkce.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import { setup, startAuthorization, runAuthCodeFlow } from './helpers';
+
+test.describe('PKCE (S256)', () => {
+  test('exchanges the code when the verifier matches', async ({ page }) => {
+    const s = await setup(page, 'pkce');
+    await runAuthCodeFlow(page, s, { pkce: true });
+    await expect(page.locator('#exchange_result')).toContainText('"access_token"');
+  });
+
+  test('rejects the exchange with a missing or wrong verifier', async ({ page }) => {
+    const s = await setup(page, 'pkce-neg');
+    await startAuthorization(page, s, { pkce: true });
+    await expect(page.locator('#authorize_result')).toContainText('"code"');
+
+    // Missing verifier → invalid_request (missing required parameter).
+    await page.locator('#tok_code_verifier').clear();
+    await page.getByRole('button', { name: 'Exchange' }).click();
+    await expect(page.locator('#exchange_result')).toContainText('invalid_request');
+
+    // Wrong verifier → invalid_grant (challenge mismatch).
+    await page.locator('#tok_code_verifier').fill('wrong-verifier-wrong-verifier-wrong-verifier');
+    await page.getByRole('button', { name: 'Exchange' }).click();
+    await expect(page.locator('#exchange_result')).toContainText('invalid_grant');
+  });
+});

--- a/e2e/tests/token-management.spec.ts
+++ b/e2e/tests/token-management.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { setup, runAuthCodeFlow } from './helpers';
+
+test.describe('Introspection and revocation', () => {
+  test('introspects an active token, revokes it and sees it die', async ({ page }) => {
+    const s = await setup(page, 'tokmgmt');
+    await runAuthCodeFlow(page, s);
+
+    const accessToken = await page.inputValue('#userinfo_token');
+    expect(accessToken).not.toBe('');
+
+    // The token-management section authenticates with the selected client.
+    const clientOption = page.locator('#tm_client option').filter({ hasText: s.app.name }).first();
+    await page.selectOption('#tm_client', (await clientOption.getAttribute('value'))!);
+
+    await page.locator('#introspect_token').fill(accessToken);
+    await page.getByRole('button', { name: 'Introspect' }).click();
+    await expect(page.locator('#introspect_result')).toContainText('"active": true');
+
+    await page.locator('#revoke_token').fill(accessToken);
+    await page.getByRole('button', { name: 'Revoke' }).click();
+    await expect(page.locator('#revoke_result')).toContainText('Revoked');
+
+    await page.getByRole('button', { name: 'Introspect' }).click();
+    await expect(page.locator('#introspect_result')).toContainText('"active": false');
+
+    // The 401 carries its error only in the WWW-Authenticate header.
+    await page.getByRole('button', { name: 'Get UserInfo' }).click();
+    await expect(page.locator('#userinfo_result')).toContainText('HTTP 401');
+    await expect(page.locator('#userinfo_result')).toContainText('invalid_token');
+  });
+});

--- a/gemfiles/doorkeeper_master.gemfile
+++ b/gemfiles/doorkeeper_master.gemfile
@@ -7,4 +7,7 @@ gem "rails", "~> 8.0.0"
 gem "rails-controller-testing"
 gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
 
+# The e2e CI job boots spec/dummy as a real server with this gemfile.
+gem "puma"
+
 gemspec path: "../"

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -6,4 +6,7 @@ gem "rails", "~> 8.1.0"
 gem "rails-controller-testing"
 gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
 
+# The e2e CI job boots spec/dummy as a real server with this gemfile.
+gem "puma"
+
 gemspec path: "../"

--- a/spec/dummy/app/views/dummy/index.html.erb
+++ b/spec/dummy/app/views/dummy/index.html.erb
@@ -216,8 +216,16 @@
 
   function getJson(url, outId, headers) {
     fetch(url, { headers: headers || { 'Accept': 'application/json' } })
-      .then(function (r) { return r.text(); })
-      .then(function (t) { try { show(outId, JSON.parse(t)); } catch (e) { show(outId, t); } })
+      .then(function (r) {
+        return r.text().then(function (t) {
+          if (t.trim() === '') {
+            var auth = r.headers.get('WWW-Authenticate');
+            show(outId, 'HTTP ' + r.status + (auth ? '\n' + auth : ''));
+            return;
+          }
+          try { show(outId, JSON.parse(t)); } catch (e) { show(outId, t); }
+        });
+      })
       .catch(function (e) { show(outId, String(e)); });
   }
   function postForm(url, params, outId, done) {

--- a/spec/dummy/app/views/dummy/index.html.erb
+++ b/spec/dummy/app/views/dummy/index.html.erb
@@ -141,6 +141,11 @@
       <label>max_age</label>
       <input type="number" id="max_age" min="0" placeholder="(unset)">
     </div>
+    <div class="field">
+      <label>force consent</label>
+      <input type="checkbox" id="force_consent">
+      <span class="hint">show the consent screen even though development skips authorization</span>
+    </div>
     <button type="button" onclick="authorize()">Authorize →</button>
     <h4>Result</h4>
     <pre id="authorize_result" class="muted">The authorization response will appear here after the redirect.</pre>
@@ -284,6 +289,7 @@
     }
     if ($('prompt').value) p.set('prompt', $('prompt').value);
     if ($('max_age').value !== '') p.set('max_age', $('max_age').value);
+    if ($('force_consent').checked) p.set('force_consent', '1');
 
     sessionStorage.setItem('oidc_ctx', JSON.stringify({
       client_id: app.uid,

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -4,8 +4,11 @@ Doorkeeper.configure do
   optional_scopes :openid
 
   resource_owner_authenticator do
-    if params[:current_user].present?
-      User.find(params[:current_user])
+    # The consent form only replays the OAuth params, so remember the user in
+    # the session to survive the POST back to /oauth/authorize.
+    session[:current_user] = params[:current_user] if params[:current_user].present?
+    if session[:current_user].present?
+      User.find(session[:current_user])
     else
       redirect_to("/login")
       nil
@@ -15,6 +18,6 @@ Doorkeeper.configure do
   grant_flows %w[authorization_code client_credentials implicit_oidc]
 
   skip_authorization do
-    Rails.env.development?
+    Rails.env.development? && params[:force_consent].blank?
   end
 end


### PR DESCRIPTION
## Motivation

The RSpec suite exercises controllers and requests in-process, but nothing ever drives the full OIDC flows through a real server over HTTP: there is currently no test that walks authorization → token exchange → userinfo end-to-end. Regressions that only surface at that level — middleware interactions, redirect handling, response modes, header-only error responses — stay invisible to CI even when every spec is green.

This PR adds a browser end-to-end suite that boots `spec/dummy` as a real Rails server and drives its dashboard UI with [Playwright](https://playwright.dev/). The dashboard already exercises discovery, authorize-URL building (nonce, PKCE S256 via WebCrypto, response modes), code exchange, ID token decoding, userinfo, introspection and revocation from plain JavaScript, so the suite automates exactly what a human would click through.

## What's covered (13 tests, chromium)

| Spec | Scenarios |
|------|-----------|
| `discovery` | openid-configuration contents; JWKS serves the RSA public key and never leaks private material |
| `auth-code` | code flow with nonce → token exchange → ID token claims (`iss`/`sub`/`aud`/`nonce`, response-targeted custom claims) → userinfo; reusing a consumed code fails with `invalid_grant` |
| `pkce` | S256 happy path; missing verifier → `invalid_request`, tampered verifier → `invalid_grant` |
| `implicit` | `id_token token` via fragment, `at_hash` present, fragment access token works against userinfo |
| `form-post` | `response_mode=form_post` delivers the code via POST and the exchange still succeeds |
| `token-management` | introspection `active: true` → revocation → `active: false`; revoked token gets a 401 from userinfo |
| `errors` | mismatched `redirect_uri` and unknown `client_id` render locally and never redirect to the foreign host |
| `consent` | the real Doorkeeper consent screen: approval issues an exchangeable code, denial returns `access_denied` |

## CI

A new independent `e2e` job runs the suite on two gemfiles — `rails_8.1` as the latest-stable signal and `doorkeeper_master` to catch upstream behavioral changes that only surface through real controllers and views. The existing build matrix and lint job are untouched. Node and the Chromium download are cached; traces, screenshots and the HTML report are uploaded as artifacts on failure.

The two gemfiles the job boots the dummy app with now include `puma`; the CI gemfiles never needed a server before because the RSpec suite runs in-process.

## Running locally

```sh
cd e2e
npm install
npx playwright install chromium
npx playwright test        # or: bundle exec rake e2e
```

`npx playwright test --ui` opens the interactive debugger. See the README's Development section and AGENTS.md for details.

<details>

<summary>Design decisions</summary>

- **Server lifecycle**: Playwright's `webServer` hook boots the dummy app in the development environment on port 3000 (the dashboard's default redirect URI) with `DATABASE_URL=sqlite3:db/e2e.sqlite3`, recreating the database on every run. The developer's `development.sqlite3` is never touched. Locally, an already running `rake server` is reused for fast iteration; CI always boots fresh.
- **No seeds**: each spec creates its own user and application through the dashboard forms, which doubles as coverage for the setup endpoints.
- **Consent screen**: two small dummy-app changes make it reachable. `skip_authorization` now yields when the new `force_consent` parameter is present, and `resource_owner_authenticator` remembers `params[:current_user]` in the session — Doorkeeper's consent form only replays the OAuth parameters, so without the session fallback the approval POST lost the resource owner and dead-ended at the nonexistent `/login`. Normal development URLs behave exactly as before, and the full RSpec suite is unaffected (443 examples, 0 failures).
- **Dashboard fix along the way**: body-less responses (e.g. the userinfo 401, whose error details live only in the `WWW-Authenticate` header) previously rendered a blank result; the dashboard now shows `HTTP <status>` plus that header.

</details>
