### PR TITLE
Move six RSpec cop settings out of .rubocop_todo.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,3 +111,21 @@ RSpec/MultipleExpectations:
   Enabled: false
 RSpec/NestedGroups:
   Enabled: false
+# The suite's specs refer to the subject as `subject` and stub collaborators
+# with plain doubles throughout; naming every subject or verifying every
+# double would be churn without a safety gain for a library this size.
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/VerifiedDoubles:
+  Enabled: false
+# `expect(...).to receive` before the action reads fine for one-shot
+# assertions; rewriting them as spies is not worth the noise.
+RSpec/MessageSpies:
+  Enabled: false
+RSpec/ExpectInHook:
+  Enabled: false
+# Token/claim specs legitimately set up several `let`s per group.
+RSpec/MultipleMemoizedHelpers:
+  Max: 7
+RSpec/IndexedLet:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,18 +13,6 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Max: 35
 
-# Configuration parameters: .
-# SupportedStyles: have_received, receive
-RSpec/MessageSpies:
-  Enabled: false
-
-RSpec/NamedSubject:
-  Enabled: false
-
-# Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
-RSpec/VerifiedDoubles:
-  Enabled: false
-
 # This gem does not enforce top-level documentation comments.
 Style/Documentation:
   Enabled: false
@@ -40,22 +28,12 @@ Style/SymbolProc:
     - "spec/lib/user_info_spec.rb"
     - "spec/support/doorkeeper_configuration.rb"
 
-# Configuration parameters: Max, AllowSubject.
-RSpec/MultipleMemoizedHelpers:
-  Max: 7
-
 RSpec/SubjectStub:
   Enabled: false
 
 # Configuration parameters: Prefixes, AllowedPatterns.
 # Prefixes: when, with, without
 RSpec/ContextWording:
-  Enabled: false
-
-RSpec/ExpectInHook:
-  Enabled: false
-
-RSpec/IndexedLet:
   Enabled: false
 
 RSpec/StubbedMock:


### PR DESCRIPTION
> Part of the `.rubocop_todo.yml` removal stack (9 PRs, merge top-down; each PR only shows its own diff and is based on the previous one).

`.rubocop_todo.yml` is meant to hold offenses waiting to be fixed. Six of its RSpec entries are deliberate choices for this suite instead, so this PR moves them into `.rubocop.yml` with a one-line rationale each:

- `RSpec/NamedSubject`, `RSpec/VerifiedDoubles`, `RSpec/MessageSpies`, `RSpec/ExpectInHook` stay disabled
- `RSpec/MultipleMemoizedHelpers` keeps `Max: 7`
- `RSpec/IndexedLet` stays disabled

`bundle exec rubocop`: no offenses. `bundle exec rake spec`: 455 examples, 0 failures. Before and after are identical for RuboCop.
