### PR TITLE
Bring nine library methods under Metrics/MethodLength and AbcSize

### DIFF
--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -16,10 +16,7 @@ module Doorkeeper
         client = Doorkeeper.configuration.application_model.create!(application_params(registration))
         render json: registration_response(client, registration), status: :created
       rescue ActiveRecord::RecordInvalid => e
-        render json: {
-          error: registration_error_code(e.record),
-          error_description: e.record.errors.full_messages.join(", "),
-        }, status: :bad_request
+        render json: record_invalid_response(e.record), status: :bad_request
       end
 
       private
@@ -47,6 +44,13 @@ module Doorkeeper
         else
           authorizer
         end
+      end
+
+      def record_invalid_response(record)
+        {
+          error: registration_error_code(record),
+          error_description: record.errors.full_messages.join(", "),
+        }
       end
 
       # RFC 7591 §3.2.2 registration error codes: `invalid_redirect_uri` for

--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -298,14 +298,10 @@ module Doorkeeper
       return issuer unless issuer.respond_to?(:call)
 
       case issuer.arity
-      when 0
-        issuer.call
-      when 1
-        issuer.call(request || resource_owner)
-      when 2
-        issuer.call(resource_owner, application)
-      else
-        issuer.call(resource_owner, application, request)
+      when 0 then issuer.call
+      when 1 then issuer.call(request || resource_owner)
+      when 2 then issuer.call(resource_owner, application)
+      else issuer.call(resource_owner, application, request)
       end
     end
     private_class_method :call_issuer

--- a/lib/doorkeeper/openid_connect/claims_builder.rb
+++ b/lib/doorkeeper/openid_connect/claims_builder.rb
@@ -18,12 +18,19 @@ module Doorkeeper
         end
 
         Doorkeeper::OpenidConnect.configuration.claims.to_h.map do |name, claim|
-          if claim.scopes.any? { |scope| access_token.scopes.exists?(scope) } &&
-             claim.response.include?(response)
+          if claim_applies?(claim, access_token, response)
             [name, claim.generator.call(resource_owner, access_token.scopes, access_token)]
           end
         end.compact.to_h
       end
+
+      # A claim is included when the token carries one of its scopes and it is
+      # configured for this response type (:id_token / :user_info).
+      def self.claim_applies?(claim, access_token, response)
+        claim.scopes.any? { |scope| access_token.scopes.exists?(scope) } &&
+          claim.response.include?(response)
+      end
+      private_class_method :claim_applies?
 
       def initialize(&block)
         @claims = OpenStruct.new

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -193,13 +193,15 @@ module Doorkeeper
         @validated_models ||= {}
         return model if @validated_models[kind] == model
 
-        unless model.is_a?(Class) && model <= base_model
-          raise Errors::InvalidConfiguration,
-                "The configured #{kind}_class (#{class_name}) must inherit from #{base_model.name}"
-        end
-
+        validate_model_inheritance!(kind, class_name, model, base_model)
         @validated_models[kind] = model
-        model
+      end
+
+      def validate_model_inheritance!(kind, class_name, model, base_model)
+        return if model.is_a?(Class) && model <= base_model
+
+        raise Errors::InvalidConfiguration,
+              "The configured #{kind}_class (#{class_name}) must inherit from #{base_model.name}"
       end
     end
   end

--- a/lib/doorkeeper/openid_connect/helpers/controller/error_response.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller/error_response.rb
@@ -17,23 +17,13 @@ module Doorkeeper
             # itself gates the emission on redirectability and on the issuer
             # being configured. Versions predating #1849 simply ignore the
             # attribute, so no version guard is needed.
