### PR TITLE
Release 2.0.0.beta1 :tada:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,21 @@ Upgrading? [Migration from Old Versions](https://github.com/doorkeeper-gem/doork
 
 ## Unreleased
 
+- Add entry here
+
+## v2.0.0.beta1 (2026-08-20)
+
+>[!IMPORTANT]
+>
+>- **This is a prerelease.** RubyGems does not resolve prereleases from an unqualified requirement, so it must be requested explicitly: `gem "doorkeeper-openid_connect", "2.0.0.beta1"`
+>- **Migration required:** existing installations must add the `post_logout_redirect_uris` column — `rails generate doorkeeper:openid_connect:add_post_logout_redirect_uris` followed by `rails db:migrate` ([#243])
+>- **Breaking (hybrid response type):** the `id_token token` response object is now the configured `id_token_class` extended with `HybridIdTokenConcern`, and a custom `id_token_class` must expose an `#access_token` reader ([#337])
+>- **Breaking (constant removed):** `Doorkeeper::OpenidConnect::IdTokenToken` is gone — custom subclasses must subclass `IdToken` and include `HybridIdTokenConcern` ([#338])
+>- **Breaking (Dynamic Client Registration):** a registration request that omits `response_types` / `grant_types` now defaults to `["code"]` / `["authorization_code"]` per RFC 7591 §2, instead of inheriting the server's global configuration ([#350])
+>
+>[Migration from Old Versions](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/wiki/Migration-from-Old-Versions) walks through each one.
+
 - [#243] Add per-client `post_logout_redirect_uris` for RP-Initiated Logout, exposed via `Doorkeeper::Application#post_logout_redirect_uris` and `#valid_post_logout_redirect_uri?(uri)`. URIs are validated with the same rules as `redirect_uri`; Dynamic Client Registration accepts and echoes them back
-
-> [!NOTE]
-> **Migration required:** existing installations must run `rails generate doorkeeper:openid_connect:add_post_logout_redirect_uris` followed by `rails db:migrate`
-
 - [#320] Support mounting the engine under multiple named scopes — `use_doorkeeper_openid_connect as: :users` makes each mount's discovery document advertise its own endpoints ([#192])
 - [#322] Fall back to Doorkeeper's `issuer` configuration when the OpenID Connect `issuer` is not set. The OpenID Connect value still takes precedence ([#321])
 - [#323] Resolve `token_endpoint_auth_methods_supported` from Doorkeeper's client authentication methods registry when available, falling back to legacy `client_credentials_methods` on older versions
@@ -38,7 +48,6 @@ Upgrading? [Migration from Old Versions](https://github.com/doorkeeper-gem/doork
 - [#372] Fix duplicate entries in the discovery document's `claims_supported` when a custom claim shadows a base claim (`iss`/`sub`/`aud`/`exp`/`iat`)
 - [#373] Fix `prompt=consent` under Doorkeeper's `api_only` mode — the consent step now returns the pre-authorization as JSON instead of attempting to render a template that `ActionController::API` cannot serve
 - [#381] Echo the registered `client_name` in the Dynamic Client Registration response, as RFC 7591 §3.2.1 requires the response to include all registered client metadata
-- Add entry here
 
 ## v1.10.5 (2026-07-09)
 

--- a/lib/doorkeeper/openid_connect/version.rb
+++ b/lib/doorkeeper/openid_connect/version.rb
@@ -2,10 +2,10 @@
 
 module Doorkeeper
   module OpenidConnect
-    MAJOR = 1
-    MINOR = 10
-    TINY = 5
-    PRE = nil
+    MAJOR = 2
+    MINOR = 0
+    TINY = 0
+    PRE = "beta1"
 
     # Full version number
     VERSION = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
## Proposal: cut `2.0.0.beta1`

`master` (022d1fd) is green — 455 specs pass, RuboCop clean, `gem build` succeeds, and the 25 PRs merged since v1.10.5 are all accounted for in the CHANGELOG. The code is ready to ship.

I'd like to cut a `2.0.0.beta1` prerelease so the four breaking changes can get real-world validation before we commit to a final `2.0.0`. A beta window also lets us land a few more major-only changes (see _Road to final_ below) that would otherwise have to wait until 3.0.

### Why not wait for Doorkeeper 6.0 final?

Our Doorkeeper 6.0 support (#323, #333, #334, #353) is entirely capability-probed — `config.respond_to?(:client_authentication_methods)`, `Doorkeeper::OAuth.const_defined?(:MetadataResponse, false)`, `server_scopes.respond_to?(:allowed)`, etc. When a probe misses, the code falls back to the legacy path gracefully. There is no hard version pin to update when dk 6.0 ships, so waiting doesn't buy us anything concrete.

---

## What this PR changes

Same shape as the `Release 1.10.5 :tada:` commit (9473ace): a version bump and a CHANGELOG heading, nothing else.

| File | Change |
|------|--------|
| `lib/doorkeeper/openid_connect/version.rb` | `MAJOR=2, MINOR=0, TINY=0, PRE="beta1"` |
| `CHANGELOG.md` | `## Unreleased` gets a fresh placeholder; 25 entries move under `## v2.0.0.beta1 (2026-08-20)` with an `>[!IMPORTANT]` block |

### Breaking changes in this release

> [!IMPORTANT]
>
> - **This is a prerelease.** Pin explicitly: `gem "doorkeeper-openid_connect", "2.0.0.beta1"`
> - **Migration required:** add the `post_logout_redirect_uris` column ([#243])
> - **Hybrid response type reworked:** custom `id_token_class` must expose an `#access_token` reader ([#337])
> - **Constant removed:** `Doorkeeper::OpenidConnect::IdTokenToken` is gone ([#338])
> - **DCR defaults changed:** omitted `response_types`/`grant_types` now default per RFC 7591 §2 ([#350])
>
> [Migration from Old Versions](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/wiki/Migration-from-Old-Versions) walks through each one.

---

## Installing the prerelease

RubyGems does not resolve prereleases from an unqualified requirement (`~> 1.10` stays on 1.10.5), so testers need an explicit pin:

```ruby
gem "doorkeeper-openid_connect", "2.0.0.beta1"
```

---

## Road to `2.0.0` final

These changes are cheaper to land during the beta window — they'd otherwise wait for 3.0:

| Item | Status | Notes |
|------|--------|-------|
| Remove `jws_private_key` / `jws_public_key` | #387 | Promised "in the next major release" since v1.4.0. Shim-less removal, matching dk 6.0.beta1's approach |
| #364 — require inheritance for `id_token_class` / `user_info_class` | Needs rebase | Breaking; conflicts with post-#337 internals |
| #365 — validate class override initializer arity | Mergeable | Pairs with #364 (merge #364 first) |
| #244 — nonce support | Mergeable | Wiki Nonces.md update needed at merge time |

Targeting **2–4 weeks** from beta1 to final. If the beta period stretches, a `1.10.6` backport becomes an option for the bug fixes that `~> 1.10` users can't reach via the prerelease — but cherry-pick cost is non-trivial (the fixes land on files reworked by #337), so ideally we keep the window short.

Not targeting 2.0: #382 / #383 (Back-Channel Logout, draft) → 2.1.

---

## Verification

| Check | Result |
|-------|--------|
| `bundle exec rake spec` (dk 5.9.5 / Rails 8.1) | 455 examples, 0 failures |
| `bundle exec rubocop` | 126 files, 0 offenses |
| `gem build` | `doorkeeper-openid_connect-2.0.0.beta1.gem` ✓ |
| `rake -T release` tag | `v2.0.0.beta1` (matches existing `v`-prefixed tags) |
| Autoload health (#360 / #362) | All 29 constants resolve ✓ |
| CHANGELOG PR references | All 25 entries point to merged PRs ✓ |

## Notes

- `Gemfile.lock` and `gemfiles/*.lock` are gitignored — no lockfile churn.
- #380 (forward password grant arguments to `super`) is intentionally absent from the CHANGELOG (`Skip-Changelog`): the incompatibility it fixes exists only on Doorkeeper `main` (dk#1794, still open), so no released Doorkeeper is affected.
- When creating the GitHub Release, **check "Set as a pre-release"** — without it, `Latest release` switches to the beta and breaks the landing page for `~> 1.10` users.