### PR TITLE
Remove the deprecated jws_private_key and jws_public_key settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Upgrading? [Migration from Old Versions](https://github.com/doorkeeper-gem/doork
 
 ## Unreleased
 
+- [#387] **Breaking:** Remove the deprecated `jws_private_key` and `jws_public_key` initializer settings
 - Add entry here
 
 ## v2.0.0.beta1 (2026-08-20)

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -68,15 +68,6 @@ module Doorkeeper
         def build
           @config
         end
-
-        def jws_public_key(*_args)
-          warn "DEPRECATION WARNING: `jws_public_key` is not needed anymore and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb"
-        end
-
-        def jws_private_key(*args)
-          warn "DEPRECATION WARNING: `jws_private_key` has been replaced by `signing_key` and will be removed in a future version, please remove it from config/initializers/doorkeeper_openid_connect.rb"
-          signing_key(*args)
-        end
       end
 
       mattr_reader(:builder_class) { Config::Builder }

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -135,26 +135,6 @@ describe Doorkeeper::OpenidConnect, "configuration" do
     end
   end
 
-  describe "jws_public_key" do
-    it "warns that the setting is no longer needed" do
-      expect do
-        described_class.configure do
-          jws_public_key "public_key"
-        end
-      end.to output(/DEPRECATION WARNING: `jws_public_key` is not needed anymore/).to_stderr
-    end
-  end
-
-  describe "jws_private_key" do
-    it "delegates to signing_key" do
-      value = "private_key"
-      described_class.configure do
-        jws_private_key value
-      end
-      expect(subject.signing_key).to eq(value)
-    end
-  end
-
   describe "signing_key" do
     it "sets the value that is accessible via signing_key" do
       value = "private_key"


### PR DESCRIPTION
## Summary

Removes the `jws_private_key` and `jws_public_key` initializer settings, which the CHANGELOG has promised to remove "in the next major release" since v1.4.0. 2.0 is that release — this is the last chance to honour the promise before it slips to 3.0.

- `jws_private_key` has been nothing but an alias for `signing_key` since v1.4.0
- `jws_public_key` has never been read — the builder method accepted the argument and silently dropped it

Both emitted a deprecation warning on every boot that still configured them.

## What users see after upgrading

The initializer is `instance_eval`'d on `Config::Builder`, so a leftover setting now raises at boot:

```
NoMethodError: undefined method 'jws_private_key' for an instance of
  Doorkeeper::OpenidConnect::Config::Builder
```

That is a loud, immediate failure that names the setting — better than silently ignoring a stale configuration. It matches how Doorkeeper core handles removals (6.0.0.beta1 removed the `Doorkeeper::OAuth::Client::Credentials` class methods outright, with no raising stub), so no compatibility shim is introduced here.

The fix is a one-line edit in `config/initializers/doorkeeper_openid_connect.rb`:

```ruby
-  jws_private_key ENV["OIDC_SIGNING_KEY"]
+  signing_key ENV["OIDC_SIGNING_KEY"]
```

and deleting the `jws_public_key` line outright.

## Changes

| File | What changed |
|------|-------------|
| `lib/doorkeeper/openid_connect/config.rb` | Drop the two `Config::Builder` methods |
| `spec/lib/config_spec.rb` | Replace the two deprecation specs with removal guards asserting each setting raises `NoMethodError` naming itself — prevents silent re-introduction |
| `CHANGELOG.md` | **Breaking** entry |

## Verification

| Gemfile | Result |
|---------|--------|
| default (dk 5.9.5 / Rails 8.1) | 455 examples, 0 failures |
| `doorkeeper_5.5` | 453 / 0 |
| `doorkeeper_5.7` | 453 / 0 |
| `doorkeeper_6.0` | 464 / 0 |
| `doorkeeper_master` | 464 / 0 |

`bundle exec rubocop` — 126 files, 0 offenses. The `jws_private_key` deprecation warning that the suite used to print is gone.

No other reference to either setting exists in the repository — not in the README, not in the generated initializer template, and not on the wiki's Configuration page.

## Wiki follow-up

The [Migration from Old Versions](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/wiki/Migration-from-Old-Versions) page's "From 1.10.x to 2.0.x" section needs one more bullet:

> - **`jws_private_key` / `jws_public_key` removed.** Rename `jws_private_key` to `signing_key`; delete `jws_public_key`, which was never read. A leftover setting raises `NoMethodError` at boot.
