### PR TITLE
Add a Capybara end-to-end suite for the dummy app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,46 @@ jobs:
       - name: Run tests
         timeout-minutes: 10
         run: bundle exec rake spec
+  e2e:
+    name: E2E (${{ matrix.gemfile }})
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]'))
+    strategy:
+      fail-fast: false
+      matrix:
+        # Short names (not gemfile paths like the build matrix) so they can
+        # name the failure artifact below — expressions have no replace().
+        gemfile:
+          - rails_8.1
+          - doorkeeper_master
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      # Cuprite drives the Chrome the runner image already ships, so the suite
+      # needs nothing beyond the bundle.
+      - name: Run E2E tests
+        timeout-minutes: 15
+        run: bundle exec rake e2e
+
+      - name: Upload the pages of failed examples
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts-${{ matrix.gemfile }}
+          path: spec/dummy/tmp/e2e/
+          retention-days: 7
   lint:
     name: RuboCop
     runs-on: ubuntu-latest

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,10 +40,19 @@ Layout/LineLength:
     - lib/doorkeeper/openid_connect/orm/active_record/mixins/openid_request.rb
     - lib/generators/doorkeeper/openid_connect/templates/initializer.rb
   Max: 100
+Lint/Debugger:
+  Exclude:
+    # The end-to-end suite deliberately keeps the page of a failed example,
+    # through Capybara's save_page/save_screenshot, which this cop reads as
+    # debugger entry points.
+    - spec/e2e/e2e_helper.rb
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
     - doorkeeper-openid_connect.gemspec
+Metrics/ParameterLists:
+  Exclude:
+    - spec/**/*
 Metrics/MethodLength:
   Exclude:
     - spec/dummy/db/**/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This repository is the `doorkeeper-openid_connect` gem: a Rails engine that adds
 - `app/controllers/doorkeeper/openid_connect/**`: discovery, userinfo, dynamic registration endpoints
 - `spec/**`: test suite
 - `spec/dummy/**`: Rails app used by controller/integration-style specs
+- `spec/e2e/**`: Capybara + Cuprite browser tests that drive the dummy app over real HTTP
 
 ## Test and lint commands
 
@@ -41,11 +42,27 @@ bundle exec rake spec
 bundle exec rubocop
 ```
 
+Browser end-to-end tests (Capybara boots the dummy app, Cuprite drives it in an
+installed Chrome):
+
+```bash
+bundle exec rake e2e
+```
+
 Notes:
 
 - The default `Gemfile` uses `ENV["rails"]` and defaults to Rails `8.0.0`.
-- CI runs `bundle exec rake spec` across the matrix in `.github/workflows/ci.yml`.
+- CI runs `bundle exec rake spec` across the matrix in `.github/workflows/ci.yml`,
+  plus the `e2e` job on two gemfiles.
 - Use the root-level test command unless a task specifically requires a different `BUNDLE_GEMFILE`.
+- `rake e2e` is a separate task, and `rake spec` excludes `spec/e2e`, because the
+  e2e suite boots the dummy app in the development environment (with its own
+  `db/e2e.sqlite3`) while the rest of the suite boots it in the test environment.
+  One process can only do one of the two.
+- Development mode is what the dashboard needs: Doorkeeper skips authorization
+  there, so passing `force_consent=1` to `/oauth/authorize` is what makes the
+  consent screen render. The dummy `resource_owner_authenticator` remembers
+  `params[:current_user]` in the session to survive the consent form POST.
 
 ## Change expectations
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,11 @@ end
 
 group :development do
   gem "puma"
+
+  # The browser end-to-end suite in spec/e2e. `require: false` keeps them out
+  # of the dummy application's own Bundler.require.
+  gem "capybara", require: false
+  gem "cuprite", require: false
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ To run the local engine server:
 bundle exec rake server
 ```
 