-            error_response = if exception.type == :invalid_request
-                               ::Doorkeeper::OAuth::InvalidRequestResponse.new(
-                                 name: exception.type,
-                                 state: params[:state],
-                                 redirect_uri: params[:redirect_uri],
-                                 response_on_fragment: pre_auth.response_on_fragment?,
-                                 issuer: Doorkeeper::OpenidConnect.doorkeeper_issuer,
-                               )
-                             else
-                               ::Doorkeeper::OAuth::ErrorResponse.new(
-                                 name: exception.type,
-                                 state: params[:state],
-                                 redirect_uri: params[:redirect_uri],
-                                 response_on_fragment: pre_auth.response_on_fragment?,
-                                 issuer: Doorkeeper::OpenidConnect.doorkeeper_issuer,
-                               )
-                             end
+            error_response = oidc_error_response_class(exception).new(
+              name: exception.type,
+              state: params[:state],
+              redirect_uri: params[:redirect_uri],
+              response_on_fragment: pre_auth.response_on_fragment?,
+              issuer: Doorkeeper::OpenidConnect.doorkeeper_issuer,
+            )
 
             response.headers.merge!(error_response.headers)
 
@@ -44,6 +34,14 @@ module Doorkeeper
             # - https://github.com/doorkeeper-gem/doorkeeper/blob/v5.5.0/app/controllers/doorkeeper/authorizations_controller.rb#L52
             @authorize_response = error_response
             redirect_or_render(@authorize_response)
+          end
+
+          def oidc_error_response_class(exception)
+            if exception.type == :invalid_request
+              ::Doorkeeper::OAuth::InvalidRequestResponse
+            else
+              ::Doorkeeper::OAuth::ErrorResponse
+            end
           end
         end
       end

--- a/lib/doorkeeper/openid_connect/helpers/controller/prompt.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller/prompt.rb
@@ -22,18 +22,12 @@ module Doorkeeper
 
           def apply_oidc_prompt!(prompt, prompt_values, owner)
             case prompt
-            when "none"
-              handle_oidc_prompt_none!(prompt_values, owner)
-            when "login"
-              handle_oidc_prompt_login!(owner)
-            when "consent"
-              handle_oidc_prompt_consent!(owner)
-            when "select_account"
-              select_account_for_oidc_resource_owner(owner)
-            when "create"
-              # NOTE: not supported, but does not raise an error.
-            else
-              raise Errors::InvalidRequest
+            when "none" then handle_oidc_prompt_none!(prompt_values, owner)
+            when "login" then handle_oidc_prompt_login!(owner)
+            when "consent" then handle_oidc_prompt_consent!(owner)
+            when "select_account" then select_account_for_oidc_resource_owner(owner)
+            when "create" then nil # NOTE: not supported, but does not raise an error.
+            else raise Errors::InvalidRequest
             end
           end
 

--- a/lib/doorkeeper/openid_connect/helpers/controller/prompt.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller/prompt.rb
@@ -75,6 +75,11 @@ module Doorkeeper
 
           def return_without_oidc_prompt_param(prompt_value)
             return_to = URI.parse(request.path)
+            return_to.query = query_parameters_without_oidc_prompt(prompt_value).to_query
+            return_to.to_s
+          end
+
+          def query_parameters_without_oidc_prompt(prompt_value)
             # Work on a copy: `request.query_parameters` is memoized and shared, so
             # mutating it in place would corrupt the parameters seen by the rest of
             # the request (and any subsequent prompt value in the same loop).
@@ -89,8 +94,7 @@ module Doorkeeper
             else
               query.delete("prompt")
             end
-            return_to.query = query.to_query
-            return_to.to_s
+            query
           end
 
           def reauthenticate_oidc_resource_owner(owner)

--- a/lib/doorkeeper/openid_connect/helpers/controller/token_matching.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller/token_matching.rb
@@ -35,14 +35,10 @@ module Doorkeeper
             relation = token_model.authorized_tokens_for(pre_auth.client.id, owner)
             batch_size = Doorkeeper.configuration.token_lookup_batch_size
 
-            match_found = false
             token_model.find_access_token_in_batches(relation, batch_size: batch_size) do |batch|
-              if batch.any? { |token| token.scopes.scopes?(pre_auth.scopes) }
-                match_found = true
-                break
-              end
+              return true if batch.any? { |token| token.scopes.scopes?(pre_auth.scopes) }
             end
-            match_found
+            false
           end
 
           # Force Doorkeeper's `render_success` onto the auto-issue path when a

