### PR TITLE
Count multi-line literals as one line in Metrics/MethodLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,10 @@ Metrics/ParameterLists:
 # Spec support code and the dummy app favour one readable setup method over
 # a split one; Metrics/BlockLength and ParameterLists already skip spec/.
 Metrics/MethodLength:
+  # A multi-line hash, array, heredoc or method call is one statement; a
+  # method that builds a metadata document should not be split just because
+  # the literal listing its keys is long.
+  CountAsOne: [array, hash, heredoc, method_call]
   Exclude:
     - spec/**/*
 Metrics/AbcSize:


### PR DESCRIPTION
> Part of the `.rubocop_todo.yml` removal stack (9 PRs, merge top-down; each PR only shows its own diff and is based on the previous one).

Adopts RuboCop's `CountAsOne: [array, hash, heredoc, method_call]` so `Metrics/MethodLength` measures control flow rather than literal width. A method that builds a metadata or registration document should not be split just because the hash listing its keys is long.

Behind the todo file this drops the remaining Metrics offenses from 20 to 12 (all of the removed ones were hash-literal builders such as `oidc_metadata`).

`bundle exec rubocop`: no offenses. `bundle exec rake spec`: 455 examples, 0 failures.
