### PR TITLE
Pin the development dependency on json below 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,19 @@ group :development do
   gem "cuprite", require: false
 end
 
+# json 3.0 (2026-09-07) removed the `quirks_mode` option from `JSON.generate`.
+# ActiveSupport's `JSONGemEncoder` still passes it up to and including the 8.0
+# series, and `ENV["rails"]` above defaults to 8.0, so an unpinned resolution
+# turns every `render json:` in `rake spec` into an `ArgumentError`. Only this
+# Gemfile is affected: ActiveSupport 8.0 and 7.x do not depend on the json gem,
+# so RuboCop's `json (>= 2.3)` is what pulls it in here, and the CI gemfiles
+# that do resolve json 3 run Rails 8.1, which no longer passes the option.
+#
+# `~> 2.21` rather than `< 3` so 3.0.0.rc1 is not resolvable either, matching
+# the pin in gemfiles/rails_8.0.gemfile.
+#
+# TODO: drop this pin once a released 8.0.x carries the ActiveSupport fix
+# (already on 8-0-stable).
+gem "json", "~> 2.21"
+
 gemspec


### PR DESCRIPTION
## What

Pins the development dependency on `json` to `~> 2.21` in the root `Gemfile`.

## Why

[json 3.0.0](https://rubygems.org/gems/json/versions/3.0.0) was released on 2026-09-07 and removed the `quirks_mode` option from `JSON.generate`. ActiveSupport's `JSONGemEncoder` still passes it up to and including the 8.0 series, so every `render json:` raises `ArgumentError: unknown keyword: quirks_mode`.

The root `Gemfile` defaults to `ENV["rails"] ||= "8.0.0"`, and RuboCop depends on `json (>= 2.3)`, which is what brings the gem into this bundle. A fresh resolution therefore picks up json 3.0.0 alongside ActiveSupport 8.0.5.1, and the suite that every contributor runs first fails:

| root `Gemfile`, Rails 8.0.5.1 | `bundle exec rake spec` |
| --- | --- |
| json 3.0.0 (before) | 461 examples, **83 failures** |
| json 2.21.2 (after) | 461 examples, 0 failures |

`~> 2.21` rather than `< 3` for the same reason as the pin [#398](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/398) added to `gemfiles/rails_8.0.gemfile`: `< 3` leaves `3.0.0.rc1` resolvable.

## Why only the root Gemfile

CI is unaffected, which is why nothing went red on `master`. ActiveSupport 8.0 and 7.x do not declare a dependency on the json gem — they use the default gem that ships with the Ruby — and none of those CI gemfiles carry anything else that pulls json in, so a fresh resolution leaves json out of the bundle entirely. Verified per gemfile:

| gemfile | json resolved | `rake spec` |
| --- | --- | --- |
| `rails_7.0` / `rails_7.1` / `rails_7.2` | not in the bundle | 461 examples, 0 failures |
| `doorkeeper_5.5` / `5.6` / `5.7` | not in the bundle | 459 examples, 0 failures |
| `doorkeeper_6.0` | not in the bundle | 470 examples, 0 failures |
| `rails_8.0` | 2.21.2 (already pinned by #398) | 461 examples, 0 failures |
| `rails_8.1` | **3.0.0** | 461 examples, 0 failures |
| `doorkeeper_master` | **3.0.0** | 470 examples, 0 failures |

ActiveSupport **8.1** does declare `json` as a dependency, so `rails_8.1.gemfile` and `doorkeeper_master.gemfile` are the two that actually resolve json 3.0.0 — and they pass, because 8.1 dropped the `quirks_mode` argument. `rake e2e` on `gemfiles/rails_8.1.gemfile` is green as well (13 examples, 0 failures). Both are deliberately left unpinned so CI keeps exercising json 3.

> [!IMPORTANT]
> ActiveSupport 8.1 is not fully json-3-clean: `ActiveSupport::JSON.decode` still calls `::JSON.parse(json, options)` with a positional Hash, which json 3 rejects (`wrong number of arguments (given 2, expected 1)`). Our suite does not reach that path today — [doorkeeper#1925](https://github.com/doorkeeper-gem/doorkeeper/pull/1925) does, which is why the main repository needed a much broader pin. Worth remembering if a future spec starts touching `flash` or cookie decoding on 8.1.

## Verification

Ruby 4.0.2, fresh resolution (no lockfile) for every gemfile above. On the root `Gemfile` after the pin:

- `bundle exec rake spec` — 461 examples, 0 failures
- `bundle exec rake e2e` — 13 examples, 0 failures
- `bundle exec rubocop` — 126 files inspected, no offenses
- `rails=7.1.0` / `rails=7.2.0` / `rails=8.1.0` — 461 examples, 0 failures each

> [!NOTE]
>
> - Development dependency only. It constrains nothing for host applications and is not added to the gemspec.
> - **TODO:** drop the pin once a released 8.0.x carries the ActiveSupport fix. It is already on `8-0-stable`, but the 8.0 series is past its bug-fix window, so it likely has to ride along with a security release — the same caveat the `gemfiles/rails_8.0.gemfile` pin carries.