### PR TITLE
Point readers at the migration guide from the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Upgrading? [Migration from Old Versions](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/wiki/Migration-from-Old-Versions) walks through every breaking change and the steps it asks for, and the rest of the [wiki](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/wiki) documents the configuration and behavior the entries below refer to.
+
 ## Unreleased
 
 - [#243] Add per-client `post_logout_redirect_uris` for RP-Initiated Logout, exposed via `Doorkeeper::Application#post_logout_redirect_uris` and `#valid_post_logout_redirect_uri?(uri)`. URIs are validated with the same rules as `redirect_uri`; Dynamic Client Registration accepts and echoes them back


### PR DESCRIPTION
Closes #378

Add a one-line pointer to the migration guide and wiki at the top of `CHANGELOG.md`. After #374 trimmed the entries to focus on what upgraders need, the implementation detail lives in the wiki — but readers who open the changelog directly have no signpost. The README already links the migration guide; this gives the changelog the same courtesy.

See #378 for the full wiki audit confirming coverage of every Unreleased breaking change.

No code change.

> [!TIP]
> The pointer sits above `## Unreleased`, not inside it — so when the section is renamed to a version heading at release time, the signpost stays at the top of the file permanently.