### PR TITLE
Drop the Metrics overrides from .rubocop_todo.yml

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-Metrics/MethodLength:
-  Max: 33
-
-# Configuration parameters: IgnoredMethods.
-Metrics/AbcSize:
-  Max: 35
-
 # The Doorkeeper config DSL (subject, auth_time_from_resource_owner, claim)
 # invokes these blocks with extra arguments, so a strict-arity `&:sym`
 # lambda raises ArgumentError. Keep explicit blocks here.

--- a/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/discovery_controller.rb
@@ -28,6 +28,10 @@ module Doorkeeper
 
       private
 
+      # One method per metadata document: the provider metadata is a flat
+      # listing of endpoints and capabilities, and splitting it would hide the
+      # shape of the published document.
+      # rubocop:disable Metrics/AbcSize
       def provider_response
         doorkeeper = ::Doorkeeper.configuration
         openid_connect = ::Doorkeeper::OpenidConnect.configuration
@@ -79,6 +83,7 @@ module Doorkeeper
           code_challenge_methods_supported: code_challenge_methods_supported(doorkeeper),
         }.compact
       end
+      # rubocop:enable Metrics/AbcSize
 
       def response_modes_supported(doorkeeper)
         doorkeeper.authorization_response_flows.flat_map(&:response_mode_matches).uniq

--- a/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
+++ b/app/controllers/doorkeeper/openid_connect/dynamic_client_registration_controller.rb
@@ -82,6 +82,10 @@ module Doorkeeper
         Doorkeeper.config.application_model.column_names.include?("post_logout_redirect_uris")
       end
 
+      # One method per metadata document: the registration response echoes
+      # the client metadata as RFC 7591 §3.2.1 lists it, and splitting it
+      # would hide the shape of the published document.
+      # rubocop:disable Metrics/AbcSize
       def registration_response(doorkeeper_application, registration)
         response = {
           client_id: doorkeeper_application.uid,
@@ -115,6 +119,7 @@ module Doorkeeper
 
         response
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end


### PR DESCRIPTION
> Part of the `.rubocop_todo.yml` removal stack (9 PRs, merge top-down; each PR only shows its own diff and is based on the previous one).

After the previous PRs only two `Metrics/AbcSize` offenses remain, both in methods that build a metadata document: `DiscoveryController#provider_response` and `DynamicClientRegistrationController#registration_response` (RFC 7591 §3.2.1). Splitting them would hide the shape of the published document, so they get an inline `rubocop:disable Metrics/AbcSize` with the reason, and `Metrics/MethodLength` / `Metrics/AbcSize` now run at RuboCop's defaults everywhere else.

`bundle exec rubocop`: no offenses. `bundle exec rake spec`: 455 examples, 0 failures.
