### PR TITLE
Defer the openid_request association until OIDC is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrading? [Migration from Old Versions](https://github.com/doorkeeper-gem/doork
 - [#364] **Breaking:** Require `id_token_class` / `user_info_class` overrides to inherit from `Doorkeeper::OpenidConnect::IdToken` / `UserInfo` ([#344](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/344)). Adds an `IdToken#select_key` hook returning the signing key and its algorithm together (`IdToken::SigningKey`) for per-client, rotating or multi-tenant keys, and binds the `at_hash` digest to that algorithm (OIDC Core §3.2.2.10) rather than the global `signing_algorithm`
 - [#387] **Breaking:** Remove the deprecated `jws_private_key` and `jws_public_key` initializer settings
 - [#399] **Breaking:** Rename `Doorkeeper::OpenidConnect::HybridIdTokenConcern` to `AtHashConcern`. The old name described the `id_token token` response type as a hybrid flow, but OpenID Connect Core defines that response type under the Implicit Flow (§3.2) — the Hybrid Flow response types of §3.3 are not implemented by this gem. Removed without an alias: the constant only ever shipped in 2.0.0.beta1
+- [#402] Fix a boot failure (`MissingConfiguration`) when the access grant model loads before `Doorkeeper::OpenidConnect.configure` — e.g. from an initializer sorting between `doorkeeper.rb` and `doorkeeper_openid_connect.rb` (regression since v1.10.3)
 - Add entry here
 
 ## v2.0.0.beta1 (2026-08-20)

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -10,6 +10,12 @@ module Doorkeeper
 
       @config = Config::Builder.new(&block).build
       validate_issuer_consistency
+      # Access grant models that loaded before this point deferred their
+      # `openid_request` association because it needs `open_id_request_class`.
+      # The namespace is spelled out: a bare `AccessGrant` would resolve to
+      # Doorkeeper's own grant model through the enclosing lexical scope if the
+      # autoload were ever dropped.
+      OpenidConnect::AccessGrant.wire_pending_hosts
       @config
     end
 

--- a/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb
@@ -3,13 +3,47 @@
 module Doorkeeper
   module OpenidConnect
     module AccessGrant
-      def self.prepended(base)
-        base.class_eval do
-          has_one :openid_request,
-                  class_name: Doorkeeper::OpenidConnect.configuration.open_id_request_class,
-                  foreign_key: "access_grant_id",
-                  inverse_of: :access_grant,
-                  dependent: :delete
+      class << self
+        # Wiring the `openid_request` association needs
+        # `open_id_request_class`, so it can only run once
+        # `Doorkeeper::OpenidConnect.configure` has. The grant model is not
+        # guaranteed to load after that: Doorkeeper's own `initialize_models!`
+        # reaches for it from `Doorkeeper.configure` (immediately, when a
+        # railtie has already loaded `ActiveRecord::Base`), and any initializer
+        # sorting between `doorkeeper.rb` and `doorkeeper_openid_connect.rb`
+        # can name the model itself. Reading the configuration here would raise
+        # `MissingConfiguration` in both cases — with a message pointing at an
+        # initializer that does exist and simply has not run yet.
+        #
+        # So wire immediately when the configuration is there, and otherwise
+        # remember the host model and wire it from `configure`.
+        def prepended(base)
+          return pending_hosts << base unless OpenidConnect.configured?
+
+          wire_openid_request_association(base)
+        end
+
+        # Called from `Doorkeeper::OpenidConnect.configure` for the models that
+        # loaded before it.
+        def wire_pending_hosts
+          pending_hosts.each { |base| wire_openid_request_association(base) }
+          pending_hosts.clear
+        end
+
+        private
+
+        def pending_hosts
+          @pending_hosts ||= []
+        end
+
+        def wire_openid_request_association(base)
+          base.class_eval do
+            has_one :openid_request,
+                    class_name: Doorkeeper::OpenidConnect.configuration.open_id_request_class,
+                    foreign_key: "access_grant_id",
+                    inverse_of: :access_grant,
+                    dependent: :delete
+          end
         end
       end
     end

--- a/spec/lib/orm/active_record_spec.rb
+++ b/spec/lib/orm/active_record_spec.rb
@@ -62,4 +62,56 @@ describe "Doorkeeper::OpenidConnect ActiveRecord ORM integration" do
       expect(custom_model.reflect_on_association(:openid_request)).not_to be_nil
     end
   end
+
+  # Regression coverage for the boot failure introduced in v1.10.3 (#308).
+  #
+  # Since #308 the association is wired from the grant mixin's `included`
+  # callback, so it is evaluated whenever the model loads — which the host
+  # application can easily arrange to happen before
+  # `Doorkeeper::OpenidConnect.configure` runs: Doorkeeper's own
+  # `initialize_models!` reaches for the grant model from `Doorkeeper.configure`
+  # (immediately, on Doorkeeper 5.5.x with `ActiveRecord::Base` already loaded),
+  # and any initializer sorting between `doorkeeper.rb` and
+  # `doorkeeper_openid_connect.rb` can name the model itself. Reading
+  # `open_id_request_class` at that point raised `MissingConfiguration`, whose
+  # message ("Do you have doorkeeper_openid_connect initializer?") points at an
+  # initializer that does exist and simply has not run yet. #174 is the same
+  # ordering hazard one layer down: an unrelated gem (Sorcery) loaded
+  # `ActiveRecord::Base` before the doorkeeper initializers, and Doorkeeper's
+  # own model wiring reported a missing Doorkeeper initializer.
+  describe "an access grant model that loads before the OpenID Connect configuration" do
+    around do |example|
+      previous_config = Doorkeeper::OpenidConnect.instance_variable_get(:@config)
+      Doorkeeper::OpenidConnect.instance_variable_set(:@config, nil)
+      example.run
+    ensure
+      Doorkeeper::OpenidConnect.instance_variable_set(:@config, previous_config)
+    end
+
+    def load_grant_model
+      Class.new(ApplicationRecord) do
+        self.table_name = "oauth_access_grants"
+        include Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant
+      end
+    end
+
+    it "does not raise MissingConfiguration" do
+      expect { load_grant_model }.not_to raise_error
+    end
+
+    it "wires the association once the configuration arrives" do
+      custom_model = load_grant_model
+
+      expect(custom_model.reflect_on_association(:openid_request)).to be_nil
+
+      Doorkeeper::OpenidConnect.configure do
+        issuer "dummy"
+        open_id_request_class "CustomOpenidRequest308"
+      end
+
+      association = custom_model.reflect_on_association(:openid_request)
+      expect(association).not_to be_nil
+      expect(association.options[:class_name]).to eq("CustomOpenidRequest308")
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`Doorkeeper::OpenidConnect::AccessGrant.prepended` reads `open_id_request_class` off the OpenID Connect configuration while the host model's class body is being evaluated:

```ruby
def self.prepended(base)
  base.class_eval do
    has_one :openid_request,
            class_name: Doorkeeper::OpenidConnect.configuration.open_id_request_class,
            ...
  end
end
```

Since v1.10.3 (#308) that hook fires from Doorkeeper's grant mixin `included` callback, which means it runs **whenever the grant model loads**. The host application does not have to arrange for that to happen after `Doorkeeper::OpenidConnect.configure`, and two ordinary setups arrange for it to happen before:

**(a) Doorkeeper 5.5.x.** `Doorkeeper.configure` → `setup_orm_models` → `initialize_models!` wraps its work in `ActiveSupport.on_load(:active_record)`, which fires *immediately* when a preceding initializer or gem railtie has already loaded `ActiveRecord::Base`. The grant model is constantized right there — while `doorkeeper_openid_connect.rb`, later in alphabetical order, has not run yet.

**(b) Every Doorkeeper version.** Any initializer sorting between `doorkeeper.rb` and `doorkeeper_openid_connect.rb` that names the grant model loads it directly:

```ruby
# config/initializers/doorkeeper_extensions.rb
Doorkeeper::AccessGrant.class_eval do
  scope :recent, -> { order(created_at: :desc) }
end
```

Both boot the application into:

```
Doorkeeper::OpenidConnect::Errors::MissingConfiguration:
  Configuration for Doorkeeper OpenID Connect missing.
  Do you have doorkeeper_openid_connect initializer?
```

The message points at an initializer that *does* exist and has simply not run yet, so it sends the reporter looking in the wrong place. #174 is the same ordering hazard one layer down — an unrelated gem (Sorcery) loaded `ActiveRecord::Base` before the doorkeeper initializers, and Doorkeeper's own model wiring reported a missing *Doorkeeper* initializer.

Before #308 the wiring ran from `run_hooks` / `initialize_models!` rather than from the model's own load, so path (b) did not exist at all.

## Fix

Wire the association immediately when the configuration is already there; otherwise remember the host model and wire it from `configure`.

- `AccessGrant.prepended` checks `Doorkeeper::OpenidConnect.configured?` and defers into a pending list when it is false.
- `Doorkeeper::OpenidConnect.configure` calls `OpenidConnect::AccessGrant.wire_pending_hosts` after `validate_issuer_consistency`. The namespace is written out because a bare `AccessGrant` inside `module Doorkeeper::OpenidConnect` would resolve to Doorkeeper's own grant model through the enclosing lexical scope if the autoload were ever dropped.

Nothing changes for the ordinary ordering: with the configuration present, the association is wired exactly as before, at exactly the same moment.

## Side effect

An application that loads this gem but never configures it no longer fails while the grant model loads. It still fails at boot — `use_doorkeeper_openid_connect` in `routes.rb` reads `configuration.dynamic_client_registration`, and routes load after initializers — but now the "Do you have doorkeeper_openid_connect initializer?" message appears in a context where it is accurate.

## Backward compatibility

No breaking change. `AccessGrant.prepended` keeps its signature and its observable effect; `wire_pending_hosts` is new and additive.