### PR TITLE
Exclude spec/ from Metrics/MethodLength and Metrics/AbcSize

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,9 +53,14 @@ Metrics/BlockLength:
 Metrics/ParameterLists:
   Exclude:
     - spec/**/*
+# Spec support code and the dummy app favour one readable setup method over
+# a split one; Metrics/BlockLength and ParameterLists already skip spec/.
 Metrics/MethodLength:
   Exclude:
-    - spec/dummy/db/**/*
+    - spec/**/*
+Metrics/AbcSize:
+  Exclude:
+    - spec/**/*
 # Match upstream doorkeeper: require trailing commas on multiline literals.
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: consistent_comma


### PR DESCRIPTION
> Part of the `.rubocop_todo.yml` removal stack (9 PRs, merge top-down; each PR only shows its own diff and is based on the previous one).

`Metrics/BlockLength` and `Metrics/ParameterLists` already skip `spec/`; spec support code and the dummy app favour one readable setup method over a split one for the same reason. This widens the existing `spec/dummy/db/**/*` exclusion to the whole tree, so every remaining Metrics offense behind the todo file is in library code.

`bundle exec rubocop`: no offenses. `bundle exec rake spec`: 455 examples, 0 failures.
