### PR TITLE
Fix the remaining RSpec/ContextWording, StubbedMock and DescribeMethod offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,14 +26,3 @@ Style/SymbolProc:
 
 RSpec/SubjectStub:
   Enabled: false
-
-# Configuration parameters: Prefixes, AllowedPatterns.
-# Prefixes: when, with, without
-RSpec/ContextWording:
-  Enabled: false
-
-RSpec/StubbedMock:
-  Enabled: false
-
-RSpec/DescribeMethod:
-  Enabled: false

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -227,7 +227,7 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
         end
       end
 
-      context "and a matching token" do
+      context "with a matching token" do
         before do
           create :access_token, token_attributes
         end
@@ -314,7 +314,7 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
         end
       end
 
-      context "and no matching token" do
+      context "without a matching token" do
         it "redirects to the callback if skip_authorization is set to true" do
           allow(controller).to receive(:skip_authorization?).and_return(true)
 
@@ -372,7 +372,7 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       # Issue #63: a `prompt=none` request that asks for a narrower subset of
       # scopes than was previously granted must succeed without showing the
       # consent form (which is forbidden under `prompt=none`).
-      context "and a token covering a wider scope than the request (issue #63)" do
+      context "with a token covering a wider scope than the request (issue #63)" do
         let(:application) { create :application, scopes: "openid profile email" }
         let(:granted_scopes) { "openid profile email" }
         let(:token_attributes) do

--- a/spec/controllers/dynamic_client_registration_controller_spec.rb
+++ b/spec/controllers/dynamic_client_registration_controller_spec.rb
@@ -268,7 +268,7 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
       end
     end
 
-    context "token_endpoint_auth_methods_supported in the response" do
+    context "with token_endpoint_auth_methods_supported in the response" do
       it "matches the server's configured client_credentials methods" do
         Doorkeeper.configure do
           orm :active_record
@@ -288,7 +288,7 @@ describe Doorkeeper::OpenidConnect::DynamicClientRegistrationController, type: :
       end
     end
 
-    context "security regression: confidential client cannot bypass credentials" do
+    context "when a confidential client tries to bypass its credentials (security regression)" do
       it "is not returned by by_uid_and_secret(uid, nil)" do
         expect do
           post :register, params: {

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe Doorkeeper::OpenidConnect, "configuration" do
+describe Doorkeeper::OpenidConnect, ".configuration" do
   subject { described_class.configuration }
 
   describe "#configure" do
@@ -417,13 +417,13 @@ describe Doorkeeper::OpenidConnect, "configuration" do
 
   describe "protocol" do
     it "defaults to https in production" do
-      expect(::Rails.env).to receive(:production?).and_return(true)
+      allow(::Rails.env).to receive(:production?).and_return(true)
 
       expect(subject.protocol.call).to eq(:https)
     end
 
     it "defaults to http in other environments" do
-      expect(::Rails.env).to receive(:production?).and_return(false)
+      allow(::Rails.env).to receive(:production?).and_return(false)
 
       expect(subject.protocol.call).to eq(:http)
     end

--- a/spec/lib/oauth/id_token_request_spec.rb
+++ b/spec/lib/oauth/id_token_request_spec.rb
@@ -60,7 +60,7 @@ describe Doorkeeper::OAuth::IdTokenRequest do
     end
   end
 
-  context "token reuse" do
+  context "with reuse_access_token enabled" do
     it "creates a new token if there are no matching tokens" do
       allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
       expect do


### PR DESCRIPTION
> Part of the `.rubocop_todo.yml` removal stack (9 PRs, merge top-down; each PR only shows its own diff and is based on the previous one).

Nine offenses, all in specs:

- **ContextWording (6):** reword context descriptions to start with when/with/without (`"and a matching token"` → `"with a matching token"`, `"token reuse"` → `"with reuse_access_token enabled"`, …)
- **StubbedMock (2):** `expect(::Rails.env).to receive(:production?)` → `allow`; the examples use the stubbed return value and never asserted the call
- **DescribeMethod (1):** `describe Doorkeeper::OpenidConnect, "configuration"` → `".configuration"`, the method the subject calls

Then the three cops are dropped from `.rubocop_todo.yml`.

`bundle exec rubocop`: no offenses. `bundle exec rake spec`: 455 examples, 0 failures.
