### PR TITLE
CI: pin the action references to commit SHAs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -41,7 +41,7 @@ jobs:
             echo "result=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: dangoslen/changelog-enforcer@v3.7.0
+      - uses: dangoslen/changelog-enforcer@8b5e9dc3121363bb7c0115f8533404d92af382de # v3.7.0
         if: steps.docs_only.outputs.result != 'true'
         with:
           # Dependabot PRs are labeled "dependencies" automatically and don't

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,10 @@ jobs:
             gemfile: gemfiles/doorkeeper_6.0.gemfile
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Not pinned: upstream ships setup-ruby from a moving `v1` branch, and a
+      # pinned commit only offers the Rubies and runner images of its own day.
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -88,7 +90,7 @@ jobs:
           - doorkeeper_master
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -104,7 +106,7 @@ jobs:
 
       - name: Upload the pages of failed examples
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-artifacts-${{ matrix.gemfile }}
           path: spec/dummy/tmp/e2e/
@@ -119,7 +121,7 @@ jobs:
         || contains(github.event.pull_request.title,  '[skip ci]'))
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -25,7 +25,8 @@ jobs:
     env:
       BUNDLE_ONLY: rubocop
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Not pinned — see the note in ci.yml.
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4'


### PR DESCRIPTION
### Pins

| Action | SHA | Version |
| --- | --- | --- |
| `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 |
| `dangoslen/changelog-enforcer` | `8b5e9dc3121363bb7c0115f8533404d92af382de` | v3.7.0 |
| `reviewdog/action-rubocop` | `b6d5e953a5fc0bf3ab65254e77730ea2174d6d6d` | v2.22.0 (unchanged) |