### PR TITLE
Fix CI: exclude EOL Rails from ruby-head, pin json for 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,23 @@ jobs:
           - gemfiles/rails_8.1.gemfile
           - gemfiles/doorkeeper_master.gemfile
         exclude:
+          # None of these Rails series will be made to work on a development
+          # Ruby: 7.0, 7.1 and 7.2 have all passed the two-year security-fix
+          # window Rails grants a series (7.2.0 shipped 2024-08-09), so nothing
+          # lands there any more. The released Rubies still cover all three.
+          #
+          # 7.0 has been excluded since Ruby 3.4 landed. 7.1 and 7.2 joined
+          # when json 3.0 — which ruby-head bundles — turned an unknown
+          # keyword argument into an ArgumentError while ActiveSupport's
+          # JSONGemEncoder still passed `quirks_mode: true`, so every
+          # `render json:` raises. That one is fixed on Rails main and on
+          # 8-0-stable, but neither fix reaches a 7.x series.
           - ruby: head
             gemfile: gemfiles/rails_7.0.gemfile
+          - ruby: head
+            gemfile: gemfiles/rails_7.1.gemfile
+          - ruby: head
+            gemfile: gemfiles/rails_7.2.gemfile
         # Oldest supported Doorkeeper series — one Ruby each is enough to
         # keep the `>= 5.5` gemspec constraint honest.
         include:

--- a/gemfiles/doorkeeper_master.gemfile
+++ b/gemfiles/doorkeeper_master.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "doorkeeper", git: "https://github.com/doorkeeper-gem/doorkeeper.git"
-gem "rails", "~> 8.0.0"
+gem "rails", "~> 8.1.0"
 gem "rails-controller-testing"
 gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
 

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,6 +2,14 @@
 
 source "https://rubygems.org"
 
+# json 3.0 raises on unknown keyword arguments, and the released 8.0.x
+# ActiveSupport still passes `quirks_mode: true` from JSONGemEncoder, so every
+# `render json:` fails under ruby-head. The fix is on 8-0-stable but unreleased.
+# `~> 2.21` rather than `< 3` so 3.0.0.rc1 is not resolvable either.
+# TODO: drop this pin once an 8.0.x release carries the fix. That may be a
+# while: the 8.0 series is past its one-year bug-fix window, so the fix has to
+# ride along with a security release.
+gem "json", "~> 2.21"
 gem "rails", "~> 8.0.0"
 gem "rails-controller-testing"
 gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]


### PR DESCRIPTION
## Problem

The four `Ruby head` CI jobs below are red on `master`, without anything in this repository having changed:

- `Ruby head (gemfiles/rails_7.1.gemfile)`
- `Ruby head (gemfiles/rails_7.2.gemfile)`
- `Ruby head (gemfiles/rails_8.0.gemfile)`
- `Ruby head (gemfiles/doorkeeper_master.gemfile)`

Each one fails the same way, ~90 examples per job:

```
Failure/Error: render json: user_info, status: :ok

ArgumentError:
  unknown keyword: quirks_mode
```

ruby-head (4.1.0dev) bundles **json 3.0**, which made passing an unknown keyword argument an `ArgumentError` instead of ignoring it. ActiveSupport's `JSONGemEncoder#stringify` still calls `JSON.generate(..., quirks_mode: true)`, so on the affected Rails series every `render json:` raises. Rails `main` (8.1) has already dropped the argument; `8-0-stable` carries the fix but has not been released; 7.1 and 7.2 are EOL and will not get it.

## Changes

**1. Exclude ruby-head × Rails 7.1 / 7.2 (`.github/workflows/ci.yml`)**

Neither series will be fixed — 7.1 is out of support and 7.2 receives security fixes only — so there is no upstream change to wait for. Their ruby-head rows join the existing `rails_7.0` exclusion. Coverage is unchanged for every released Ruby (3.2 / 3.3 / 3.4 / 4.0), which is what actually matters for Rails series that no longer take bug fixes.

While there, the exclusion block gained a comment covering all three entries. `rails_7.0`'s reason had only ever lived in the commit message that added it (`a7990d9`, when Ruby 3.4 landed), so reading the workflow gave no hint why that row existed.

**2. `gemfiles/doorkeeper_master.gemfile`: Rails `~> 8.0.0` → `~> 8.1.0`**

This gemfile exists to track doorkeeper's `main` branch, and doorkeeper `main` only requires `railties >= 5` — the 8.0 pin was incidental, not a constraint. Moving it to 8.1 puts it on the series that already carries the fix, and is also what the gemfile should be tracking anyway.

**3. `gemfiles/rails_8.0.gemfile`: pin `json` to `~> 2.21`**

Rails 8.0 is supported and does deserve ruby-head coverage, so it gets a pin rather than an exclusion. `~> 2.21` rather than `< 3` deliberately: `< 3` still resolves `3.0.0.rc1`, which reintroduces the failure. Same technique as the `concurrent-ruby` pin already in `gemfiles/rails_7.0.gemfile`.

>[!NOTE]
> **TODO:** remove this pin once an 8.0.x patch release ships the ActiveSupport fix (already on `8-0-stable`). It is a workaround for an unreleased fix, not a permanent constraint.

## Verification

Locally, on the changed gemfiles:

| gemfile | result |
| --- | --- |
| `gemfiles/doorkeeper_master.gemfile` (Rails 8.1.3.1, doorkeeper `main`) | 468 examples, 0 failures |
| `gemfiles/rails_8.0.gemfile` (Rails 8.0.5.1, json 2.21.2) | 459 examples, 0 failures |
| `rake e2e` on `gemfiles/doorkeeper_master.gemfile` | 13 examples, 0 failures |

CI configuration only — no library code and no specs are touched.