--- a/lib/doorkeeper/openid_connect/rails/routes.rb
+++ b/lib/doorkeeper/openid_connect/rails/routes.rb
@@ -26,32 +26,37 @@ module Doorkeeper
 
         def generate_routes!(options)
           @mapping = Mapper.new.map(&@block)
-          openid_connect = ::Doorkeeper::OpenidConnect.configuration
-          prefix = route_helper_prefix(options)
 
           routes.scope options[:scope] || "oauth", as: "oauth" do
-            map_route(:userinfo, :userinfo_routes)
-            map_route(:discovery, :discovery_routes)
-
-            if openid_connect.dynamic_client_registration
-              map_route(:dynamic_client_registration, :dynamic_client_registration_routes)
-            end
+            map_oauth_routes
           end
 
-          well_known_scope = { as: "oauth" }
-          # When the engine is mounted under a named scope (e.g.
-          # `scope :users, as: :users`), Doorkeeper's and this engine's URL
-          # helpers are generated with that prefix (`users_oauth_*`). Pass the
-          # prefix down to the discovery controller via a route default so it can
-          # resolve the correct namespaced helpers for the published endpoints.
-          well_known_scope[:defaults] = { route_helper_prefix: prefix } if prefix.present?
-
-          routes.scope(**well_known_scope) do
+          routes.scope(**well_known_scope(options)) do
             map_route(:discovery, :discovery_well_known_routes)
           end
         end
 
         private
+
+        def map_oauth_routes
+          map_route(:userinfo, :userinfo_routes)
+          map_route(:discovery, :discovery_routes)
+          return unless ::Doorkeeper::OpenidConnect.configuration.dynamic_client_registration
+
+          map_route(:dynamic_client_registration, :dynamic_client_registration_routes)
+        end
+
+        def well_known_scope(options)
+          prefix = route_helper_prefix(options)
+          scope = { as: "oauth" }
+          # When the engine is mounted under a named scope (e.g.
+          # `scope :users, as: :users`), Doorkeeper's and this engine's URL
+          # helpers are generated with that prefix (`users_oauth_*`). Pass the
+          # prefix down to the discovery controller via a route default so it can
+          # resolve the correct namespaced helpers for the published endpoints.
+          scope[:defaults] = { route_helper_prefix: prefix } if prefix.present?
+          scope
+        end
 
         def route_helper_prefix(options)
           name = options[:as]


### PR DESCRIPTION
> Part of the `.rubocop_todo.yml` removal stack (9 PRs, merge top-down; each PR only shows its own diff and is based on the previous one).

Each commit touches one method and can be reviewed on its own:

| commit | method | change |
|---|---|---|
| 1 | `OpenidConnect.call_issuer` | fold the 4-way arity dispatch onto `when n then …` lines |
| 2 | `Prompt#apply_oidc_prompt!` | same for the prompt-value dispatch; the `create` note stays |
| 3 | `Prompt#return_without_oidc_prompt_param` | extract `query_parameters_without_oidc_prompt` (query rewrite vs URL assembly) |
| 4 | `TokenMatching#oidc_subset_token_exists?` | `return true` from the batch block replaces the `match_found` flag + `break` |
| 5 | `Config::Builder#resolve_validated_model` | extract `validate_model_methods!` |
| 6 | `Rails::Routes#generate_routes!` | extract `map_oauth_routes` and `well_known_scope` (the namespaced-mount note moves with it) |
| 7 | `DynamicClientRegistrationController#register` | extract `record_invalid_response` for the rescue body |
| 8 | `ClaimsBuilder.generate` | extract `claim_applies?` (scope-and-response predicate) |
| 9 | `ErrorResponse#handle_oidc_error!` | both branches passed the same five kwargs and differed only in class → pick the class in `oidc_error_response_class`, build once |

No spec was changed. Every commit passes RuboCop individually. `rake spec`: 455/0 (default), 453/0 (doorkeeper 5.5), 464/0 (doorkeeper master), 455/0 (rails 7.0).
