### PR TITLE
Echo the registered `client_name` in the Dynamic Client Registration response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [#370] Correct the stale `rake db:migrate` command to `rails db:migrate` in the README, the [#243] migration note, and the `post_logout_redirect_uris` missing-column error message
 - [#372] Fix duplicate entries in the discovery document's `claims_supported` when a custom claim shadows a base claim (`iss`/`sub`/`aud`/`exp`/`iat`)
 - [#373] Fix `prompt=consent` under Doorkeeper's `api_only` mode — the consent step now returns the pre-authorization as JSON instead of attempting to render a template that `ActionController::API` cannot serve
+- [#381] Echo the registered `client_name` in the Dynamic Client Registration response, as RFC 7591 §3.2.1 requires the response to include all registered client metadata
 - Add entry here
 
 ## v1.10.5 (2026-07-09)

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -82,6 +82,10 @@ module Doorkeeper
         response = {
           client_id: doorkeeper_application.uid,
           client_id_issued_at: doorkeeper_application.created_at.to_i,
+          # RFC 7591 §3.2.1: the response must include all registered client
+          # metadata. The name is always present on a successfully created
+          # application (the model validates its presence).
+          client_name: doorkeeper_application.name,
           redirect_uris: doorkeeper_application.redirect_uri.split,
           token_endpoint_auth_method: registration.token_endpoint_auth_method,
           token_endpoint_auth_methods_supported: registration.token_endpoint_auth_methods_supported,

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -49,6 +49,7 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
           "client_secret_expires_at" => 0,
           "client_id" => doorkeeper_application.uid,
           "client_id_issued_at" => doorkeeper_application.created_at.to_i,
+          "client_name" => "dummy_client",
           "redirect_uris" => redirect_uris,
           "token_endpoint_auth_method" => "client_secret_basic",
           "token_endpoint_auth_methods_supported" => %w[client_secret_basic client_secret_post],
@@ -57,6 +58,23 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
           "scope" => "public",
           "application_type" => "web",
         })
+      end
+    end
+
+    context "when client_name is provided" do
+      it "stores it and echoes it back (RFC 7591 §3.2.1)" do
+        post :register, params: {
+          client_name: "My Example App",
+          redirect_uris: redirect_uris,
+          scope: "public",
+        }
+
+        expect(response.status).to eq 201
+
+        body = JSON.parse(response.body)
+        doorkeeper_application = Doorkeeper::Application.find_by(uid: body["client_id"])
+        expect(doorkeeper_application.name).to eq("My Example App")
+        expect(body["client_name"]).to eq("My Example App")
       end
     end
 


### PR DESCRIPTION
[RFC 7591 §3.2.1](https://www.rfc-editor.org/rfc/rfc7591#section-3.2.1) requires a successful registration response to include **all registered client metadata**:

> Additionally, the authorization server MUST return all registered metadata about this client, including any fields provisioned by the authorization server itself.

The registration endpoint accepts `client_name` and stores it as the application's `name`, but the `201 Created` response never echoes it back — the client has no confirmation of what was registered. Since the response is also the RFC's mechanism for telling the client which values the server actually recorded (clients are expected to replace their own values with the returned ones), silently dropping an accepted field breaks that contract.

>[!NOTE]
>
> #### Why the echo is unconditional
> 
> `client_name` is always present on a successfully created application: the application model validates `name` for presence, so a registration request without `client_name` already fails with `invalid_client_metadata` before reaching the response builder. There is no "registered without a name" state to guard against, unlike `post_logout_redirect_uris` (which stays conditional because registration of that field is optional).