+To run the browser end-to-end tests, which boot the dummy app with
+[Capybara](https://github.com/teamcapybara/capybara) and drive its dashboard
+through [Cuprite](https://github.com/rubycdp/cuprite):
+
+```sh
+bundle exec rake e2e
+```
+
+They need an installed Chrome or Chromium and nothing else. Run them with
+`HEADLESS=false` to watch a flow in a visible browser. The suite boots the app
+in the development environment against its own `spec/dummy/db/e2e.sqlite3`
+database, so it leaves the one behind `bundle exec rake server` alone, and it
+saves the page of a failing example to `spec/dummy/tmp/e2e`.
+
 By default, Rails 8.0 is used. To use a specific version run:
 
 ```sh

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,11 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new
+RSpec::Core::RakeTask.new(:spec) do |t|
+  # The end-to-end suite boots the dummy application in the development
+  # environment, so it cannot share this process. `rake e2e` runs it.
+  t.rspec_opts = %(--exclude-pattern "spec/e2e/**/*_spec.rb")
+end
 
 task default: :spec
 task test: :spec
@@ -23,4 +27,9 @@ task :server do
   Dir.chdir("spec/dummy") do
     system("bin/rails server")
   end
+end
+
+desc "Run browser end-to-end tests against the test application"
+RSpec::Core::RakeTask.new(:e2e) do |t|
+  t.pattern = "spec/e2e/**/*_spec.rb"
 end

--- a/gemfiles/doorkeeper_master.gemfile
+++ b/gemfiles/doorkeeper_master.gemfile
@@ -7,4 +7,10 @@ gem "rails", "~> 8.0.0"
 gem "rails-controller-testing"
 gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
 
+# The e2e CI job runs with this gemfile: Capybara boots spec/dummy as a real
+# server and Cuprite drives it in Chrome.
+gem "capybara", require: false
+gem "cuprite", require: false
+gem "puma"
+
 gemspec path: "../"

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -6,4 +6,10 @@ gem "rails", "~> 8.1.0"
 gem "rails-controller-testing"
 gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
 
+# The e2e CI job runs with this gemfile: Capybara boots spec/dummy as a real
+# server and Cuprite drives it in Chrome.
+gem "capybara", require: false
+gem "cuprite", require: false
+gem "puma"
+
 gemspec path: "../"

--- a/spec/dummy/app/controllers/dummy_controller.rb
+++ b/spec/dummy/app/controllers/dummy_controller.rb
@@ -21,7 +21,9 @@ class DummyController < ApplicationController
   def create_application
     application = Doorkeeper::Application.new(
       name: params[:name],
-      redirect_uri: params[:redirect_uri].presence || "http://localhost:3000/callback",
+      # Default to this server's own callback, whatever host and port it is
+      # reachable on, so the dashboard also works on a non-default port.
+      redirect_uri: params[:redirect_uri].presence || callback_url,
       scopes: params[:scopes].presence || "openid",
     )
 

--- a/spec/dummy/app/views/dummy/index.html.erb
+++ b/spec/dummy/app/views/dummy/index.html.erb
@@ -216,8 +216,16 @@
 
   function getJson(url, outId, headers) {
     fetch(url, { headers: headers || { 'Accept': 'application/json' } })
-      .then(function (r) { return r.text(); })
-      .then(function (t) { try { show(outId, JSON.parse(t)); } catch (e) { show(outId, t); } })
+      .then(function (r) {
+        return r.text().then(function (t) {
+          if (t.trim() === '') {
+            var auth = r.headers.get('WWW-Authenticate');
+            show(outId, 'HTTP ' + r.status + (auth ? '\n' + auth : ''));
+            return;
+          }
+          try { show(outId, JSON.parse(t)); } catch (e) { show(outId, t); }
+        });
+      })
       .catch(function (e) { show(outId, String(e)); });
   }
   function postForm(url, params, outId, done) {

--- a/spec/dummy/app/views/dummy/index.html.erb
+++ b/spec/dummy/app/views/dummy/index.html.erb
@@ -9,7 +9,7 @@
 
   <h3>Users</h3>
   <% if @users.any? %>
-    <table>
+    <table id="users">
       <tr><th>id</th><th>name</th></tr>
       <% @users.each do |user| %>
         <tr><td><%= user.id %></td><td><%= user.name %></td></tr>
@@ -28,7 +28,7 @@
 
   <h3>Applications</h3>
   <% if @applications.any? %>
-    <table>
+    <table id="applications">
       <tr><th>id</th><th>name</th><th>uid (client_id)</th><th>secret</th><th>redirect_uri</th><th>scopes</th></tr>
       <% @applications.each do |app| %>
         <tr>

--- a/spec/dummy/app/views/dummy/index.html.erb
+++ b/spec/dummy/app/views/dummy/index.html.erb
@@ -46,7 +46,7 @@
   <% end %>
   <%= form_with url: applications_path, method: :post do |f| %>
     <div class="field"><label>name</label><%= f.text_field :name, placeholder: "my-client", required: true %></div>
-    <div class="field"><label>redirect_uri</label><%= f.text_field :redirect_uri, value: "http://localhost:3000/callback" %></div>
+    <div class="field"><label>redirect_uri</label><%= f.text_field :redirect_uri, value: callback_url %></div>
     <div class="field"><label>scopes</label><%= f.text_field :scopes, value: "openid" %></div>
     <div class="field"><%= f.submit "Create application" %></div>
   <% end %>

--- a/spec/dummy/app/views/dummy/index.html.erb
+++ b/spec/dummy/app/views/dummy/index.html.erb
@@ -141,6 +141,11 @@
       <label>max_age</label>
       <input type="number" id="max_age" min="0" placeholder="(unset)">
     </div>
+    <div class="field">
+      <label>force consent</label>
+      <input type="checkbox" id="force_consent">
+      <span class="hint">show the consent screen even though development skips authorization</span>
+    </div>
     <button type="button" onclick="authorize()">Authorize →</button>
     <h4>Result</h4>
     <pre id="authorize_result" class="muted">The authorization response will appear here after the redirect.</pre>
@@ -284,6 +289,7 @@
     }
     if ($('prompt').value) p.set('prompt', $('prompt').value);
     if ($('max_age').value !== '') p.set('max_age', $('max_age').value);
+    if ($('force_consent').checked) p.set('force_consent', '1');
 
     sessionStorage.setItem('oidc_ctx', JSON.stringify({
       client_id: app.uid,

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -4,17 +4,25 @@ Doorkeeper.configure do
   optional_scopes :openid
 
   resource_owner_authenticator do
-    if params[:current_user].present?
-      User.find(params[:current_user])
-    else
+    # The consent form only replays the OAuth params, so remember the user in
+    # the session to survive the POST back to /oauth/authorize.
+    session[:current_user] = params[:current_user] if params[:current_user].present?
+    # `find_by`, not `find`: the id arrives from a query parameter, so a stale
+    # or made-up value must send the visitor to the login page rather than
+    # raise RecordNotFound.
+    user = User.find_by(id: session[:current_user]) if session[:current_user].present?
+
+    if user.nil?
+      session.delete(:current_user)
       redirect_to("/login")
-      nil
     end
+
+    user
   end
 
   grant_flows %w[authorization_code client_credentials implicit_oidc]
 
   skip_authorization do
-    Rails.env.development?
+    Rails.env.development? && params[:force_consent].blank?
   end
 end

--- a/spec/e2e/auth_code_spec.rb
+++ b/spec/e2e/auth_code_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative "e2e_helper"
+
+RSpec.describe "Authorization code flow" do
+  it "issues a code, exchanges it for tokens and serves userinfo" do
+    client = dashboard_client("authcode")
+    nonce = run_auth_code_flow(client, nonce: true)
+
+    payload = id_token_payload
+    expect(payload["iss"]).to eq("dummy")
+    expect(payload["sub"]).to eq(client.user_id)
+    expect(payload["aud"]).to eq(client.uid)
+    expect(payload["nonce"]).to eq(nonce)
+    expect(payload["exp"]).to be_a(Integer)
+    expect(payload["iat"]).to be_a(Integer)
+    expect(payload["exp"]).to be > payload["iat"]
+    # Without an explicit `response:` option a claim is userinfo-only, so the
+    # ID token carries just the ones targeted at it.
+    expect(payload).not_to have_key("name")
+    expect(payload).to have_key("id_token_response")
+    expect(payload).to have_key("both_responses")
+    expect(payload).not_to have_key("user_info_response")
+
+    click_button "Get UserInfo"
+    expect(page).to have_css("#userinfo_result", text: %("sub": "#{client.user_id}"))
+    # `name` defaults to the profile scope, which this client was not granted.
+    expect(page).to have_no_css("#userinfo_result", text: '"name"')
+    expect(page).to have_css("#userinfo_result", text: '"variable_name": "openid-name"')
+    expect(page).to have_css("#userinfo_result", text: '"user_info_response": "user_info"')
+    expect(page).to have_css("#userinfo_result", text: '"both_responses": "both"')
+    expect(page).to have_no_css("#userinfo_result", text: '"id_token_response"')
+  end
+
+  it "rejects an already used authorization code" do
+    client = dashboard_client("authcode-reuse")
+    run_auth_code_flow(client)
+
+    # The first exchange consumed the code; replaying it must fail.
+    click_button "Exchange"
+    expect(page).to have_css("#exchange_result", text: "invalid_grant")
+  end
+end

--- a/spec/e2e/consent_spec.rb
+++ b/spec/e2e/consent_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "e2e_helper"
+
+# force_consent=1 turns off the development-only skip_authorization, so
+# Doorkeeper's real consent screen renders. Capybara resets the session between
+# examples, so the remembered current_user never leaks from one to the next.
+RSpec.describe "Consent screen" do
+  it "issues a code that can be exchanged when the user approves" do
+    client = dashboard_client("consent-ok")
+    start_authorization(client, force_consent: true)
+
+    expect(page).to have_text("Authorization required")
+    expect(page).to have_text(client.name)
+
+    click_button "Authorize"
+
+    expect(page).to have_css("#authorize_result", text: '"code"')
+    click_button "Exchange"
+    expect(page).to have_css("#exchange_result", text: '"access_token"')
+  end
+
+  it "redirects back with access_denied when the user denies" do
+    client = dashboard_client("consent-ng")
+    start_authorization(client, force_consent: true)
+
+    expect(page).to have_text("Authorization required")
+
+    click_button "Deny"
+
+    expect(page).to have_css("#authorize_result", text: "access_denied")
+    expect(page).to have_no_css("#authorize_result", text: '"code"')
+  end
+end

--- a/spec/e2e/discovery_spec.rb
+++ b/spec/e2e/discovery_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "e2e_helper"
+
+RSpec.describe "Discovery" do
+  it "serves the openid-configuration document" do
+    visit "/"
+    click_button "GET openid-configuration"
+
+    expect(page).to have_css("#disc_config", text: '"issuer": "dummy"')
+
+    config = JSON.parse(find("#disc_config").text)
+    expect(config["authorization_endpoint"]).to eq("#{base_url}/oauth/authorize")
+    expect(config["token_endpoint"]).to eq("#{base_url}/oauth/token")
+    expect(config["userinfo_endpoint"]).to eq("#{base_url}/oauth/userinfo")
+    expect(config["jwks_uri"]).to eq("#{base_url}/oauth/discovery/keys")
+    expect(config["scopes_supported"]).to include("openid")
+    expect(config["response_types_supported"]).to include("code", "id_token", "id_token token")
+    expect(config["code_challenge_methods_supported"]).to include("S256")
+    expect(config["id_token_signing_alg_values_supported"]).to eq(["RS256"])
+    expect(config["subject_types_supported"]).to eq(["public"])
+  end
+
+  it "serves the JWKS with the RSA public key only" do
+    visit "/"
+    click_button "GET jwks (discovery/keys)"
+
+    expect(page).to have_css("#disc_keys", text: '"kty": "RSA"')
+
+    keys = JSON.parse(find("#disc_keys").text)["keys"]
+    expect(keys.size).to eq(1)
+
+    key = keys.first
+    expect(key["use"]).to eq("sig")
+    expect(key["alg"]).to eq("RS256")
+    expect(key["kid"]).to be_present
+    expect(key["n"]).to be_present
+    # Never expose private key material.
+    expect(key.keys).not_to include("d", "p", "q")
+  end
+end

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# The end-to-end suite drives a real browser against the dummy application, so
+# it boots that application the way `rake server` does — in the development
+# environment — instead of the test environment the rest of the suite uses.
+# Development is what makes the dashboard usable end to end: Doorkeeper skips
+# the consent screen there unless `force_consent` asks for it, and it accepts
+# the plain-http redirect URIs the dashboard hands out.
+#
+# One process can only boot the application once, so these specs are excluded
+# from `rake spec` and run on their own through `rake e2e`.
+if defined?(Rails.env) && !Rails.env.development?
+  raise <<~MESSAGE
+    The end-to-end suite boots the dummy application in the development
+    environment, so it cannot share a process with the specs that boot it in
+    the #{Rails.env} environment. Run it on its own:
+
+        bundle exec rake e2e
+  MESSAGE
+end
+
+ENV["RAILS_ENV"] = "development"
+# Its own database, so a run never disturbs the one behind `rake server`.
+# Relative paths resolve against Rails.root, i.e. spec/dummy/db/e2e.sqlite3.
+ENV["DATABASE_URL"] = "sqlite3:db/e2e.sqlite3"
+
+require "capybara/rspec"
+require "capybara/cuprite"
+require "dummy/config/environment"
+require "spec_helper"
+
+Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |file| require file }
+
+# Every run starts from an empty database: the specs create the users and
+# applications they need through the dashboard, and nothing should survive a
+# run to make the next one pass.
+ActiveRecord::Schema.verbose = false
+load Rails.root.join("db/schema.rb")
+
+Capybara.register_driver :cuprite do |app|
+  Capybara::Cuprite::Driver.new(
+    app,
+    window_size: [1400, 1000],
+    # HEADLESS=false opens a visible browser, which is the quickest way to see
+    # what a failing flow actually does.
+    headless: ENV["HEADLESS"] != "false",
+    timeout: 20,
+    process_timeout: 30,
+    browser_options: {
+      # This browser only ever loads the dummy application from 127.0.0.1, and
+      # its sandbox needs the unprivileged user namespaces that the Ubuntu CI
+      # runners disable.
+      "no-sandbox" => nil,
+      "disable-dev-shm-usage" => nil,
+    },
+  )
+end
+
+Capybara.app = Rails.application
+Capybara.server = :puma, { Silent: true }
+Capybara.default_driver = :cuprite
+Capybara.javascript_driver = :cuprite
+Capybara.default_max_wait_time = 10
+Capybara.disable_animation = true
+Capybara.save_path = Rails.root.join("tmp/e2e")
+
+RSpec.configure do |config|
+  config.define_derived_metadata(file_path: %r{/spec/e2e/}) do |metadata|
+    metadata[:type] = :feature
+  end
+
+  config.include Dashboard, type: :feature
+
+  # Capybara resets the session in an `after` hook of its own. This one is
+  # declared later, so RSpec runs it first and it still has the failed page to
+  # photograph.
+  config.after(type: :feature) do |example|
+    next unless example.exception
+
+    name = example.full_description.gsub(/[^\w]+/, "-").delete_suffix("-")[0, 120]
+    page.save_screenshot("#{name}.png")
+    page.save_page("#{name}.html")
+    warn "Saved the failed page to #{Capybara.save_path}/#{name}.{png,html}"
+  rescue StandardError => e
+    warn "Could not save the failed page: #{e.class}: #{e.message}"
+  end
+end

--- a/spec/e2e/errors_spec.rb
+++ b/spec/e2e/errors_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative "e2e_helper"
+
+RSpec.describe "Authorization error responses" do
+  it "refuses a redirect_uri that does not match the client" do
+    client = dashboard_client("err-redirect")
+
+    authorize(
+      client_id: client.uid,
+      redirect_uri: "http://evil.example/cb",
+      response_type: "code",
+      scope: "openid",
+      current_user: client.user_id,
+    )
+
+    # The error must be rendered here, never redirected to the evil host.
+    expect(current_host).to eq(URI.parse(base_url).host)
+    expect(page).to have_text(/redirect uri/i)
+  end
+
+  it "rejects an unknown client_id" do
+    client = dashboard_client("err-client")
+
+    authorize(
+      client_id: "this-client-does-not-exist",
+      redirect_uri: "#{base_url}/callback",
+      response_type: "code",
+      scope: "openid",
+      current_user: client.user_id,
+    )
+
+    expect(current_host).to eq(URI.parse(base_url).host)
+    expect(page).to have_text(/client/i)
+  end
+
+  def authorize(params)
+    visit "/oauth/authorize?#{params.to_query}"
+  end
+
+  def current_host
+    URI.parse(page.current_url).host
+  end
+end

--- a/spec/e2e/form_post_spec.rb
+++ b/spec/e2e/form_post_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "e2e_helper"
+
+RSpec.describe "response_mode=form_post" do
+  it "delivers the code via POST and the exchange still succeeds" do
+    client = dashboard_client("formpost")
+    run_auth_code_flow(client, response_mode: "form_post", nonce: true)
+
+    expect(page).to have_css("#exchange_result", text: '"id_token"')
+  end
+end

--- a/spec/e2e/implicit_spec.rb
+++ b/spec/e2e/implicit_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "e2e_helper"
+
+RSpec.describe "Implicit flow (id_token token)" do
+  it "returns tokens in the fragment and binds them with at_hash" do
+    client = dashboard_client("implicit")
+    nonce = start_authorization(client, response_type: "id_token token", nonce: true)
+
+    # The callback page relays the fragment parameters back to the dashboard.
+    expect(page).to have_css("#authorize_result", text: '"access_token"')
+    expect(page).to have_css("#authorize_result", text: '"id_token"')
+    expect(page).to have_no_css("#authorize_result", text: '"code"')
+
+    payload = id_token_payload
+    expect(payload["iss"]).to eq("dummy")
+    expect(payload["sub"]).to eq(client.user_id)
+    expect(payload["aud"]).to eq(client.uid)
+    expect(payload["nonce"]).to eq(nonce)
+    expect(payload["at_hash"]).to be_present
+
+    # The dashboard fills in the fragment's access token; it must work.
+    click_button "Get UserInfo"
+    expect(page).to have_css("#userinfo_result", text: %("sub": "#{client.user_id}"))
+  end
+end

--- a/spec/e2e/pkce_spec.rb
+++ b/spec/e2e/pkce_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "e2e_helper"
+
+RSpec.describe "PKCE (S256)" do
+  it "exchanges the code when the verifier matches" do
+    client = dashboard_client("pkce")
+    run_auth_code_flow(client, pkce: true)
+
+    expect(page).to have_css("#exchange_result", text: '"access_token"')
+  end
+
+  it "rejects the exchange with a missing or wrong verifier" do
+    client = dashboard_client("pkce-neg")
+    start_authorization(client, pkce: true)
+    expect(page).to have_css("#authorize_result", text: '"code"')
+
+    # Missing verifier → invalid_request (a required parameter is absent).
+    fill_in "tok_code_verifier", with: ""
+    click_button "Exchange"
+    expect(page).to have_css("#exchange_result", text: "invalid_request")
+
+    # Wrong verifier → invalid_grant (it does not match the challenge).
+    fill_in "tok_code_verifier", with: "wrong-verifier-wrong-verifier-wrong-verifier"
+    click_button "Exchange"
+    expect(page).to have_css("#exchange_result", text: "invalid_grant")
+  end
+end

--- a/spec/e2e/support/dashboard.rb
+++ b/spec/e2e/support/dashboard.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# Drives the dummy application's dashboard — spec/dummy/app/views/dummy/index.html.erb,
+# the browser stand-in for the README's curl commands — so the specs read as
+# flows rather than as selectors.
+module Dashboard
+  # A user and the OAuth application it authorizes, both created through the
+  # dashboard's own forms.
+  Client = Struct.new(:user_id, :user_name, :name, :uid, :secret, keyword_init: true)
+
+  # Creates a user and an application whose names are unique to this example,
+  # so a run never depends on what another example left behind.
+  def dashboard_client(prefix)
+    suffix = SecureRandom.hex(4)
+    user_name = "#{prefix}-user-#{suffix}"
+    app_name = "#{prefix}-app-#{suffix}"
+
+    Client.new(
+      user_id: create_user(user_name),
+      user_name: user_name,
+      name: app_name,
+      **create_application(app_name),
+    )
+  end
+
+  # Creates a user through the dashboard form and returns its id.
+  def create_user(name)
+    visit "/"
+    within "form[action='/users']" do
+      fill_in "name", with: name
+      click_button "Create user"
+    end
+
+    find("#users tr", text: name).first("td").text.strip
+  end
+
+  # Creates an application through the dashboard form and returns its
+  # credentials, read back from the client <select> the dashboard renders.
+  def create_application(name)
+    visit "/"
+    within "form[action='/applications']" do
+      fill_in "name", with: name
+      click_button "Create application"
+    end
+
+    option = find("#auth_client option", text: name)
+    { uid: option["data-uid"], secret: option["data-secret"] }
+  end
+
+  # Fills in the dashboard's authorization form and sends the request.
+  # Returns the nonce the dashboard generated, when one was asked for.
+  def start_authorization(client, response_type: "code", response_mode: nil,
+                          nonce: false, pkce: false, force_consent: false)
+    visit "/"
+    find("#current_user option[value='#{client.user_id}']").select_option
+    find("#auth_client option", text: client.name).select_option
+    select response_type, from: "response_type"
+    select response_mode, from: "response_mode" if response_mode
+
+    generated_nonce = nil
+    if nonce
+      check "nonce_enabled"
+      generated_nonce = find("#nonce").value
+      expect(generated_nonce).not_to be_empty
+    end
+
+    if pkce
+      check "pkce_enabled"
+      # The verifier and challenge are generated asynchronously.
+      expect(page).to have_css("#code_verifier", text: /\S/)
+    end
+
+    check "force_consent" if force_consent
+
+    click_button "Authorize →"
+    generated_nonce
+  end
+
+  # Runs the whole authorization code flow: authorize, bounce back through
+  # /callback, exchange the code. Leaves the browser on the dashboard with the
+  # ID token decoded and the access token filled in for UserInfo.
+  def run_auth_code_flow(client, **options)
+    nonce = start_authorization(client, **options)
+    expect(page).to have_css("#authorize_result", text: '"code"')
+
+    click_button "Exchange"
+    expect(page).to have_css("#exchange_result", text: '"access_token"')
+    expect(page).to have_css("#exchange_result", text: '"id_token"')
+
+    nonce
+  end
+
+  # The decoded ID token payload the dashboard renders.
+  def id_token_payload
+    expect(page).to have_css("#idtoken_payload", text: '"iss"')
+    JSON.parse(find("#idtoken_payload").text)
+  end
+
+  # The base URL of the application under test, which the dashboard's own
+  # links and the discovery document are expected to agree with.
+  def base_url
+    page.server.base_url
+  end
+end

--- a/spec/e2e/token_management_spec.rb
+++ b/spec/e2e/token_management_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "e2e_helper"
+
+RSpec.describe "Introspection and revocation" do
+  it "introspects an active token, revokes it and sees it die" do
+    client = dashboard_client("tokmgmt")
+    run_auth_code_flow(client)
+
+    access_token = find("#userinfo_token").value
+    expect(access_token).not_to be_empty
+
+    # The token management section authenticates as the selected client.
+    find("#tm_client option", text: client.name).select_option
+
+    fill_in "introspect_token", with: access_token
+    click_button "Introspect"
+    expect(page).to have_css("#introspect_result", text: '"active": true')
+
+    fill_in "revoke_token", with: access_token
+    click_button "Revoke"
+    expect(page).to have_css("#revoke_result", text: "Revoked")
+
+    click_button "Introspect"
+    expect(page).to have_css("#introspect_result", text: '"active": false')
+
+    # The 401 carries its error only in the WWW-Authenticate header.
+    click_button "Get UserInfo"
+    expect(page).to have_css("#userinfo_result", text: "HTTP 401")
+    expect(page).to have_css("#userinfo_result", text: "invalid_token")
+  end
+end


### PR DESCRIPTION
Supersedes #369 — rewritten from Playwright to Capybara + Cuprite per [the discussion there](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/369#issuecomment-5292276439), keeping the test stack within the Ruby ecosystem so any Ruby contributor can pick up and maintain it.

### Motivation

The RSpec suite exercises controllers and requests in-process, but nothing ever drives the full OIDC flows through a real server over HTTP: there is currently no test that walks authorization → token exchange → userinfo end-to-end. Regressions that only surface at that level — middleware interactions, redirect handling, response modes, header-only error responses — stay invisible to CI even when every spec is green.

This PR adds a browser end-to-end suite that boots `spec/dummy` as a real Rails server and drives its dashboard UI with [Capybara](https://github.com/teamcapybara/capybara) + [Cuprite](https://github.com/rubycdp/cuprite) (Ferrum/CDP, no Selenium). No Node.js required — just an installed Chrome.

### What's covered (13 tests)

| Spec             | Scenarios                                                    |
| ---------------- | ------------------------------------------------------------ |
| discovery        | openid-configuration contents; JWKS serves the RSA public key and never leaks private material |
| auth-code        | code flow with nonce → token exchange → ID token claims (`iss`/`sub`/`aud`/`nonce`, response-targeted custom claims) → userinfo; reusing a consumed code fails with `invalid_grant` |
| pkce             | S256 happy path; missing verifier → `invalid_request`, tampered verifier → `invalid_grant` |
| implicit         | `id_token token` via fragment, `at_hash` present, fragment access token works against userinfo |
| form-post        | `response_mode=form_post` delivers the code via POST and the exchange still succeeds |
| token-management | introspection `active: true` → revocation → `active: false`; revoked token gets a 401 from userinfo |
| errors           | mismatched `redirect_uri` and unknown `client_id` render locally and never redirect to the foreign host |
| consent          | the real Doorkeeper consent screen: approval issues an exchangeable code, denial returns `access_denied` |

### Running locally

```sh
bundle exec rake e2e
```

`HEADLESS=false` opens a visible browser. The suite boots the app in the development environment against its own `spec/dummy/db/e2e.sqlite3`, so it leaves the one behind `bundle exec rake server` alone.

### Design decisions

<details> <summary>Why development environment, not test?</summary>

The dashboard needs two things that only work in development: Doorkeeper's `skip_authorization` (which the consent specs override with `force_consent=1`) and relaxed `force_ssl_in_redirect_uri` for `http://` callback URIs. Switching the existing test environment would risk breaking the 444 in-process specs, so the E2E suite runs in a separate process with its own database.

</details> <details> <summary>Why a separate rake task?</summary>

`rake spec` excludes `spec/e2e/` and `rake e2e` targets only `spec/e2e/`. One process can only boot the dummy app in one environment, so they cannot share a run. Running bare `rspec` without the task prints an explicit message pointing to `rake e2e`.

</details>
