### PR TITLE
Skip the changelog check for documentation-only pull requests

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,7 +16,33 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
+      # A pull request that only edits Markdown files documents the project
+      # instead of changing the library, so it leaves an upgrader nothing to
+      # read in CHANGELOG.md. Recognizing that here rather than through a label
+      # keeps the job green on its own: external contributors cannot label
+      # their own pull requests, so a label-based exemption would always wait
+      # for a maintainer first.
+      - name: Detect a documentation-only pull request
+        id: docs_only
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FILES_ENDPOINT: repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files
+        run: |
+          files="$(gh api --paginate "$FILES_ENDPOINT" --jq '.[].filename')"
+          other="$(printf '%s\n' "$files" | grep -v '\.md$' || true)"
+
+          echo "Changed files:"
+          echo "$files"
+
+          if [ -n "$files" ] && [ -z "$other" ]; then
+            echo "Only Markdown files were changed; skipping the changelog check."
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: dangoslen/changelog-enforcer@v3.7.0
+        if: steps.docs_only.outputs.result != 'true'
         with:
           # Dependabot PRs are labeled "dependencies" automatically and don't
           # need a changelog entry; "Skip-Changelog" keeps a manual escape hatch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 We are using the [Feature Branch Workflow (also known as GitHub Flow)](https://guides.github.com/introduction/flow/), and prefer delivery as pull requests.
 
-Our first line of defense is the [CI workflow](.github/workflows/ci.yml), triggered for every pull request, which runs the specs against each supported Ruby, Rails and Doorkeeper combination. Two more workflows run alongside it: [rubocop](.github/workflows/rubocop.yml) reports style offenses as review comments, and the [changelog verifier](.github/workflows/changelog.yml) expects every pull request to update `CHANGELOG.md` unless it is labeled `Skip-Changelog`.
+Our first line of defense is the [CI workflow](.github/workflows/ci.yml), triggered for every pull request, which runs the specs against each supported Ruby, Rails and Doorkeeper combination. Two more workflows run alongside it: [rubocop](.github/workflows/rubocop.yml) reports style offenses as review comments, and the [changelog verifier](.github/workflows/changelog.yml) expects every pull request to update `CHANGELOG.md`. A pull request that only edits Markdown files is exempt automatically; anything else is exempt only when it is labeled `Skip-Changelog`.
 
 Create a feature branch:
 


### PR DESCRIPTION
Follow-up to https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/371#issuecomment-5291466469

The changelog verifier asks every pull request to update `CHANGELOG.md`. The escape hatch today is the `Skip-Changelog` label, which an external contributor cannot apply to their own pull request — so a documentation-only PR stays red until a maintainer intervenes.

This adds a step that checks the changed file paths before the enforcer runs. When every changed file ends in `.md`, the enforcer is skipped automatically. The `Skip-Changelog` and `dependencies` labels still work as manual escape hatches for everything else.

The check uses step-level `if` rather than `paths-ignore` on the workflow trigger — `paths-ignore` would prevent the job from firing at all, which blocks merge when the check is required.

No library change.