### PR TITLE
Move the Style/Documentation setting out of .rubocop_todo.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,6 +75,10 @@ Style/WordArray:
   MinSize: 3
 Style/ClassAndModuleChildren:
   Enabled: false
+# Top-level documentation comments are not enforced in this gem; the README
+# and the wiki document the public surface.
+Style/Documentation:
+  Enabled: false
 Style/NumericPredicate:
   Enabled: false
 Style/DoubleNegation:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,10 +13,6 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Max: 35
 
-# This gem does not enforce top-level documentation comments.
-Style/Documentation:
-  Enabled: false
-
 # The Doorkeeper config DSL (subject, auth_time_from_resource_owner, claim)
 # invokes these blocks with extra arguments, so a strict-arity `&:sym`
 # lambda raises ArgumentError. Keep explicit blocks here.


### PR DESCRIPTION
> Part of the `.rubocop_todo.yml` removal stack (9 PRs, merge top-down; each PR only shows its own diff and is based on the previous one).

Skipping top-level documentation comments is a deliberate choice for this gem (the README and the wiki document the public surface), so the setting belongs in `.rubocop.yml` next to the other `Style` choices, not in the todo file.

`bundle exec rubocop`: no offenses. `bundle exec rake spec`: 455 examples, 0 failures.
