### PR TITLE
Handle a String `auth_time` from `auth_time_from_session`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrading? [Migration from Old Versions](https://github.com/doorkeeper-gem/doork
 - [#364] **Breaking:** Require `id_token_class` / `user_info_class` overrides to inherit from `Doorkeeper::OpenidConnect::IdToken` / `UserInfo` ([#344](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/344)). Adds an `IdToken#select_key` hook returning the signing key and its algorithm together (`IdToken::SigningKey`) for per-client, rotating or multi-tenant keys, and binds the `at_hash` digest to that algorithm (OIDC Core §3.2.2.10) rather than the global `signing_algorithm`
 - [#387] **Breaking:** Remove the deprecated `jws_private_key` and `jws_public_key` initializer settings
 - [#399] **Breaking:** Rename `Doorkeeper::OpenidConnect::HybridIdTokenConcern` to `AtHashConcern`. The old name described the `id_token token` response type as a hybrid flow, but OpenID Connect Core defines that response type under the Implicit Flow (§3.2) — the Hybrid Flow response types of §3.3 are not implemented by this gem. Removed without an alias: the constant only ever shipped in 2.0.0.beta1
+- [#401] Fix `max_age` reauthentication loop when `auth_time_from_session` returns a String — a `Time` stored on the session round-trips as a String through the JSON cookie serializer (Rails 7.0+ default), and `to_i` on it yielded the year instead of an epoch (same class of bug as [#248])
 - Add entry here
 
 ## v2.0.0.beta1 (2026-08-20)

--- a/lib/doorkeeper/openid_connect/helpers/controller/max_age.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller/max_age.rb
@@ -8,6 +8,29 @@ module Doorkeeper
         # §3.1.2.1): when the resource owner's last authentication is older
         # than `max_age` seconds, reauthentication is required.
         module MaxAge
+          # The shapes a `Time` takes once it has been serialized into the
+          # session:
+          #
+          # * `"2026-09-05T03:59:10.270Z"` — `ActiveSupport::JSON`, which is
+          #   what the JSON cookie serializer emits
+          # * `"2026/09/05 03:59:10 +0000"` — the same encoder with
+          #   `ActiveSupport::JSON::Encoding.use_standard_json_time_format`
+          #   turned off
+          # * `"2026-09-05 03:59:27 UTC"` — `JSON.generate` on a bare `Time`
+          #
+          # The date separator is captured and backreferenced so the two forms
+          # cannot be mixed, and the zone suffix is optional so that a
+          # serializer which drops it still reads as a local time.
+          OIDC_SERIALIZED_AUTH_TIME = %r{
+            \A
+            (?<year>\d{4})(?<sep>[-/])(?<month>\d{2})\k<sep>(?<day>\d{2})  # date
+            [T\ ]
+            \d{2}:\d{2}:\d{2}                    # time
+            (?:\.\d+)?                           # optional fractional seconds
+            (?:\ ?(?:Z|UTC|[+-]\d{2}:?\d{2}))?   # optional zone
+            \z
+          }x
+
           private
 
           def handle_oidc_max_age_param!(owner)
@@ -56,8 +79,71 @@ module Doorkeeper
           def normalized_oidc_auth_time(owner)
             auth_time = resolve_oidc_auth_time(owner)
             return auth_time if !auth_time || auth_time.is_a?(Time) || auth_time.is_a?(DateTime)
+            return parse_oidc_auth_time_string(auth_time) if auth_time.is_a?(String)
 
             Time.zone.at(auth_time.to_i)
+          end
+
+          # A `Time` written to the session comes back as a String once the
+          # session is serialized, which is the default since Rails 7.0
+          # (`config.load_defaults` selects the JSON cookie serializer). Running
+          # such a value through `to_i` yields the leading year — `"2026-09-05
+          # T03:59:10.270Z".to_i` is `2026` — placing auth_time in 1970 and
+          # making every `max_age` request look stale, so the RP and the
+          # provider bounce the user through reauthentication forever. Same
+          # class of bug as #248, which fixed the Integer case.
+          #
+          # A numeric String is an epoch. The grammar covers every *numeric*
+          # String `to_i` resolved — optional surrounding whitespace, an
+          # optional sign, an optional fractional part — and `to_f` rather than
+          # `to_i` keeps the sub-second part of `"1757150000.5"`. A signed
+          # value stays meaningful either way: `"+1757150000"` is the epoch it
+          # looks like, and a negative one resolves to a pre-1970 time, which
+          # is stale under any `max_age` and so requires reauthentication
+          # regardless.
+          #
+          # Anchoring it at both ends is the one deliberate narrowing here.
+          # `to_i` also truncated a String to its leading integer, so
+          # `"1788703912 seconds"` used to resolve and no longer does. Keeping
+          # that as a fallback would reinstate the bug above for every
+          # serialization this method does not recognise —
+          # `"20260905T035910Z".to_i` is `20260905`, i.e. 1970 and stale
+          # forever — while reading `"99999999999999 garbage"` as a year
+          # 3170843 timestamp, i.e. fresh. Truncation guesses wrong in both
+          # directions; a String that is not wholly a number is not an epoch.
+          #
+          # Anything else has to look like one of the
+          # serialized timestamps, which `Time.zone.parse` then reads. `parse`
+          # is not used on its own because it is far more permissive than any
+          # of those formats: it takes `"10 minutes"` for day 10 of the current
+          # month, and such a value landing in the future would read as *fresh*
+          # and silently skip the `max_age` reauthentication.
+          # `Time.zone.iso8601` is no alternative — it rejects the bare-`Time`
+          # form outright.
+          #
+          # Matching the shape is not enough on its own: `parse` rolls an
+          # impossible calendar date over instead of raising, so `"2026-02-31"`
+          # comes back as 2026-03-03 — a date far enough ahead would read as
+          # fresh and skip the reauthentication. The day is therefore checked
+          # with `Date.valid_date?` before parsing.
+          #
+          # What is left over is rescued: an out-of-range hour, minute or
+          # second raises `ArgumentError`, and a numeric String too long to be
+          # a Float (`"9" * 400` overflows to `Float::INFINITY`) makes
+          # `Time.zone.at` raise `FloatDomainError`. A value of any of these
+          # shapes returns nil, which `oidc_auth_time_stale?` treats as "no
+          # known auth_time" and so requires reauthentication — a malformed
+          # callback value must fail closed, not 500.
+          def parse_oidc_auth_time_string(value)
+            return Time.zone.at(value.to_f) if value.match?(/\A\s*[+-]?\d+(?:\.\d+)?\s*\z/)
+
+            match = OIDC_SERIALIZED_AUTH_TIME.match(value)
+            return unless match
+            return unless Date.valid_date?(match[:year].to_i, match[:month].to_i, match[:day].to_i)
+
+            Time.zone.parse(value)
+          rescue ArgumentError, RangeError
+            nil
           end
 
           def oidc_auth_time_stale?(auth_time, max_age)

--- a/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
+++ b/lib/generators/doorkeeper/openid_connect/templates/initializer.rb
@@ -59,9 +59,13 @@ Doorkeeper::OpenidConnect.configure do
   # piggy-backing on a fresh login from another device.
   #
   # The block is executed in the controller's scope and receives the
-  # current `session` and `request`. Return value can be a `Time`,
-  # `DateTime`, or anything responding to `to_i`. Return `nil` to force
-  # reauthentication.
+  # current `session` and `request`. Return value can be a `Time`, a
+  # `DateTime`, epoch seconds (an Integer or a numeric String), or a
+  # serialized timestamp String such as `"2026-09-05T03:59:10.270Z"` — a
+  # `Time` stored in the session comes back as the latter once it
+  # round-trips through the JSON cookie serializer, which Rails 7.0+
+  # selects by default. A String of any other shape is read as an unknown
+  # auth_time and forces reauthentication, as does `nil`.
   #
   # auth_time_from_session do |session, _request|
   #   # Example implementation: capture auth_time on the session at login,

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -707,6 +707,175 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
         expect(response).to redirect_to "/reauthenticate"
       end
 
+      # A `Time` put on the session comes back as a String once the session is
+      # serialized, which the JSON cookie serializer — the default since Rails
+      # 7.0 — always does. `to_i` on such a value returns the leading year,
+      # placing auth_time in 1970 and making every request look stale.
+      context "when the session round-tripped the auth_time through a serializer" do
+        it "accepts a bare-Time JSON String within max_age" do
+          authorize_with_session!(
+            { current_session_auth_time: 5.seconds.ago.utc.strftime("%Y-%m-%d %H:%M:%S UTC") },
+            max_age: 10,
+          )
+
+          expect_authorization_form!
+        end
+
+        it "accepts an ISO 8601 String within max_age" do
+          authorize_with_session!(
+            { current_session_auth_time: 5.seconds.ago.utc.iso8601(3) },
+            max_age: 10,
+          )
+
+          expect_authorization_form!
+        end
+
+        it "reauthenticates on an ISO 8601 String older than max_age" do
+          authorize_with_session!(
+            { current_session_auth_time: 5.minutes.ago.utc.iso8601(3) },
+            max_age: 10,
+          )
+
+          expect(response).to redirect_to "/reauthenticate"
+        end
+
+        # `ActiveSupport::JSON::Encoding.use_standard_json_time_format` can be
+        # turned off, and the same encoder then emits `"%Y/%m/%d %H:%M:%S %z"`.
+        it "accepts the non-standard ActiveSupport JSON time format within max_age" do
+          authorize_with_session!(
+            { current_session_auth_time: 5.seconds.ago.utc.strftime("%Y/%m/%d %H:%M:%S %z") },
+            max_age: 10,
+          )
+
+          expect_authorization_form!
+        end
+
+        it "reauthenticates on a non-standard ActiveSupport JSON time older than max_age" do
+          authorize_with_session!(
+            { current_session_auth_time: 5.minutes.ago.utc.strftime("%Y/%m/%d %H:%M:%S %z") },
+            max_age: 10,
+          )
+
+          expect(response).to redirect_to "/reauthenticate"
+        end
+
+        it "reauthenticates on a String mixing the two date separators" do
+          authorize_with_session!(
+            { current_session_auth_time: 5.seconds.ago.utc.strftime("%Y-%m/%d %H:%M:%S %z") },
+            max_age: 10,
+          )
+
+          expect(response).to redirect_to "/reauthenticate"
+        end
+
+        it "accepts a digit-only String as epoch seconds" do
+          authorize_with_session!(
+            { current_session_auth_time: 5.seconds.ago.to_i.to_s },
+            max_age: 10,
+          )
+
+          expect_authorization_form!
+        end
+
+        # `to_i` on the String resolved a fractional or signed epoch just as
+        # well as a bare one, so narrowing to digit-only values would have
+        # regressed both of these to nil.
+        it "accepts a fractional epoch String" do
+          authorize_with_session!(
+            { current_session_auth_time: 5.seconds.ago.to_f.to_s },
+            max_age: 10,
+          )
+
+          expect_authorization_form!
+        end
+
+        it "accepts a positively signed epoch String" do
+          authorize_with_session!(
+            { current_session_auth_time: "+#{5.seconds.ago.to_i}" },
+            max_age: 10,
+          )
+
+          expect_authorization_form!
+        end
+
+        # A negative epoch is a pre-1970 time, which is stale under any max_age.
+        it "reauthenticates on a negatively signed epoch String" do
+          authorize_with_session!(
+            { current_session_auth_time: "-#{5.seconds.ago.to_i}" },
+            max_age: 10,
+          )
+
+          expect(response).to redirect_to "/reauthenticate"
+        end
+
+        # `"9" * 400` overflows to `Float::INFINITY`, which makes `Time.zone.at`
+        # raise `FloatDomainError` — a `RangeError`, not an `ArgumentError`.
+        it "reauthenticates on a numeric String too large to be a Float" do
+          authorize_with_session!(
+            { current_session_auth_time: "9" * 400 },
+            max_age: 10,
+          )
+
+          expect(response).to redirect_to "/reauthenticate"
+        end
+
+        # `to_i` truncated a String to its leading integer, so this used to
+        # resolve. Keeping that fallback would send every unrecognised
+        # serialization back to 1970 — the loop this fixes — so it is dropped
+        # deliberately and the value fails closed instead.
+        it "reauthenticates on a String with a numeric prefix and a suffix" do
+          authorize_with_session!(
+            { current_session_auth_time: "#{5.seconds.ago.to_i} seconds" },
+            max_age: 10,
+          )
+
+          expect(response).to redirect_to "/reauthenticate"
+        end
+
+        it "reauthenticates when the String cannot be parsed as a time" do
+          authorize_with_session!(
+            { current_session_auth_time: "not a time" },
+            max_age: 10,
+          )
+
+          expect(response).to redirect_to "/reauthenticate"
+        end
+
+        # `Time.zone.parse` alone reads "10 minutes" as day 10 of the current
+        # month, which is a future timestamp for most of the month and would
+        # therefore look fresh and skip reauthentication entirely.
+        it "reauthenticates on a String that only Time.zone.parse would accept" do
+          authorize_with_session!(
+            { current_session_auth_time: "10 minutes" },
+            max_age: 10,
+          )
+
+          expect(response).to redirect_to "/reauthenticate"
+        end
+
+        # `Time.zone.parse` rolls an impossible calendar date over rather than
+        # raising, so February 31st comes back as March 3rd. A year far enough
+        # ahead makes that rollover land in the future, which would read as
+        # fresh and skip reauthentication if the date were not validated.
+        it "reauthenticates on a well-shaped String holding an impossible date" do
+          authorize_with_session!(
+            { current_session_auth_time: "2999-02-31 03:59:27 UTC" },
+            max_age: 10,
+          )
+
+          expect(response).to redirect_to "/reauthenticate"
+        end
+
+        it "reauthenticates on a well-shaped String holding an out-of-range time" do
+          authorize_with_session!(
+            { current_session_auth_time: "2999-09-05 25:00:00 UTC" },
+            max_age: 10,
+          )
+
+          expect(response).to redirect_to "/reauthenticate"
+        end
+      end
+
       it "does not emit the auth_time_from_resource_owner deprecation warning" do
         expect(Doorkeeper::OpenidConnect::Helpers::Controller)
           .not_to receive(:warn_auth_time_from_resource_owner_deprecation)


### PR DESCRIPTION
## Problem

`auth_time_from_session` (#271) is documented in the generated initializer as returning "a `Time`, `DateTime`, or anything responding to `to_i`", and its own example is:

```ruby
auth_time_from_session do |session, _request|
  session[:auth_time]
end
```

Follow that and the callback returns a **String**. A `Time` written to the session comes back serialized once the session round-trips, and the JSON cookie serializer — which `config.load_defaults` has selected since Rails 7.0 — is exactly such a round-trip:

```ruby
session[:auth_time] = Time.current       # => 2026-09-05 03:59:10 UTC
# next request
session[:auth_time]                      # => "2026-09-05T03:59:10.270Z"
```

`normalized_oidc_auth_time` fell through to `Time.zone.at(auth_time.to_i)`, and `to_i` on that String returns the **leading year**:

```ruby
"2026-09-05T03:59:10.270Z".to_i                 # => 2026
Time.zone.at(2026)                              # => 1970-01-01 00:33:46 UTC
```

auth_time lands in 1970, so `oidc_auth_time_stale?` reports stale for every `max_age` value. The provider reauthenticates, writes a fresh `auth_time` to the session, and the very next authorization request is stale again — the RP and the provider bounce the user through reauthentication indefinitely.

This is the same class of bug as #248, which fixed the Integer case for `auth_time_from_resource_owner`. It affects every release since v1.10.0, where `auth_time_from_session` was introduced.

## Fix

`normalized_oidc_auth_time` gains a String branch. The accepted forms, in the order they are tried:

| input | read as | examples |
| --- | --- | --- |
| **numeric** — `/\A\s*[+-]?\d+(?:\.\d+)?\s*\z/`, i.e. optional surrounding whitespace, optional sign, optional fractional part | epoch seconds, via `Time.zone.at(value.to_f)` | `"1757150000"`, `"+1757150000"`, `"1757150000.5"`, `" 1757150000 "` |
| one of the three **serialized `Time` shapes** below, carrying a real calendar date | `Time.zone.parse(value)` | `"2026-09-05T03:59:10.270Z"`, `"2026/09/05 03:59:10 +0000"`, `"2026-09-05 03:59:27 UTC"` |
| **anything else**, and anything that raises during conversion | `nil` | `"10 minutes"`, `"not a time"`, `"2999-02-31 03:59:27 UTC"`, `"9" * 400` |

`nil` is what `oidc_auth_time_stale?` already treats as "no known auth_time", so every rejection requires reauthentication — the branch fails closed, and never with a 500.

Two deliberate choices in that grammar:

- **The numeric form covers every numeric String `to_i` resolved.** `to_i` took `"+1757150000"`, `"1757150000.5"` and `" 1757150000 "` alike, so narrowing to digit-only values would have been a regression of its own. `to_f` rather than `to_i` additionally keeps the sub-second part. A negative epoch is accepted and resolves to a pre-1970 time, which is stale under any `max_age` and so requires reauthentication anyway.
- **The numeric form is anchored at both ends, which is the one deliberate narrowing.** See *Backward compatibility* below.
- **Non-numeric values are matched against a whitelist rather than handed to `parse`.** The direction of failure is why: a value that reads as a **future** timestamp is not stale, so it skips the very reauthentication `max_age` asks for. A permissive parse fails *open*, and `nil` is the only safe answer for something that is not recognisably a timestamp.

### Why `Time.zone.parse` and not `Time.zone.iso8601`

`iso8601` is the stricter choice, but there are three serialized shapes in play and it covers only the first:

| serializer | `Time.current` becomes | `iso8601` |
| --- | --- | --- |
| `ActiveSupport::JSON` (the JSON cookie serializer) | `"2026-09-05T03:59:10.270Z"` | ✅ |
| the same encoder with `ActiveSupport::JSON::Encoding.use_standard_json_time_format` off | `"2026/09/05 03:59:10 +0000"` | ❌ raises |
| `JSON.generate` on a bare `Time` | `"2026-09-05 03:59:27 UTC"` | ❌ raises |

Rejecting the other two would turn one silent failure into another, so `parse` wins — and the looseness it brings is fenced off ahead of the call instead.

### Fencing off `parse`

**1. `parse` guesses at values that are not timestamps at all.** `Time.zone.parse("10 minutes")` returns day 10 of the *current* month, which is a future timestamp for most of the month. So the value has to match one of the three shapes above first. The date separator is captured and backreferenced, so `-` and `/` cannot be mixed:

```ruby
OIDC_SERIALIZED_AUTH_TIME = %r{
  \A
  (?<year>\d{4})(?<sep>[-/])(?<month>\d{2})\k<sep>(?<day>\d{2})  # date
  [T\ ]
  \d{2}:\d{2}:\d{2}                    # time
  (?:\.\d+)?                           # optional fractional seconds
  (?:\ ?(?:Z|UTC|[+-]\d{2}:?\d{2}))?   # optional zone
  \z
}x
```

**2. Matching the shape is still not enough.** `parse` raises on an out-of-range month, hour, minute or second — but it silently *rolls over* an impossible day instead:

```ruby
Time.zone.parse("2026-02-31 00:00:00 UTC")   # => 2026-03-03 00:00:00 UTC   ← no exception
Time.zone.parse("2026-09-31 00:00:00 UTC")   # => 2026-10-01 00:00:00 UTC   ← no exception
Time.zone.parse("2026-13-01 00:00:00 UTC")   # ArgumentError: mon out of range
Time.zone.parse("2026-09-05 25:00:00 UTC")   # ArgumentError: hour out of range
```

A well-formed `"2999-02-31 03:59:27 UTC"` therefore clears the regex, rolls over to 2999-03-03, and reads as fresh. The captured `year`/`month`/`day` are checked with `Date.valid_date?` before parsing to close that off.

**3. What no up-front check catches is rescued.** A malformed callback value has to fail closed rather than raise a 500, and two shapes get past the checks and blow up in the conversion instead:

```ruby
Time.zone.parse("2026-09-05 25:00:00 UTC")   # ArgumentError: hour out of range
Time.zone.at(("9" * 400).to_f)               # FloatDomainError — to_f overflows to Infinity
```

`FloatDomainError` is a `RangeError`, not an `ArgumentError`, so both are rescued to `nil`.

None of the `parse` looseness is reachable from the outside — the session is a signed (and usually encrypted) cookie, so its contents are server-authored and a client cannot inject any of these values. They are guards against a deployment whose own callback hands over a malformed value, where failing open would silently disable `max_age` and failing loudly would 500.

## Tests

`spec/controllers/doorkeeper/authorizations_controller_spec.rb` gains a context covering all three serialized shapes within and beyond `max_age`, an integer and a fractional epoch String, a positively signed epoch String, and seven values that must fail closed: a non-timestamp String, `"10 minutes"` (which only `parse` would accept), a well-shaped impossible date whose rollover lands in the future, a well-shaped out-of-range time, a date mixing the two separators, a numeric String too large to be a Float, and a String with a numeric prefix and a trailing suffix.

## Also updated

The generated initializer's comment for `auth_time_from_session`, which was the source of the mismatch:

```diff
- # current `session` and `request`. Return value can be a `Time`,
- # `DateTime`, or anything responding to `to_i`. Return `nil` to force
- # reauthentication.
+ # current `session` and `request`. Return value can be a `Time`, a
+ # `DateTime`, epoch seconds (an Integer or a numeric String), or a
+ # serialized timestamp String such as `"2026-09-05T03:59:10.270Z"` — a
+ # `Time` stored in the session comes back as the latter once it
+ # round-trips through the JSON cookie serializer, which Rails 7.0+
+ # selects by default. A String of any other shape is read as an unknown
+ # auth_time and forces reauthentication, as does `nil`.
```

The wiki's `Configuration.md` and `Prompt-and-Max-Age.md` carry the same "anything responding to `to_i`" wording and need the same correction; that is out of scope here and will follow separately.

## Backward compatibility

Every previously working return type — `Time`, `DateTime`, `ActiveSupport::TimeWithZone`, an Integer epoch, and a numeric String whether signed, fractional or whitespace-wrapped — takes the same path as before, or a strictly more accurate one.

Two String cases change, and only one of them is visible:

- A String that is neither a number nor a recognisable timestamp used to be read as `0` by `to_i` and placed at 1970-01-01, i.e. permanently stale. It now yields `nil`, which is stale as well — same outcome, different reason recorded.
- **`to_i` also truncated a String to its leading integer, and that is deliberately not preserved.** `"1788703912 seconds"` used to resolve to that epoch; it now fails closed. Retaining truncation as a fallback would reinstate the bug this PR fixes for every serialization the whitelist does not recognise — `"20260905T035910Z".to_i` is `20260905`, back in 1970 and stale forever — while reading `"99999999999999 garbage"` as a year 3170843 timestamp, i.e. *fresh*, skipping `max_age` entirely. Truncation guesses wrong in both directions, and a String that is not wholly a number is not an epoch.

No configuration that returns a `Time` — which is what the initializer's own example does, and what the round-trip in *Problem* produces — is affected by either.