### PR TITLE
Forward the password grant request's arguments to `super`

### DIFF
--- a/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb
@@ -6,16 +6,11 @@ module Doorkeeper
       module PasswordAccessTokenRequest
         attr_reader :nonce
 
-        if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.1")
-          def initialize(server, client, credentials, resource_owner, parameters = {})
-            super
-            @nonce = parameters[:nonce]
-          end
-        else
-          def initialize(server, client, resource_owner, parameters = {})
-            super
-            @nonce = parameters[:nonce]
-          end
+        # Forward every argument: the superclass signature has changed across
+        # Doorkeeper versions and keeps changing (e.g. doorkeeper#1794).
+        def initialize(...)
+          super
+          @nonce = parameters[:nonce]
         end
 
         private


### PR DESCRIPTION
Closes #377.

This gem prepends `Doorkeeper::OAuth::PasswordAccessTokenRequest` to capture the `nonce` for the ID Token, and the prepend redeclares Doorkeeper's parameter list to do it:

```ruby
if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.1")
  def initialize(server, client, credentials, resource_owner, parameters = {})
    super
    @nonce = parameters[:nonce]
  end
else
  def initialize(server, client, resource_owner, parameters = {})
    super
    @nonce = parameters[:nonce]
  end
end
```

Redeclaring the list is what makes the prepend brittle: it has to be right about a signature this gem does not own. It already had to grow a version branch once, when 5.5.1 inserted `credentials`, and the next change to that method breaks the password grant outright.

## The mechanism

[doorkeeper#1794](https://github.com/doorkeeper-gem/doorkeeper/pull/1794) (DPoP, RFC 9449) adds a `dpop_proof:` keyword to the request strategies. Its `Request::Password` passes the keyword unconditionally:

```ruby
@request ||= OAuth::PasswordAccessTokenRequest.new(
  Doorkeeper.config,
  client,
  credentials,
  resource_owner,
  parameters,
  dpop_proof: dpop_proof,
)
```

A method that accepts no keywords receives that as a sixth positional Hash, so every `grant_type=password` request raises before any DPoP logic runs — the value being `nil` for a client that sends no proof does not help, because the keyword is passed either way:

```
ArgumentError:
  wrong number of arguments (given 6, expected 4..5)
# ./lib/doorkeeper/openid_connect/oauth/password_access_token_request.rb:10:in 'Doorkeeper::OpenidConnect::OAuth::PasswordAccessTokenRequest#initialize'
# .../doorkeeper/lib/doorkeeper/request/password.rb:9:in 'Doorkeeper::Request::Password#request'
```

The failure is in this gem, not in doorkeeper#1794: a prepend that redeclares a superclass's positional parameters is asserting that the signature will not change, and `super` here never needed that assertion in the first place.

## The fix

```diff
-        if Gem.loaded_specs["doorkeeper"].version >= Gem::Version.create("5.5.1")
-          def initialize(server, client, credentials, resource_owner, parameters = {})
-            super
-            @nonce = parameters[:nonce]
-          end
-        else
-          def initialize(server, client, resource_owner, parameters = {})
-            super
-            @nonce = parameters[:nonce]
-          end
-        end
+        # Forward every argument: the superclass signature has changed across
+        # Doorkeeper versions and keeps changing (e.g. doorkeeper#1794).
+        def initialize(...)
+          super
+          @nonce = parameters[:nonce]
+        end
```

`def initialize(...)` forwards whatever the superclass takes, so the prepend stops having an opinion about the signature. The `nonce` is read through the public `parameters` reader, which the superclass provides in every supported version — including the `doorkeeper >= 5.5` floor, where `parameters` is declared via `attr_reader` alongside `client`, `resource_owner`, and `access_token`. Argument forwarding needs Ruby 2.7+ and the gemspec requires `>= 3.2`.

The version branch goes with it: both arms existed only to name the parameters, so the 5.5.0-vs-5.5.1 distinction no longer needs to be made here.

## Verification

Against the current test matrix, unchanged results:

| Doorkeeper | Result |
| --- | --- |
| 5.5.4 | 443 examples, 0 failures |
| 5.6.9 | 443 examples, 0 failures |
| 5.7.1 | 443 examples, 0 failures |
| 6.0.0.beta2 | 454 examples, 0 failures |
| `main` (76d7a9c) | 454 examples, 0 failures |

And against doorkeeper#1794 at its current head (`4d8c5c1`), `path:`-mounted:

- **Before:** 454 examples, **2 failures** — both `ArgumentError`, in `spec/requests/password_grant_id_token_spec.rb`
- **After:** 454 examples, **0 failures**

RuboCop reports no offenses.