### PR TITLE
Keep RSpec/SubjectStub enabled and mark its legitimate uses inline

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,6 +23,3 @@ Style/SymbolProc:
     - "spec/lib/id_token_spec.rb"
     - "spec/lib/user_info_spec.rb"
     - "spec/support/doorkeeper_configuration.rb"
-
-RSpec/SubjectStub:
-  Enabled: false

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -777,6 +777,8 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
     end
   end
 
+  # Stubs the helpers the action delegates to, so the example exercises only this method's branching.
+  # rubocop:disable RSpec/SubjectStub
   describe "#reauthenticate_oidc_resource_owner" do
     let(:performed) { true }
 
@@ -841,7 +843,10 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
   end
+  # rubocop:enable RSpec/SubjectStub
 
+  # Stubs the response writer so the example can observe the reset without rendering.
+  # rubocop:disable RSpec/SubjectStub
   describe "#clear_oidc_response" do
     before { allow(subject).to receive(:response_body=) }
 
@@ -858,7 +863,10 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       expect { subject.send :clear_oidc_response }.not_to raise_error
     end
   end
+  # rubocop:enable RSpec/SubjectStub
 
+  # Stubs the helpers the action delegates to, so the example exercises only this method's branching.
+  # rubocop:disable RSpec/SubjectStub
   describe "#select_account_for_oidc_resource_owner" do
     let(:performed) { true }
 
@@ -908,6 +916,7 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
   end
+  # rubocop:enable RSpec/SubjectStub
 
   describe "#pre_auth" do
     it "permits nonce parameter" do

--- a/spec/lib/id_token_spec.rb
+++ b/spec/lib/id_token_spec.rb
@@ -259,6 +259,8 @@ describe Doorkeeper::OpenidConnect::IdToken do
     end
   end
 
+  # Stubs the claim source so the examples can feed #as_json blank claims directly.
+  # rubocop:disable RSpec/SubjectStub
   describe "#as_json" do
     let(:valid_claims) do
       {
@@ -298,6 +300,7 @@ describe Doorkeeper::OpenidConnect::IdToken do
       end
     end
   end
+  # rubocop:enable RSpec/SubjectStub
 
   describe "#as_jws_token" do
     shared_examples "a jws token" do

--- a/spec/lib/token_endpoint_auth_methods_supported_mixin_spec.rb
+++ b/spec/lib/token_endpoint_auth_methods_supported_mixin_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Doorkeeper::OpenidConnect::TokenEndpointAuthMethodsSupportedMixin
     end.new
   end
 
+  # Stubs doorkeeper_config, the mixin's only input, to emulate each Doorkeeper generation.
+  # rubocop:disable RSpec/SubjectStub
   describe "#token_endpoint_auth_methods_supported" do
     context "when Doorkeeper exposes the client authentication methods registry (doorkeeper#1840)" do
       # Doorkeeper >= the release shipping the registry returns
@@ -90,4 +92,5 @@ RSpec.describe Doorkeeper::OpenidConnect::TokenEndpointAuthMethodsSupportedMixin
       end
     end
   end
+  # rubocop:enable RSpec/SubjectStub
 end

--- a/spec/lib/user_info_spec.rb
+++ b/spec/lib/user_info_spec.rb
@@ -147,6 +147,8 @@ describe Doorkeeper::OpenidConnect::UserInfo do
     end
   end
 
+  # Stubs the claim source so the example can feed #as_json blank claims directly.
+  # rubocop:disable RSpec/SubjectStub
   describe "#as_json" do
     it "returns claims with nil values and empty strings removed" do
       allow(subject).to receive(:claims).and_return({
@@ -160,4 +162,5 @@ describe Doorkeeper::OpenidConnect::UserInfo do
       })
     end
   end
+  # rubocop:enable RSpec/SubjectStub
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -10,6 +10,8 @@ describe Doorkeeper::OpenidConnect::Orm::ActiveRecord::Mixins::Application do
     expect(subject).to respond_to(:valid_post_logout_redirect_uri?)
   end
 
+  # Stubs has_attribute? to emulate an installation that has not run the migration yet.
+  # rubocop:disable RSpec/SubjectStub
   describe "#post_logout_redirect_uris" do
     it "returns an empty array when not set" do
       expect(subject.post_logout_redirect_uris).to eq([])
@@ -54,6 +56,7 @@ describe Doorkeeper::OpenidConnect::Orm::ActiveRecord::Mixins::Application do
         .to raise_error(ActiveModel::MissingAttributeError, /add_post_logout_redirect_uris/)
     end
   end
+  # rubocop:enable RSpec/SubjectStub
 
   describe "post_logout_redirect_uris validation" do
     # The attribute is validated by delegating to Doorkeeper's own


### PR DESCRIPTION
> Part of the `.rubocop_todo.yml` removal stack (9 PRs, merge top-down; each PR only shows its own diff and is based on the previous one).

The todo file disabled `RSpec/SubjectStub` globally. The 17 offenses it hid all stub a **collaborator the method under test reads from**, never the method being asserted:

| spec | stubbed | why |
|---|---|---|
| `authorizations_controller_spec` #reauthenticate / #select_account | `clear_oidc_response`, `performed?` | isolate the method's own branching from the helpers it delegates to |
| `authorizations_controller_spec` #clear_oidc_response | `response_body=` | observe the reset without rendering |
| `id_token_spec` / `user_info_spec` #as_json | `claims` | feed blank claims directly to the serializer |
| `application_spec` | `has_attribute?` | emulate an installation that has not run the migration |
| `token_endpoint_auth_methods_supported_mixin_spec` | `doorkeeper_config` | emulate each Doorkeeper generation (the mixin's only input) |

Those are partial doubles used to isolate a method, which is not the smell the cop targets. So instead of disabling the cop, wrap the seven example groups in `rubocop:disable/enable` with a one-line reason each and drop the entry from the todo file, leaving the cop enabled for new code.

`bundle exec rubocop`: no offenses. `bundle exec rake spec`: 455 examples, 0 failures.
